### PR TITLE
fix & feat

### DIFF
--- a/app/protos/grpc.proto
+++ b/app/protos/grpc.proto
@@ -1980,6 +1980,7 @@ message AddMenuRequest {
 message QueryAllMenuItemRequest {
   string Mode = 1;
   string Group = 2;
+  string Verbose = 3;
 }
 
 message ImportMenuItemRequest {

--- a/app/renderer/src/main/src/components/basics/YakitLoading.tsx
+++ b/app/renderer/src/main/src/components/basics/YakitLoading.tsx
@@ -208,7 +208,7 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
         }
 
         return false
-    }, [currentYakit, latestYakit, currentYaklang, latestYaklang, yakitStatus])
+    }, [currentYakit, latestYakit, currentYaklang, latestYaklang, yakitStatus, readyTime.current])
 
     const selectEngineMode = useMemoizedFn((key: string) => {
         if (key === "remote" && onEngineModeChange) {

--- a/app/renderer/src/main/src/components/layout/FuncDomain.tsx
+++ b/app/renderer/src/main/src/components/layout/FuncDomain.tsx
@@ -72,10 +72,13 @@ export interface FuncDomainProp {
     isRemoteMode: boolean
     onEngineModeChange: (type: YaklangEngineMode) => any
     typeCallback: (type: YakitSettingCallbackType) => any
+
+    /** @name 当前是否展示项目管理页面 */
+    showProjectManage?: boolean
 }
 
 export const FuncDomain: React.FC<FuncDomainProp> = React.memo((props) => {
-    const {isEngineLink, isReverse = false, engineMode, isRemoteMode, onEngineModeChange, typeCallback} = props
+    const {isEngineLink, isReverse = false, engineMode, isRemoteMode, onEngineModeChange, typeCallback, showProjectManage = false} = props
 
     /** 登录用户信息 */
     const {userInfo, setStoreUserInfo} = useStore()
@@ -165,7 +168,7 @@ export const FuncDomain: React.FC<FuncDomainProp> = React.memo((props) => {
                     <ScreensHotSvgIcon className={styles["icon-style"]} />
                 </div> */}
 
-                <div
+                {!showProjectManage && <div
                     className={styles["ui-op-btn-wrapper"]}
                     onClick={() => {
                         getLocalValue("SHOW_BASE_CONSOLE").then((val: boolean) => {
@@ -180,21 +183,21 @@ export const FuncDomain: React.FC<FuncDomainProp> = React.memo((props) => {
                             <RocketSvgIcon style={{fontSize: 20}} className={styles["icon-style"]}/>
                         </Tooltip>
                     </div>
-                </div>
+                </div>}
 
                 <div className={styles["short-divider-wrapper"]}>
                     <div className={styles["divider-style"]}></div>
                 </div>
                 <div className={styles["state-setting-wrapper"]}>
-                    <UIOpRisk isEngineLink={isEngineLink}/>
-                    <UIOpNotice isEngineLink={isEngineLink} isRemoteMode={isRemoteMode}/>
-                    <UIOpSetting
+                    {!showProjectManage && <UIOpRisk isEngineLink={isEngineLink} />}
+                    <UIOpNotice isEngineLink={isEngineLink} isRemoteMode={isRemoteMode} />
+                    {!showProjectManage && <UIOpSetting
                         engineMode={engineMode}
                         onEngineModeChange={onEngineModeChange}
                         typeCallback={typeCallback}
-                    />
+                    />}
                 </div>
-                <div className={styles["divider-wrapper"]}></div>
+                {!showProjectManage && <><div className={styles["divider-wrapper"]}></div>
                 <div className={styles["user-wrapper"]}>
                     {userInfo.isLogin ? (
                         <div className={styles["user-info"]}>
@@ -259,7 +262,7 @@ export const FuncDomain: React.FC<FuncDomainProp> = React.memo((props) => {
                             <UnLoginSvgIcon/>
                         </div>
                     )}
-                </div>
+                </div></>}
             </div>
 
             {loginShow && <Login visible={loginShow} onCancel={() => setLoginShow(false)}/>}

--- a/app/renderer/src/main/src/components/layout/UILayout.tsx
+++ b/app/renderer/src/main/src/components/layout/UILayout.tsx
@@ -53,6 +53,7 @@ import {
     TransferProject
 } from "@/pages/softwareSettings/ProjectManage"
 import {isSimpleEnterprise} from "@/utils/envfile"
+import { YakitHint } from "../yakitUI/YakitHint/YakitHint"
 
 import classNames from "classnames"
 import styles from "./uiLayout.module.scss"
@@ -656,8 +657,7 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
     const [yakitMode, setYakitMode] = useState<"soft" | "store" | "">("")
     const changeYakitMode = useMemoizedFn((type: "soft" | "store") => {
         if (type === "soft" && yakitMode !== "soft") {
-            setYakitMode(type)
-            setLinkDatabase(true)
+            setLinkDatabaseHint(true)
         }
     })
     /** 软件配置界面完成事件回调 */
@@ -673,6 +673,7 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
     }
 
     const [linkDatabase, setLinkDatabase] = useState<boolean>(false)
+    const [linkDatabaseHint, setLinkDatabaseHint] = useState<boolean>(false)
 
     /**
      * 管理员模式补充情况
@@ -1071,6 +1072,18 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
                     setProjectTransferShow({visible: false})
                 }}
                 setVisible={(open: boolean) => setProjectTransferShow({visible: open})}
+            />
+            
+            <YakitHint
+                visible={linkDatabaseHint}
+                title="是否进入项目管理"
+                content="如果有正在进行中的任务，回到项目管理页则都会停止，确定回到项目管理页面吗?"
+                onOk={() => {
+                    setYakitMode("soft")
+                    setLinkDatabase(true)
+                    setLinkDatabaseHint(false)
+                }}
+                onCancel={() => setLinkDatabaseHint(false)}
             />
         </div>
     )

--- a/app/renderer/src/main/src/components/layout/UILayout.tsx
+++ b/app/renderer/src/main/src/components/layout/UILayout.tsx
@@ -854,9 +854,10 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
                                                 isRemoteMode={engineMode === "remote"}
                                                 onEngineModeChange={changeEngineMode}
                                                 typeCallback={typeCallback}
+                                                showProjectManage={linkDatabase}
                                             />
-                                            <div className={styles["divider-wrapper"]}></div>
-                                            <GlobalReverseState isEngineLink={engineLink} />
+                                            {!linkDatabase && <><div className={styles["divider-wrapper"]}></div>
+                                            <GlobalReverseState isEngineLink={engineLink} /></>}
                                         </>
                                     )}
                                 </div>
@@ -875,7 +876,7 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
                                 <div className={styles["header-left"]}>
                                     {engineLink && (
                                         <>
-                                            <GlobalReverseState isEngineLink={engineLink} />
+                                            {!linkDatabase && <GlobalReverseState isEngineLink={engineLink} />}
 
                                             {!isSimpleEnterprise && <div
                                                 className={classNames(styles["yakit-mode-icon"], {
@@ -906,6 +907,7 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
                                                     isRemoteMode={engineMode === "remote"}
                                                     onEngineModeChange={changeEngineMode}
                                                     typeCallback={typeCallback}
+                                                    showProjectManage={linkDatabase}
                                                 />
                                             </div>
                                         </>

--- a/app/renderer/src/main/src/components/layout/performanceDisplay.module.scss
+++ b/app/renderer/src/main/src/components/layout/performanceDisplay.module.scss
@@ -47,7 +47,7 @@
     }
 
     .icon-rotate-animation {
-        animation: rotate 1s linear infinite;
+        animation: rotate 5s linear infinite;
     }
 
     // 360度旋转

--- a/app/renderer/src/main/src/components/layout/update/UpdateYakitAndYaklang.tsx
+++ b/app/renderer/src/main/src/components/layout/update/UpdateYakitAndYaklang.tsx
@@ -67,7 +67,7 @@ export const UpdateYakitAndYaklang: React.FC<UpdateYakitAndYaklangProps> = React
             return yakitUpdateContent.content.split("\n")
         }
         return []
-    }, [])
+    }, [yakitUpdateContent])
     const yaklangContent: string[] = useMemo(() => {
         if (!yaklangUpdateContent.content) return []
         if (yaklangUpdateContent.version !== latestYaklang) return []
@@ -75,10 +75,12 @@ export const UpdateYakitAndYaklang: React.FC<UpdateYakitAndYaklangProps> = React
             return yaklangUpdateContent.content.split("\n")
         }
         return []
-    }, [])
+    }, [yaklangUpdateContent])
 
     /** 获取 yakit 更新内容 */
     const fetchYakitLastVersion = useMemoizedFn(() => {
+        if (yakitUpdateContent.version) return
+
         NetWorkApi<FetchUpdateContentProp, any>({
             diyHome: "https://www.yaklang.com",
             method: "get",
@@ -89,7 +91,7 @@ export const UpdateYakitAndYaklang: React.FC<UpdateYakitAndYaklangProps> = React
                 if (!res) return
                 try {
                     const data: UpdateContentProp = JSON.parse(res)
-                    if (data.content === yakitUpdateContent.content) return
+                    if (data.version !== latestYakit) return
                     setYakitUpdateContent({...data})
                 } catch (error) {}
             })
@@ -97,6 +99,8 @@ export const UpdateYakitAndYaklang: React.FC<UpdateYakitAndYaklangProps> = React
     })
     /** 获取 yaklang 更新内容 */
     const fetchYaklangLastVersion = useMemoizedFn(() => {
+        if (yaklangUpdateContent.version) return
+
         NetWorkApi<FetchUpdateContentProp, any>({
             diyHome: "https://www.yaklang.com",
             method: "get",
@@ -107,7 +111,7 @@ export const UpdateYakitAndYaklang: React.FC<UpdateYakitAndYaklangProps> = React
                 if (!res) return
                 try {
                     const data: UpdateContentProp = JSON.parse(res)
-                    if (data.content === yaklangUpdateContent.content) return
+                    if (data.version !== latestYaklang) return
                     setYaklangUpdateContent({...data})
                 } catch (error) {}
             })
@@ -115,9 +119,9 @@ export const UpdateYakitAndYaklang: React.FC<UpdateYakitAndYaklangProps> = React
     })
 
     useEffect(() => {
-        fetchYakitLastVersion()
-        fetchYaklangLastVersion()
-    }, [])
+        if (latestYakit) fetchYakitLastVersion()
+        if (latestYaklang) fetchYaklangLastVersion()
+    }, [latestYakit, latestYaklang])
 
     useEffect(() => {
         ipcRenderer.on("download-yakit-engine-progress", (e: any, state: DownloadingState) => {

--- a/app/renderer/src/main/src/pages/MainOperator.tsx
+++ b/app/renderer/src/main/src/pages/MainOperator.tsx
@@ -86,7 +86,6 @@ const singletonRoute: Route[] = [
     Route.DB_Domain,
     Route.DB_Risk,
     Route.DB_Report,
-    Route.DB_Projects,
     Route.DB_CVE,
 
     Route.PoC,

--- a/app/renderer/src/main/src/pages/MainOperator.tsx
+++ b/app/renderer/src/main/src/pages/MainOperator.tsx
@@ -82,7 +82,6 @@ const singletonRoute: Route[] = [
     // database
     Route.DB_Ports,
     Route.DB_HTTPHistory,
-    Route.DB_ExecResults,
     Route.DB_Domain,
     Route.DB_Risk,
     Route.DB_Report,
@@ -1200,6 +1199,14 @@ const Main: React.FC<MainProp> = React.memo((props) => {
             if (type === "facade-server") addFacadeServer(data)
             if (type === "add-yak-running") addYakRunning(data)
             if (type === "**screen-recorder") addTabPage(Route.ScreenRecorderPage)
+            if (type === "open-plugin-store"){
+                const flag = getPageCache().filter(item => item.route === Route.ModManager).length
+                if(flag === 0 ){ addTabPage(Route.ModManager) }
+                else{
+                    removePage(Route.AddYakitScript, false) 
+                    setTimeout(() => ipcRenderer.invoke("send-local-script-list"), 50);
+                }
+            }
             console.info("send to tab: ", type)
         })
 

--- a/app/renderer/src/main/src/pages/fuzzer/HTTPFuzzerPage.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HTTPFuzzerPage.tsx
@@ -381,12 +381,20 @@ export const HTTPFuzzerPage: React.FC<HTTPFuzzerPageProp> = (props) => {
     }, [historyTask])
 
     useEffect(() => {
-        // 缓存全局参数
+        // 缓存全局参数(将fuzz参数的缓存从本地文件替换到引擎数据库内)
         getLocalValue(WEB_FUZZ_PROXY).then((e) => {
-            if (!e) {
-                return
+            if (e) {
+                setLocalValue(WEB_FUZZ_PROXY, "")
+                setRemoteValue(WEB_FUZZ_PROXY, `${e}`)
+                setProxy(`${e}`)
+            } else {
+                getRemoteValue(WEB_FUZZ_PROXY).then((e) => {
+                    if (!e) {
+                        return
+                    }
+                    setProxy(`${e}`)
+                })
             }
-            setProxy(`${e}`)
         })
     }, [])
 
@@ -1017,6 +1025,7 @@ export const HTTPFuzzerPage: React.FC<HTTPFuzzerPageProp> = (props) => {
                                 onClick={() => {
                                     resetResponse()
 
+                                    setRemoteValue(WEB_FUZZ_PROXY, `${proxy}`)
                                     setRedirectedResponse(undefined)
                                     sendFuzzerSettingInfo()
                                     submitToHTTPFuzzer()

--- a/app/renderer/src/main/src/pages/fuzzer/components/ShareImport/index.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/components/ShareImport/index.tsx
@@ -34,12 +34,15 @@ export function onImportShare() {
     })
 }
 export function onImportPlugin() {
-    showModal({
-        title: "更新插件源",
+    const m = showModal({
+        title: "导入插件ID",
         width: 800,
         content: (
             <div style={{width: 780}}>
-                <LoadYakitPluginForm onlyId={true} onFinished={() => info("更新进程执行完毕")} />
+                <LoadYakitPluginForm onlyId={true} onFinished={() => {
+                    info("更新进程执行完毕")
+                    m.destroy()
+                }} />
             </div>
         )
     })

--- a/app/renderer/src/main/src/pages/fuzzer/components/ShareImport/index.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/components/ShareImport/index.tsx
@@ -1,12 +1,13 @@
 import React, {useEffect, useRef, useState} from "react"
 import {Button, Form, Input, InputNumber} from "antd"
 import {useMemoizedFn} from "ahooks"
-import {failed, warn} from "@/utils/notification"
+import {failed, info, warn} from "@/utils/notification"
 import "./index.scss"
 import {API} from "@/services/swagger/resposeType"
 import {NetWorkApi} from "@/services/fetch"
 import {useStore} from "@/store"
 import {showModal} from "@/utils/showModal";
+import { LoadYakitPluginForm } from "@/pages/yakitStore/YakitStorePage"
 
 const layout = {
     labelCol: {span: 5},
@@ -30,6 +31,17 @@ export function onImportShare() {
     const m = showModal({
         title: "导入协作资源",
         content: <ShareImport onClose={() => m.destroy()}/>
+    })
+}
+export function onImportPlugin() {
+    showModal({
+        title: "更新插件源",
+        width: 800,
+        content: (
+            <div style={{width: 780}}>
+                <LoadYakitPluginForm onlyId={true} onFinished={() => info("更新进程执行完毕")} />
+            </div>
+        )
     })
 }
 

--- a/app/renderer/src/main/src/pages/layout/HeardMenu/HeardMenu.module.scss
+++ b/app/renderer/src/main/src/pages/layout/HeardMenu/HeardMenu.module.scss
@@ -656,3 +656,16 @@ border-radius: 0px 4px 4px 0px;
         color: var(--yakit-primary-color);
     }
 }
+
+.import-resource-menu-popover {
+    :global {
+        .ant-popover-inner {
+            border: 1px solid var(--yakit-border-color);
+            box-shadow: 0px 8px 16px rgba(133, 137, 158, 0.1);
+            border-radius: 4px;
+            .ant-popover-inner-content {
+                padding: 6px 4px 8px 4px;
+            }
+        }
+    }
+}

--- a/app/renderer/src/main/src/pages/mitm/MITMRule/MITMRule.tsx
+++ b/app/renderer/src/main/src/pages/mitm/MITMRule/MITMRule.tsx
@@ -318,8 +318,8 @@ export const MITMRule: React.FC<MITMRuleProp> = (props) => {
                 width: 80,
                 render: (text, record: MITMContentReplacerRule) => (
                     <div className={classNames(styles["table-hit-color-content"])}>
-                        <div className={classNames(styles["table-hit-color"], HitColor[text].className)} />
-                        {HitColor[text].title}
+                        <div className={classNames(styles["table-hit-color"], HitColor[text]?.className)} />
+                        {HitColor[text]?.title || "-"}
                     </div>
                 )
             },

--- a/app/renderer/src/main/src/pages/mitm/MITMServerStartForm/MITMServerStartForm.tsx
+++ b/app/renderer/src/main/src/pages/mitm/MITMServerStartForm/MITMServerStartForm.tsx
@@ -126,7 +126,7 @@ export const MITMServerStartForm: React.FC<MITMServerStartFormProp> = React.memo
             const newHostHistoryList = [params.host, ...hostHistoryList].filter((_, index) => index < 10)
             setRemoteValue(MITMConsts.MITMDefaultHostHistoryList, JSON.stringify(newHostHistoryList))
         }
-        setLocalValue(WEB_FUZZ_PROXY, params.downstreamProxy)
+        // setLocalValue(WEB_FUZZ_PROXY, params.downstreamProxy)
         setRemoteValue(MITMConsts.MITMDefaultServer, params.host)
         setRemoteValue(MITMConsts.MITMDefaultPort, `${params.port}`)
         // setRemoteValue(MITMConsts.MITMDefaultDownstreamProxy, params.downstreamProxy)

--- a/app/renderer/src/main/src/pages/softwareSettings/ProjectManage.tsx
+++ b/app/renderer/src/main/src/pages/softwareSettings/ProjectManage.tsx
@@ -85,7 +85,7 @@ export interface ProjectDescription {
     ChildFolderName: string
     Type: string
 }
-interface ProjectsResponse {
+export interface ProjectsResponse {
     Pagination: {Page: number; Limit: number}
     Projects: ProjectDescription[]
     Total: number
@@ -1947,7 +1947,7 @@ interface TransferProjectProps {
     setVisible: (open: boolean) => any
     onSuccess: (type: string) => any
 }
-interface ProjectIOProgress {
+export interface ProjectIOProgress {
     TargetPath: string
     Percent: number
     Verbose: string
@@ -2037,6 +2037,7 @@ export const TransferProject: React.FC<TransferProjectProps> = memo((props) => {
 
         return () => {
             clearInterval(id)
+            ipcRenderer.invoke("cancel-ExportProject", token)
             ipcRenderer.invoke("cancel-ImportProject", token)
             ipcRenderer.removeAllListeners(`${token}-data`)
             ipcRenderer.removeAllListeners(`${token}-error`)

--- a/app/renderer/src/main/src/pages/yakitStore/YakitStorePage.tsx
+++ b/app/renderer/src/main/src/pages/yakitStore/YakitStorePage.tsx
@@ -2562,11 +2562,11 @@ const YAKIT_DEFAULT_LOAD_GIT_PROXY = "YAKIT_DEFAULT_LOAD_GIT_PROXY"
 const YAKIT_DEFAULT_LOAD_LOCAL_PATH = "YAKIT_DEFAULT_LOAD_LOCAL_PATH"
 const YAKIT_DEFAULT_LOAD_LOCAL_NUCLEI_POC_PATH = "YAKIT_DEFAULT_LOAD_LOCAL_NUCLEI_POC_PATH"
 
-export const LoadYakitPluginForm = React.memo((p: {onFinished: () => any}) => {
+export const LoadYakitPluginForm = React.memo((p: {onFinished: () => any, onlyId?: boolean}) => {
     const [gitUrl, setGitUrl] = useState("https://github.com/yaklang/yakit-store")
     const [nucleiGitUrl, setNucleiGitUrl] = useState("https://github.com/projectdiscovery/nuclei-templates")
     const [proxy, setProxy] = useState("")
-    const [loadMode, setLoadMode] = useState<"official" | "giturl" | "local" | "local-nuclei" | "uploadId">("official")
+    const [loadMode, setLoadMode] = useState<"official" | "giturl" | "local" | "local-nuclei" | "uploadId">(p.onlyId ? "uploadId" : "official")
     const [localPath, setLocalPath] = useState("")
     const [localNucleiPath, setLocalNucleiPath] = useState("")
     const [localId, setLocalId] = useState<string>("")
@@ -2668,7 +2668,7 @@ export const LoadYakitPluginForm = React.memo((p: {onFinished: () => any}) => {
             <SelectOne
                 label={" "}
                 colon={false}
-                data={[
+                data={p.onlyId ? [{text: "使用ID", value: "uploadId"}] : [
                     {text: "使用官方源", value: "official"},
                     {text: "第三方仓库源", value: "giturl"},
                     {text: "本地仓库", value: "local"},

--- a/app/renderer/src/main/src/pages/yakitStore/YakitStorePage.tsx
+++ b/app/renderer/src/main/src/pages/yakitStore/YakitStorePage.tsx
@@ -2658,6 +2658,10 @@ export const LoadYakitPluginForm = React.memo((p: {onFinished: () => any, onlyId
                         .then(() => {
                             p.onFinished()
                             success("插件导入成功")
+                            ipcRenderer.invoke("send-to-tab", {
+                                type: "open-plugin-store",
+                                data:{ }
+                            })
                         })
                         .catch((e: any) => {
                             failed(`插件导入失败: ${e}`)
@@ -2665,10 +2669,10 @@ export const LoadYakitPluginForm = React.memo((p: {onFinished: () => any, onlyId
                 }
             }}
         >
-            <SelectOne
+            {!p.onlyId && <SelectOne
                 label={" "}
                 colon={false}
-                data={p.onlyId ? [{text: "使用ID", value: "uploadId"}] : [
+                data={[
                     {text: "使用官方源", value: "official"},
                     {text: "第三方仓库源", value: "giturl"},
                     {text: "本地仓库", value: "local"},
@@ -2677,7 +2681,7 @@ export const LoadYakitPluginForm = React.memo((p: {onFinished: () => any, onlyId
                 ]}
                 value={loadMode}
                 setValue={setLoadMode}
-            />
+            />}
             {["official", "giturl"].includes(loadMode) && (
                 <>
                     {loadMode === "official" && (

--- a/app/renderer/src/main/src/pages/yakitStore/viewers/base.tsx
+++ b/app/renderer/src/main/src/pages/yakitStore/viewers/base.tsx
@@ -248,7 +248,7 @@ export const PluginResultUI: React.FC<PluginResultUIProp> = React.memo((props) =
                                             paddingBottom: 4,
                                             paddingLeft: 12,
                                             paddingRight: 12,
-                                            height: 80,
+                                            height: 100,
                                             display: "flex",
                                             flexDirection: "column",
                                             justifyContent: "space-between"

--- a/app/renderer/src/main/src/routes/routeSpec.tsx
+++ b/app/renderer/src/main/src/routes/routeSpec.tsx
@@ -109,7 +109,6 @@ import {
     MenuSolidYsoJavaHackIcon,
     MenuSolidBatchVulnerabilityDetectionIcon,
 } from "@/pages/customizeMenu/icon/solidMenuIcon"
-import {ProjectPage} from "@/pages/projects/ProjectPage"
 import {ScreenRecorderPage} from "@/pages/screenRecorder/ScreenRecorderPage";
 import {CVEViewer} from "@/pages/cve/CVEViewer";
 
@@ -158,7 +157,6 @@ export enum Route {
     DB_ExecResults = "db-exec-results",
     DB_Report = "db-reports-results",
     DB_Risk = "db-risks",
-    DB_Projects = "db-projects",
     DB_CVE = "cve",
 
     // Handler

--- a/app/renderer/src/main/src/routes/routeSpec.tsx
+++ b/app/renderer/src/main/src/routes/routeSpec.tsx
@@ -15,7 +15,6 @@ import {BrutePage} from "../pages/brute/BrutePage"
 import {DataCompare} from "../pages/compare/DataCompare"
 import {HTTPHistory} from "../components/HTTPHistory"
 import {PortAssetTable} from "../pages/assetViewer/PortAssetPage"
-import {YakScriptExecResultTable} from "../components/YakScriptExecResultTable"
 import {DomainAssetPage} from "../pages/assetViewer/DomainAssetPage"
 import {RiskPage} from "../pages/risks/RiskPage"
 import {DNSLogPage} from "../pages/dnslog/DNSLogPage"
@@ -154,7 +153,6 @@ export enum Route {
     DB_Ports = "db-ports",
     DB_HTTPHistory = "db-http-request",
     DB_Domain = "db-domains",
-    DB_ExecResults = "db-exec-results",
     DB_Report = "db-reports-results",
     DB_Risk = "db-risks",
     DB_CVE = "cve",
@@ -387,8 +385,6 @@ export const ContentByRoute = (r: Route | string, yakScriptId?: number, params?:
             return <PortAssetTable />
         case Route.DB_Domain:
             return <DomainAssetPage />
-        case Route.DB_ExecResults:
-            return <YakScriptExecResultTable />
         // case Route.ReverseServer:
         //     return <ReverseServerPage />
         // case Route.PayloadGenerater:
@@ -682,13 +678,6 @@ export const DefaultRouteMenuData: MenuDataProps[] = [
                 label: "报告",
                 icon: <MenuReportIcon />,
                 hoverIcon: <MenuSolidReportIcon />
-            },
-            {
-                id: "9-2",
-                key: Route.DB_ExecResults,
-                label: "插件执行结果",
-                icon: <MenuPlugExecutionResultsIcon />,
-                hoverIcon: <MenuSolidPlugExecutionResultsIcon />
             },
             {
                 id: "9-3",

--- a/app/renderer/src/main/src/yakitGV.ts
+++ b/app/renderer/src/main/src/yakitGV.ts
@@ -47,5 +47,12 @@ export enum CodeGV {
     /** @name 远程连接配置信息文件路径 */
     RemoteLinkPath = "$HOME/yakit-projects/auth/yakit-remote.json",
     /** @name 历史版本下载页面 */
-    HistoricalVersion = "https://github.com/yaklang/yakit/releases"
+    HistoricalVersion = "https://github.com/yaklang/yakit/releases",
+
+    /**
+     * @name 强制删除用户端的无效菜单项集合
+     * @description 该菜单数据为开发者迭代版本所产生的已消失的页面菜单项
+     * @description 每个菜单项由 '|' 字符进行分割
+     */
+    InvalidPageMenuItem = "项目管理(Beta*)|"
 }

--- a/app/renderer/src/main/src/yakitGV.ts
+++ b/app/renderer/src/main/src/yakitGV.ts
@@ -54,5 +54,5 @@ export enum CodeGV {
      * @description 该菜单数据为开发者迭代版本所产生的已消失的页面菜单项
      * @description 每个菜单项由 '|' 字符进行分割
      */
-    InvalidPageMenuItem = "项目管理(Beta*)|"
+    InvalidPageMenuItem = "项目管理(Beta*)|插件执行结果|"
 }


### PR DESCRIPTION
fix:
1、修复企业版用户菜单中的上传数据接口问题
2、修复打开yakit后的升级提示弹框内无更新内容问题
3、修复在项目管理页面时顶部出现了一些高级权限操作的情况
4、修复MITM页面的规则在添加时出现的白屏情况
5、修复'爆破与未授权'页面里卡片的高度展示问题
feat:
1、将开发者废弃的页面菜单项从用户数据库中删除功能
2、导入协作资源新增导入插件ID功能，导入成功后进入插件仓库页面
3、进入项目管理页面前进行确认弹窗提示功能
4、将fuzzer的代理和MITM页面代理的绑定逻辑取消
5、调整引擎进程小风车转速