### PR TITLE
fix mitm hot-patch editor 

### DIFF
--- a/app/renderer/src/main/src/pages/mitm/MITMServerHijacking/MITMPluginHijackContent.tsx
+++ b/app/renderer/src/main/src/pages/mitm/MITMServerHijacking/MITMPluginHijackContent.tsx
@@ -399,7 +399,7 @@ export const MITMPluginHijackContent: React.FC<MITMPluginHijackContentProps> = (
                                         Content: e.toString("utf8")
                                     })
                                 }
-                                language={ script.Type}
+                                language={ "mitm"}
                                 extraEditorProps={
                                     {
                                         noMiniMap: true,

--- a/app/renderer/src/main/src/utils/editors.tsx
+++ b/app/renderer/src/main/src/utils/editors.tsx
@@ -385,7 +385,7 @@ export const YakEditor: React.FC<EditorProps> = (props) => {
                                         : props.value
                                 }
                                 onChange={props.setValue}
-                                language={props.type || "http"}
+                                language={language || "http"}
                                 height={100}
                                 editorDidMount={(editor: IMonacoEditor, monaco: any) => {
                                     setEditor(editor)


### PR DESCRIPTION
修复mitm 热加载部分没有语法高亮的问题：
* mitm默认的插件类型为空，需要硬编码为"mitm" 
* utils/editor调用`MonacoEditor`时使用`language`而不是`props.type`