### PR TITLE
一级页面的快捷键关闭触发确认弹窗功能

### DIFF
--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -906,7 +906,7 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
                     pluginId: data.pluginId,
                     pluginName: data.pluginName
                 }
-                removeMenuPage(info)
+                onBeforeRemovePage(info)
             }
             return
         }


### PR DESCRIPTION
#1423 
【bug】按了快捷键CTRL+W没有二次确认会直接关掉所有的Fuzz窗口
解决方案：加入预设的二次确认弹框