### PR TITLE
Luoluo/feat/sequence add show setting

### DIFF
--- a/app/main/handlers/communication.js
+++ b/app/main/handlers/communication.js
@@ -101,10 +101,6 @@ module.exports = (win, getClient) => {
         win.webContents.send("fetch-positioning-http-history", params)
     })
 
-    // webfuzzer 打开提取器和匹配器Modal
-    ipcMain.handle("send-open-matcher-and-extraction", (e, params) => {
-        win.webContents.send("fetch-open-matcher-and-extraction", params)
-    })
 
     // 新建组 onAddGroup
     ipcMain.handle("send-add-group", (e, params) => {

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerPageSetting.module.scss
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerPageSetting.module.scss
@@ -1,0 +1,22 @@
+%display-flex-center {
+    display: flex;
+    align-items: center;
+    opacity: 1;
+}
+%display-column {
+    display: flex;
+    flex-direction: column;
+}
+.form-body {
+    @extend %display-column;
+    flex: 1;
+    padding: 12px;
+    overflow: auto;
+    .to-end {
+        text-align: center;
+        color: var(--yakit-disable-text-color);
+        font-size: 11px;
+        padding-top: 12px;
+        padding-bottom: 24px;
+    }
+}

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerPageSetting.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerPageSetting.tsx
@@ -1,0 +1,139 @@
+import {YakitRoute} from "@/routes/newRoute"
+import {PageNodeItemProps, defaultWebFuzzerPageInfo, usePageInfo} from "@/store/pageInfo"
+import {useMemoizedFn, useUpdateEffect} from "ahooks"
+import React, {useEffect, useState} from "react"
+import {shallow} from "zustand/shallow"
+import cloneDeep from "lodash/cloneDeep"
+import {AdvancedConfigValueProps} from "../HttpQueryAdvancedConfig/HttpQueryAdvancedConfigType"
+import {Form} from "antd"
+import styles from "./FuzzerPageSetting.module.scss"
+import {getRemoteValue, setRemoteValue} from "@/utils/kv"
+import {RemoteGV} from "@/yakitGV"
+import {yakitFailed} from "@/utils/notification"
+import YakitCollapse from "@/components/yakitUI/YakitCollapse/YakitCollapse"
+import {ExtractorsPanel, MatchersPanel, VariablePanel} from "../HttpQueryAdvancedConfig/FuzzerConfigPanels"
+import {MatchingAndExtraction} from "../MatcherAndExtractionCard/MatcherAndExtractionCardType"
+
+interface FuzzerPageSettingProps {
+    pageId: string
+    defaultHttpResponse: string
+}
+const FuzzerPageSetting: React.FC<FuzzerPageSettingProps> = React.memo((props) => {
+    const {pageId, defaultHttpResponse} = props
+    const {queryPagesDataById, updatePagesDataCacheById} = usePageInfo(
+        (s) => ({
+            queryPagesDataById: s.queryPagesDataById,
+            updatePagesDataCacheById: s.updatePagesDataCacheById
+        }),
+        shallow
+    )
+    const initWebFuzzerPageInfo = useMemoizedFn(() => {
+        const currentItem: PageNodeItemProps | undefined = queryPagesDataById(YakitRoute.HTTPFuzzer, pageId)
+        if (currentItem && currentItem.pageParamsInfo.webFuzzerPageInfo) {
+            return currentItem.pageParamsInfo.webFuzzerPageInfo
+        } else {
+            return cloneDeep(defaultWebFuzzerPageInfo)
+        }
+    })
+    const [form] = Form.useForm()
+    const [activeKey, setActiveKey] = useState<string[]>() // Collapse打开的key
+    const [advancedConfigValue, setAdvancedConfigValue] = useState<AdvancedConfigValueProps>(
+        initWebFuzzerPageInfo().advancedConfigValue
+    )
+    useEffect(() => {
+        getRemoteValue(RemoteGV.FuzzerSequenceSettingShow).then((data) => {
+            try {
+                setActiveKey(data ? JSON.parse(data) : ["匹配器", "数据提取器", "设置变量"])
+            } catch (error) {
+                yakitFailed("获取序列配置折叠面板的激活key失败:" + error)
+            }
+        })
+    }, [])
+    useUpdateEffect(() => {
+        const newAdvancedConfigValue = initWebFuzzerPageInfo().advancedConfigValue
+        setAdvancedConfigValue({...newAdvancedConfigValue})
+    }, [pageId])
+    const onSetValue = useMemoizedFn((allFields: AdvancedConfigValueProps) => {
+        // console.log('allFields',allFields)
+    })
+    /**
+     * @description 切换折叠面板，缓存activeKey
+     */
+    const onSwitchCollapse = useMemoizedFn((key) => {
+        setActiveKey(key)
+        setRemoteValue(RemoteGV.FuzzerSequenceSettingShow, JSON.stringify(key))
+    })
+    /**修改匹配器和提取器 */
+    const onEdit = useMemoizedFn((index, type: MatchingAndExtraction) => {
+        // if (outsideShowResponseMatcherAndExtraction) {
+        //     if (onShowResponseMatcherAndExtraction) onShowResponseMatcherAndExtraction("matchers", `ID:${index}`)
+        // } else {
+        //     setVisibleDrawer(true)
+        //     setDefActiveKey(`ID:${index}`)
+        //     setType(type)
+        // }
+    })
+    const onAddMatchingAndExtractionCard = useMemoizedFn((type: MatchingAndExtraction) => {
+        const keyMap = {
+            matchers: "匹配器",
+            extractors: "数据提取器"
+        }
+        if (activeKey?.findIndex((ele) => ele === keyMap[type]) === -1) {
+            onSwitchCollapse([...activeKey, keyMap[type]])
+        }
+        // if (outsideShowResponseMatcherAndExtraction) {
+        //     if (onShowResponseMatcherAndExtraction) onShowResponseMatcherAndExtraction(type, "ID:0")
+        // } else {
+        //     setType(type)
+        //     setVisibleDrawer(true)
+        // }
+    })
+    /**添加的额外操作，例如没有展开的时候点击添加需要展开该项 */
+    const onAddExtra = useMemoizedFn((type: string) => {
+        if (activeKey?.findIndex((ele) => ele === type) === -1) {
+            onSwitchCollapse([...activeKey, type])
+        }
+    })
+    return (
+        <div className={styles["form-body"]}>
+            <Form
+                form={form}
+                colon={false}
+                onValuesChange={(changedFields, allFields) => {
+                    onSetValue(allFields)
+                }}
+                size='small'
+                labelCol={{span: 10}}
+                wrapperCol={{span: 14}}
+                initialValues={{
+                    ...advancedConfigValue
+                }}
+            >
+                <YakitCollapse
+                    activeKey={activeKey}
+                    onChange={(key) => onSwitchCollapse(key)}
+                    destroyInactivePanel={true}
+                    bordered={false}
+                >
+                    <MatchersPanel
+                        key='匹配器'
+                        onAddMatchingAndExtractionCard={onAddMatchingAndExtractionCard}
+                        onEdit={onEdit}
+                        onSetValue={onSetValue}
+                    />
+                    <ExtractorsPanel
+                        key='数据提取器'
+                        onAddMatchingAndExtractionCard={onAddMatchingAndExtractionCard}
+                        onEdit={onEdit}
+                        onSetValue={onSetValue}
+                    />
+                    <VariablePanel key='设置变量' defaultHttpResponse={defaultHttpResponse} onAdd={onAddExtra} />
+                </YakitCollapse>
+
+                <div className={styles["to-end"]}>已经到底啦～</div>
+            </Form>
+        </div>
+    )
+})
+
+export default FuzzerPageSetting

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerPageSetting.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerPageSetting.tsx
@@ -110,12 +110,10 @@ const FuzzerPageSetting: React.FC<FuzzerPageSettingProps> = React.memo((props) =
         if (activeKey?.findIndex((ele) => ele === keyMap[type]) === -1) {
             onSwitchCollapse([...activeKey, keyMap[type]])
         }
-        // if (outsideShowResponseMatcherAndExtraction) {
-        //     if (onShowResponseMatcherAndExtraction) onShowResponseMatcherAndExtraction(type, "ID:0")
-        // } else {
-        //     setType(type)
-        //     setVisibleDrawer(true)
+        // const value = {
+        //     httpResponseCode: defaultHttpResponse
         // }
+        // emiter.emit("openMatcherAndExtraction", JSON.stringify(value))
     })
     /**添加的额外操作，例如没有展开的时候点击添加需要展开该项 */
     const onAddExtra = useMemoizedFn((type: string) => {

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerPageSetting.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerPageSetting.tsx
@@ -1,7 +1,7 @@
 import {YakitRoute} from "@/routes/newRoute"
 import {PageNodeItemProps, defaultWebFuzzerPageInfo, usePageInfo} from "@/store/pageInfo"
-import {useDebounceFn, useMemoizedFn, useUpdateEffect} from "ahooks"
-import React, {useEffect, useState} from "react"
+import {useDebounceFn, useInViewport, useMemoizedFn, useUpdateEffect} from "ahooks"
+import React, {useEffect, useRef, useState} from "react"
 import {shallow} from "zustand/shallow"
 import cloneDeep from "lodash/cloneDeep"
 import {AdvancedConfigValueProps} from "../HttpQueryAdvancedConfig/HttpQueryAdvancedConfigType"
@@ -40,6 +40,10 @@ const FuzzerPageSetting: React.FC<FuzzerPageSettingProps> = React.memo((props) =
     const [advancedConfigValue, setAdvancedConfigValue] = useState<AdvancedConfigValueProps>(
         initWebFuzzerPageInfo().advancedConfigValue
     )
+
+    const formBodyRef = useRef<HTMLDivElement>(null)
+    const [inViewport = true] = useInViewport(formBodyRef)
+
     useEffect(() => {
         getRemoteValue(RemoteGV.FuzzerSequenceSettingShow).then((data) => {
             try {
@@ -50,10 +54,11 @@ const FuzzerPageSetting: React.FC<FuzzerPageSettingProps> = React.memo((props) =
         })
     }, [])
     useUpdateEffect(() => {
+        if (!inViewport) return
         const newAdvancedConfigValue = initWebFuzzerPageInfo().advancedConfigValue
         form.setFieldsValue({...newAdvancedConfigValue})
         setAdvancedConfigValue({...newAdvancedConfigValue})
-    }, [pageId])
+    }, [pageId, inViewport])
     const onSetValue = useMemoizedFn((allFields: AdvancedConfigValueProps) => {
         onUpdatePageInfo(allFields)
     })
@@ -119,7 +124,7 @@ const FuzzerPageSetting: React.FC<FuzzerPageSettingProps> = React.memo((props) =
         }
     })
     return (
-        <div className={styles["form-body"]}>
+        <div className={styles["form-body"]} ref={formBodyRef}>
             <Form
                 form={form}
                 colon={false}
@@ -156,6 +161,7 @@ const FuzzerPageSetting: React.FC<FuzzerPageSettingProps> = React.memo((props) =
                         key='设置变量'
                         defaultHttpResponse={defaultHttpResponse}
                         onAdd={onAddExtra}
+                        onSetValue={onSetValue}
                     />
                 </YakitCollapse>
 

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.module.scss
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.module.scss
@@ -27,10 +27,6 @@
     }
 }
 
-.icon-active {
-    color: var(--yakit-primary-5);
-}
-
 //   ------------------ start ---------------------
 .fuzzer-sequence {
     @extend .display-flex-center;
@@ -142,16 +138,6 @@
                 box-shadow: none;
             }
 
-            // &::after {
-            //     content: "";
-            //     width: 0px;
-            //     height: 8px;
-            //     border-right: 2px solid var(--yakit-helper-text-color);
-            //     position: absolute;
-            //     bottom: -13px;
-            //     left: 50%;
-            //     right: 50%;
-            // }
             &-heard {
                 @extend .display-flex-center;
                 justify-content: space-between;
@@ -162,29 +148,11 @@
                     color: var(--yakit-disable-text-color);
                 }
 
-                .list-item-icon {
-                    @include HTTPFuzzerPageShare.base-icon-card;
-                    color: var(--yakit-body-text-color);
-
-                    path {
-                        stroke-width: 1px
-                    }
-                }
-
-                // .cog-icon {
-                //     @include HTTPFuzzerPageShare.base-icon-card;
-                //     color: var(--yakit-body-text-color);
-                // }
-
                 .drag-sort-disabled-icon {
                     @extend .item-disabled;
                     color: var(--yakit-background-color);
                 }
 
-                .list-item-disabled-icon {
-                    @extend .item-disabled;
-                    color: var(--yakit-disable-text-color);
-                }
 
                 &-title {
                     @extend .display-flex-center;
@@ -205,10 +173,6 @@
         &-item-hover {
             border-color: var(--yakit-primary-5);
             box-shadow: 0 0 2px 2px var(--yakit-primary-2);
-
-            .list-item-icon-hover {
-                background-color: var(--yakit-background-color);
-            }
         }
 
         &-item-hover-none {
@@ -329,12 +293,32 @@
                     font-size: 12px;
                     font-weight: 400;
                     line-height: 16px;
-                    margin-left: 12px
+                    margin-left: 12px;
                 }
             }
         }
     }
 
+    &-midden {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        border-right: 1px solid var(--yakit-border-color);
+        width: 300px;
+        flex-shrink: 0;
+        .setting-heard {
+            @extend .display-flex-center;
+            justify-content: space-between;
+            padding: 15px 12px 12px 12px;
+            border-bottom: 1px solid var(--yakit-border-color);
+            height: 49px;
+            font-size: 12px;
+            color: var(--yakit-header-color);
+        }
+    }
+    &-midden-hidden {
+        display: none;
+    }
 }
 
 .cog-popover {

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.module.scss
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.module.scss
@@ -153,7 +153,6 @@
                     color: var(--yakit-background-color);
                 }
 
-
                 &-title {
                     @extend .display-flex-center;
                     gap: 4px;
@@ -304,7 +303,7 @@
         flex-direction: column;
         height: 100%;
         border-right: 1px solid var(--yakit-border-color);
-        width: 300px;
+        width: 320px;
         flex-shrink: 0;
         .setting-heard {
             @extend .display-flex-center;

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.tsx
@@ -808,6 +808,7 @@ const FuzzerSequence: React.FC<FuzzerSequenceProps> = React.memo((props) => {
     /**显示页面的高级配置部分参数 */
     const onShowSetting = useMemoizedFn((val: SequenceProps) => {
         onSelect(val)
+        if (currentSequenceItem?.pageId !== val?.pageId) return
         if (currentSequenceItem) {
             setIsShowSetting(!isShowSetting)
         } else {

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.tsx
@@ -303,6 +303,7 @@ const FuzzerSequence: React.FC<FuzzerSequenceProps> = React.memo((props) => {
         } else {
             setCurrentSelectRequest(undefined)
             setCurrentSelectResponse(undefined)
+            setIsShowSetting(false)
         }
         return () => {
             setCurrentSelectRequest(undefined)

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.tsx
@@ -666,11 +666,13 @@ const FuzzerSequence: React.FC<FuzzerSequenceProps> = React.memo((props) => {
         if (index === errorIndex && item.pageId) {
             setErrorIndex(-1)
         }
+        if (!currentSequenceItem || !currentSequenceItem.pageId) {
+            setIsShowSetting(true)
+        }
         const originItem = originSequenceList.find((ele) => ele.pageId === item.pageId)
         if (!originItem) return
         sequenceList[index] = {
             ...item
-            //  pageParams: originItem.pageParams
         }
         setCurrentSequenceItem({...item})
         setSequenceList([...sequenceList])
@@ -799,7 +801,7 @@ const FuzzerSequence: React.FC<FuzzerSequenceProps> = React.memo((props) => {
             yakitNotify("error", "请配置序列后再选中")
             return
         }
-        if (!currentSequenceItem) {
+        if (!currentSequenceItem || !currentSequenceItem.pageId) {
             setIsShowSetting(true)
         }
         setCurrentSequenceItem({...val})

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.tsx
@@ -99,6 +99,7 @@ import {Uint8ArrayToString} from "@/utils/str"
 
 const ResponseAllDataCard = React.lazy(() => import("./ResponseAllDataCard"))
 const ResponseCard = React.lazy(() => import("./ResponseCard"))
+const FuzzerPageSetting = React.lazy(() => import("./FuzzerPageSetting"))
 
 const {ipcRenderer} = window.require("electron")
 
@@ -849,7 +850,20 @@ const FuzzerSequence: React.FC<FuzzerSequenceProps> = React.memo((props) => {
         }
         return flag
     }
-
+    /**多条数据返回的第一条数据的ResponseRaw,一条数据就返回这一条的 ResponseRaw */
+    const defaultHttpResponse: string = useMemo(() => {
+        if (currentSelectResponse) {
+            const {onlyOneResponse, successFuzzer} = currentSelectResponse
+            if (successFuzzer.length > 1) {
+                const firstSuccessResponse = successFuzzer[0]
+                return Uint8ArrayToString(firstSuccessResponse.ResponseRaw)
+            } else {
+                return Uint8ArrayToString(onlyOneResponse.ResponseRaw)
+            }
+        } else {
+            return Uint8ArrayToString(emptyFuzzer.ResponseRaw)
+        }
+    }, [currentSelectResponse, currentSelectRequest])
     return (
         <>
             <div
@@ -1007,7 +1021,14 @@ const FuzzerSequence: React.FC<FuzzerSequenceProps> = React.memo((props) => {
                         <span>{currentSequenceItem?.name}&nbsp;配置</span>
                         <YakitButton type='text2' icon={<OutlineXIcon />} onClick={() => setIsShowSetting(false)} />
                     </div>
-                    <div style={{padding: 12}}>{currentSequenceItem?.pageName}</div>
+                    {currentSequenceItem && (
+                        <React.Suspense fallback={<>loading...</>}>
+                            <FuzzerPageSetting
+                                pageId={currentSequenceItem.pageId}
+                                defaultHttpResponse={defaultHttpResponse}
+                            />
+                        </React.Suspense>
+                    )}
                 </div>
                 <div className={classNames(styles["fuzzer-sequence-content"])}>
                     {currentSequenceItem && isShowSequenceResponse ? (

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequence.tsx
@@ -176,7 +176,8 @@ const FuzzerSequence: React.FC<FuzzerSequenceProps> = React.memo((props) => {
     const [matcherAndExtractionHttpResponse, setMatcherAndExtractionHttpResponse] = useState<string>("")
     const [showMatcherAndExtraction, setShowMatcherAndExtraction] = useState<boolean>(false) // Response中显示匹配和提取器
 
-    const [triggerPageSetting, setTriggerPageSetting] = useState<boolean>(false)
+    const [triggerPageSetting, setTriggerPageSetting] = useState<boolean>(false) // 刷新FuzzerPageSetting中的值
+    const [triggerME, setTriggerME] = useState<boolean>(false) // 刷新匹配器和提取器的值
 
     // Request
     const [currentSelectRequest, setCurrentSelectRequest] = useState<WebFuzzerPageInfoProps>()
@@ -924,6 +925,7 @@ const FuzzerSequence: React.FC<FuzzerSequenceProps> = React.memo((props) => {
                 }
                 updatePagesDataCacheById(YakitRoute.HTTPFuzzer, {...newCurrentItem})
                 setTriggerPageSetting(!triggerPageSetting)
+                setShowMatcherAndExtraction(false)
             }
         }
     )
@@ -976,7 +978,7 @@ const FuzzerSequence: React.FC<FuzzerSequenceProps> = React.memo((props) => {
             }
         }
         return data
-    }, [currentSelectRequest, visibleDrawer, showMatcherAndExtraction, triggerPageSetting])
+    }, [currentSelectRequest, visibleDrawer, showMatcherAndExtraction, triggerME])
     return (
         <>
             <div
@@ -1139,8 +1141,9 @@ const FuzzerSequence: React.FC<FuzzerSequenceProps> = React.memo((props) => {
                             <FuzzerPageSetting
                                 pageId={currentSequenceItem.pageId}
                                 defaultHttpResponse={defaultHttpResponse}
-                                trigger={triggerPageSetting}
-                                setTrigger={setTriggerPageSetting}
+                                triggerIn={triggerPageSetting}
+                                triggerOut={triggerME}
+                                setTriggerOut={setTriggerME}
                                 onDebug={onDebug}
                             />
                         </React.Suspense>

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequenceType.d.ts
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequenceType.d.ts
@@ -50,11 +50,13 @@ export interface ExtraSettingProps {
  * @property {boolean} isShowLine 是否显示线
  * @property {boolean} disabled
  * @property {SequenceProps} pageNodeList 原始的页面节点list，用来做下拉选中选择
+ * @property {boolean} isShowSetting 是否显示高级配置
  * @function onUpdateItemPage 更新序列item
  * @function onUpdateItem 更新序列item
  * @function onApplyOtherNodes 应用到其他节点事件
  * @function onRemove 删除
  * @function onSelect 选中
+ * @function onShowSetting 显示页面的高级配置部分参数
  */
 export interface SequenceItemProps {
     item: SequenceProps
@@ -65,11 +67,15 @@ export interface SequenceItemProps {
     isShowLine: boolean
     disabled?: boolean
     pageNodeList: SequenceProps[]
+    /**是否显示高级配置 */
+    isShowSetting: boolean
     onUpdateItemPage: (s: SequenceProps) => void
     onUpdateItem: (s: SequenceProps) => void
     onApplyOtherNodes: (e: ExtraSettingProps) => void
     onRemove: (s: SequenceProps) => void
     onSelect: (s: SequenceProps) => void
+    /**显示页面的高级配置部分参数 */
+    onShowSetting: (s: SequenceProps) => void
 }
 /**
  * @description 返回参数
@@ -123,8 +129,8 @@ export interface SequenceResponseProps {
     onShowAll: () => void
 }
 
-export interface SequenceResponseRefProps{
-    validate:() => Promise<boolean>
+export interface SequenceResponseRefProps {
+    validate: () => Promise<boolean>
 }
 /**
  * @description 返回响应头部
@@ -143,7 +149,7 @@ export interface SequenceResponseHeardProps {
     currentSequenceItemPageName: string
     advancedConfigValue?: AdvancedConfigValueProps
     responseInfo?: ResponseProps
-    onShowAll: () => void,
+    onShowAll: () => void
     getHttpParams: () => FuzzerRequestProps[]
 }
 

--- a/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequenceType.d.ts
+++ b/app/renderer/src/main/src/pages/fuzzer/FuzzerSequence/FuzzerSequenceType.d.ts
@@ -1,7 +1,11 @@
 import {WebFuzzerPageInfoProps} from "../../../store/pageInfo"
 import {FuzzerResponse, FuzzerRequestProps} from "../HTTPFuzzerPage"
 import {AdvancedConfigValueProps} from "../HttpQueryAdvancedConfig/HttpQueryAdvancedConfigType"
-import {MatcherAndExtractionRefProps} from "../MatcherAndExtractionCard/MatcherAndExtractionCardType"
+import {
+    MatcherAndExtractionRefProps,
+    MatcherValueProps,
+    ExtractorValueProps
+} from "../MatcherAndExtractionCard/MatcherAndExtractionCardType"
 import {WebFuzzerType} from "../WebFuzzerPage/WebFuzzerPageType"
 /**
  * @description 序列props
@@ -115,6 +119,12 @@ export interface FuzzerSequenceResponse {
  * @property {string} hotPatchCodeWithParamGetter 热加载相关,具体不清楚,现在好像暂时没有用这个
  * @function setHotPatchCode
  * @function setHotPatchCodeWithParamGetter
+ * @function onDebug
+ * @property {MatcherValueProps} matcherValue
+ * @property {ExtractorValueProps} extractorValue
+ * @property {boolean} showMatcherAndExtraction
+ * @function setShowMatcherAndExtraction
+ * @function onSaveMatcherAndExtractionDrawer
  */
 export interface SequenceResponseProps {
     ref?: React.ForwardedRef<SequenceResponseRefProps>
@@ -127,6 +137,14 @@ export interface SequenceResponseProps {
     setHotPatchCode: (s: string) => void
     setHotPatchCodeWithParamGetter: (s: string) => void
     onShowAll: () => void
+    onDebug: (s: string) => void
+    matcherValue: MatcherValueProps
+    extractorValue: ExtractorValueProps
+    showMatcherAndExtraction?: boolean
+    setShowMatcherAndExtraction?: (b: boolean) => void
+    onSaveMatcherAndExtractionDrawer: (m: MatcherValueProps, e: ExtractorValueProps) => void
+    activeType: MatchingAndExtraction
+    activeKey: string
 }
 
 export interface SequenceResponseRefProps {

--- a/app/renderer/src/main/src/pages/fuzzer/HTTPFuzzerPage.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HTTPFuzzerPage.tsx
@@ -1345,6 +1345,7 @@ const HTTPFuzzerPage: React.FC<HTTPFuzzerPageProp> = (props) => {
             ...currentItem,
             pageParamsInfo: {
                 webFuzzerPageInfo: {
+                    ...(currentItem.pageParamsInfo?.webFuzzerPageInfo||{}),
                     pageId: param.pageId,
                     advancedConfigValue: {
                         ...param.advancedConfigValue

--- a/app/renderer/src/main/src/pages/fuzzer/HTTPFuzzerPage.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HTTPFuzzerPage.tsx
@@ -970,6 +970,7 @@ const HTTPFuzzerPage: React.FC<HTTPFuzzerPageProp> = (props) => {
                         extractors: data.extractor.extractorList || []
                     })
                 })
+                .catch(() => {})
                 .finally(() => {
                     setTimeout(() => {
                         submitToHTTPFuzzer()
@@ -1345,7 +1346,7 @@ const HTTPFuzzerPage: React.FC<HTTPFuzzerPageProp> = (props) => {
             ...currentItem,
             pageParamsInfo: {
                 webFuzzerPageInfo: {
-                    ...(currentItem.pageParamsInfo?.webFuzzerPageInfo||{}),
+                    ...(currentItem.pageParamsInfo?.webFuzzerPageInfo || {}),
                     pageId: param.pageId,
                     advancedConfigValue: {
                         ...param.advancedConfigValue
@@ -2863,11 +2864,7 @@ export const SecondNodeExtra: React.FC<SecondNodeExtraProps> = React.memo((props
                     //         一键重试
                     //     </YakitButton>
                     // </YakitPopconfirm>
-                    <YakitButton
-                        type={"primary"}
-                        size='small'
-                        disabled={true}
-                    >
+                    <YakitButton type={"primary"} size='small' disabled={true}>
                         一键重试
                     </YakitButton>
                 )}

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
@@ -264,6 +264,7 @@ export const VariablePanel: React.FC<VariablePanelProps> = React.memo((props) =>
         form.setFieldsValue({
             params: [{Key: "", Value: "", Type: "raw"}]
         })
+        variableRef.current?.setVariableActiveKey(["0"])
     })
     /** @description 变量预览 */
     const onRenderVariables = useMemoizedFn((e: React.MouseEvent<HTMLElement, MouseEvent>) => {

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
@@ -21,6 +21,7 @@ import {CopyableField} from "@/utils/inputUtil"
 import {yakitFailed, yakitNotify} from "@/utils/notification"
 import {VariableList} from "@/pages/httpRequestBuilder/HTTPRequestBuilder"
 import {OutlinePlusIcon} from "@/assets/icon/outline"
+import {RemoteGV} from "@/yakitGV"
 
 const {YakitPanel} = YakitCollapse
 const {ipcRenderer} = window.require("electron")
@@ -306,13 +307,15 @@ export const VariablePanel: React.FC<VariablePanelProps> = React.memo((props) =>
             form.setFieldsValue({
                 params: [...params, {Key: "", Value: "", Type: "raw"}]
             })
-            variableRef.current?.setVariableActiveKey([
-                ...(variableRef.current?.variableActiveKey || []),
-                `${params?.length || 0}`
-            ])
+            onSetActiveKey()
         } else {
             yakitFailed(`请将已添加【变量${index}】设置完成后再进行添加`)
         }
+    })
+
+    const onSetActiveKey = useMemoizedFn(() => {
+        const newActiveKeys = [...(variableRef.current?.variableActiveKey || []), `${params?.length || 0}`]
+        variableRef.current?.setVariableActiveKey([...newActiveKeys])
     })
     const onRemove = useMemoizedFn((index: number) => {
         const newParams = params.filter((_, i) => i !== index)
@@ -361,6 +364,7 @@ export const VariablePanel: React.FC<VariablePanelProps> = React.memo((props) =>
                 className={styles["params-panel"]}
             >
                 <VariableList
+                    cacheKey={RemoteGV.WebFuzzerVariableActiveKey}
                     ref={variableRef}
                     field='params'
                     onDel={onRemove}

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
@@ -249,11 +249,12 @@ const variableModeOptions = [
     }
 ]
 interface VariablePanelProps {
+    pageId: string
     defaultHttpResponse: string
     onAdd: (s: string) => void
 }
 export const VariablePanel: React.FC<VariablePanelProps> = React.memo((props) => {
-    const {defaultHttpResponse, onAdd, ...restProps} = props
+    const {defaultHttpResponse, onAdd, pageId, ...restProps} = props
     const form = Form.useFormInstance()
     const params = Form.useWatch("params", form) || []
 
@@ -364,7 +365,8 @@ export const VariablePanel: React.FC<VariablePanelProps> = React.memo((props) =>
                 className={styles["params-panel"]}
             >
                 <VariableList
-                    cacheKey={RemoteGV.WebFuzzerVariableActiveKey}
+                    cacheType='variableActiveKeys'
+                    pageId={pageId}
                     ref={variableRef}
                     field='params'
                     onDel={onRemove}

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
@@ -10,20 +10,20 @@ import {YakitRadioButtons} from "@/components/yakitUI/YakitRadioButtons/YakitRad
 import {
     ColorSelect,
     filterModeOptions,
-    matcherTypeList,
     matchersConditionOptions
 } from "../MatcherAndExtractionCard/MatcherAndExtractionCard"
-import {MatchersList} from "./HttpQueryAdvancedConfig"
+import {ExtractorsList, MatchersList} from "./HttpQueryAdvancedConfig"
 import {AdvancedConfigValueProps} from "./HttpQueryAdvancedConfigType"
 
 const {YakitPanel} = YakitCollapse
+
 interface MatchersPanelProps {
     onAddMatchingAndExtractionCard: (type: MatchingAndExtraction) => void
-    onEditMatcher: (index: number) => void
+    onEdit: (index: number, type: MatchingAndExtraction) => void
     onSetValue?: (v: AdvancedConfigValueProps) => void
 }
 export const MatchersPanel: React.FC<MatchersPanelProps> = React.memo((props) => {
-    const {onAddMatchingAndExtractionCard, onEditMatcher, onSetValue, ...restProps} = props
+    const {onAddMatchingAndExtractionCard, onEdit, onSetValue, ...restProps} = props
     const form = Form.useFormInstance()
     const filterMode = Form.useWatch("filterMode", form)
     const matchersCondition = Form.useWatch("matchersCondition", form)
@@ -51,6 +51,9 @@ export const MatchersPanel: React.FC<MatchersPanelProps> = React.memo((props) =>
                 ...restValue
             })
         }
+    })
+    const onEditMatcher = useMemoizedFn((index: number) => {
+        onEdit(index, "matchers")
     })
     const matcherValue = useCreation(() => {
         return {
@@ -127,6 +130,96 @@ export const MatchersPanel: React.FC<MatchersPanelProps> = React.memo((props) =>
                     onAdd={() => onAddMatchingAndExtractionCard("matchers")}
                     onRemove={onRemoveMatcher}
                     onEdit={onEditMatcher}
+                />
+            </YakitPanel>
+        </>
+    )
+})
+
+interface ExtractorsPanelProps extends MatchersPanelProps {}
+export const ExtractorsPanel: React.FC<ExtractorsPanelProps> = React.memo((props) => {
+    const {onAddMatchingAndExtractionCard, onEdit, onSetValue, ...restProps} = props
+    const form = Form.useFormInstance()
+    const extractors = Form.useWatch("extractors", form) || []
+    const onReset = useMemoizedFn((restValue) => {
+        form.setFieldsValue({
+            ...restValue
+        })
+        onChangeValue(restValue)
+    })
+    const onRemoveExtractors = useMemoizedFn((i) => {
+        const newExtractors = extractors.filter((m, n) => n !== i)
+        form.setFieldsValue({
+            extractors: newExtractors
+        })
+        onChangeValue(newExtractors)
+    })
+    /** setFieldsValue不会触发Form onValuesChange，抛出去由外界自行解决 */
+    const onChangeValue = useMemoizedFn((restValue) => {
+        if (onSetValue) {
+            const v = form.getFieldsValue()
+            onSetValue({
+                ...v,
+                ...restValue
+            })
+        }
+    })
+    const onEditExtractors = useMemoizedFn((index: number) => {
+        onEdit(index, "extractors")
+    })
+    const extractorValue = useCreation(() => {
+        return {
+            extractorList: extractors
+        }
+    }, [extractors])
+    return (
+        <>
+            <YakitPanel
+                {...restProps}
+                header={
+                    <div className={styles["matchers-panel"]}>
+                        数据提取器
+                        <div className={styles["matchers-number"]}>{extractors?.length}</div>
+                    </div>
+                }
+                key='数据提取器'
+                extra={
+                    <>
+                        <YakitButton
+                            type='text'
+                            colors='danger'
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                const restValue = {
+                                    extractors: []
+                                }
+                                onReset(restValue)
+                            }}
+                            size='small'
+                        >
+                            重置
+                        </YakitButton>
+                        <Divider type='vertical' style={{margin: 0}} />
+                        <YakitButton
+                            type='text'
+                            size='small'
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                onAddMatchingAndExtractionCard("extractors")
+                            }}
+                            className={styles["btn-padding-right-0"]}
+                        >
+                            添加/调试
+                            <HollowLightningBoltIcon />
+                        </YakitButton>
+                    </>
+                }
+            >
+                <ExtractorsList
+                    extractorValue={extractorValue}
+                    onAdd={() => onAddMatchingAndExtractionCard("extractors")}
+                    onRemove={onRemoveExtractors}
+                    onEdit={onEditExtractors}
                 />
             </YakitPanel>
         </>

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
@@ -1,0 +1,134 @@
+import React from "react"
+import styles from "./HttpQueryAdvancedConfig.module.scss"
+import YakitCollapse from "@/components/yakitUI/YakitCollapse/YakitCollapse"
+import {YakitButton} from "@/components/yakitUI/YakitButton/YakitButton"
+import {useCreation, useMemoizedFn} from "ahooks"
+import {Divider, Form} from "antd"
+import {HollowLightningBoltIcon} from "@/assets/newIcon"
+import {MatchingAndExtraction} from "../MatcherAndExtractionCard/MatcherAndExtractionCardType"
+import {YakitRadioButtons} from "@/components/yakitUI/YakitRadioButtons/YakitRadioButtons"
+import {
+    ColorSelect,
+    filterModeOptions,
+    matcherTypeList,
+    matchersConditionOptions
+} from "../MatcherAndExtractionCard/MatcherAndExtractionCard"
+import {MatchersList} from "./HttpQueryAdvancedConfig"
+import {AdvancedConfigValueProps} from "./HttpQueryAdvancedConfigType"
+
+const {YakitPanel} = YakitCollapse
+interface MatchersPanelProps {
+    onAddMatchingAndExtractionCard: (type: MatchingAndExtraction) => void
+    onEditMatcher: (index: number) => void
+    onSetValue?: (v: AdvancedConfigValueProps) => void
+}
+export const MatchersPanel: React.FC<MatchersPanelProps> = React.memo((props) => {
+    const {onAddMatchingAndExtractionCard, onEditMatcher, onSetValue, ...restProps} = props
+    const form = Form.useFormInstance()
+    const filterMode = Form.useWatch("filterMode", form)
+    const matchersCondition = Form.useWatch("matchersCondition", form)
+    const hitColor = Form.useWatch("hitColor", form)
+    const matchers = Form.useWatch("matchers", form) || []
+    const onReset = useMemoizedFn((restValue) => {
+        form.setFieldsValue({
+            ...restValue
+        })
+        onChangeValue(restValue)
+    })
+    const onRemoveMatcher = useMemoizedFn((i) => {
+        const newMatchers = matchers.filter((m, n) => n !== i)
+        form.setFieldsValue({
+            matchers: newMatchers
+        })
+        onChangeValue(newMatchers)
+    })
+    /** setFieldsValue不会触发Form onValuesChange，抛出去由外界自行解决 */
+    const onChangeValue = useMemoizedFn((restValue) => {
+        if (onSetValue) {
+            const v = form.getFieldsValue()
+            onSetValue({
+                ...v,
+                ...restValue
+            })
+        }
+    })
+    const matcherValue = useCreation(() => {
+        return {
+            matchersList: matchers,
+            filterMode,
+            matchersCondition,
+            hitColor
+        }
+    }, [matchers, filterMode, matchersCondition, hitColor])
+    return (
+        <>
+            <YakitPanel
+                {...restProps}
+                header={
+                    <div className={styles["matchers-panel"]}>
+                        匹配器
+                        <div className={styles["matchers-number"]}>{matchers?.length}</div>
+                    </div>
+                }
+                key='匹配器'
+                extra={
+                    <>
+                        <YakitButton
+                            type='text'
+                            colors='danger'
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                const restValue = {
+                                    matchers: [],
+                                    filterMode: "drop",
+                                    hitColor: "red",
+                                    matchersCondition: "and"
+                                }
+                                onReset(restValue)
+                            }}
+                            size='small'
+                        >
+                            重置
+                        </YakitButton>
+                        <Divider type='vertical' style={{margin: 0}} />
+                        <YakitButton
+                            type='text'
+                            size='small'
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                onAddMatchingAndExtractionCard("matchers")
+                            }}
+                            className={styles["btn-padding-right-0"]}
+                        >
+                            添加/调试
+                            <HollowLightningBoltIcon />
+                        </YakitButton>
+                    </>
+                }
+                className={styles["panel-wrapper"]}
+            >
+                <div className={styles["matchers-heard"]}>
+                    <div className={styles["matchers-heard-left"]}>
+                        <Form.Item name='filterMode' noStyle>
+                            <YakitRadioButtons buttonStyle='solid' options={filterModeOptions} size='small' />
+                        </Form.Item>
+                        {filterMode === "onlyMatch" && (
+                            <Form.Item name='hitColor' noStyle>
+                                <ColorSelect size='small' />
+                            </Form.Item>
+                        )}
+                    </div>
+                    <Form.Item name='matchersCondition' noStyle>
+                        <YakitRadioButtons buttonStyle='solid' options={matchersConditionOptions} size='small' />
+                    </Form.Item>
+                </div>
+                <MatchersList
+                    matcherValue={matcherValue}
+                    onAdd={() => onAddMatchingAndExtractionCard("matchers")}
+                    onRemove={onRemoveMatcher}
+                    onEdit={onEditMatcher}
+                />
+            </YakitPanel>
+        </>
+    )
+})

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
@@ -3,12 +3,13 @@ import styles from "./HttpQueryAdvancedConfig.module.scss"
 import YakitCollapse from "@/components/yakitUI/YakitCollapse/YakitCollapse"
 import {YakitButton} from "@/components/yakitUI/YakitButton/YakitButton"
 import {useCreation, useMemoizedFn} from "ahooks"
-import {Descriptions, Divider, Form} from "antd"
+import {Divider, Form} from "antd"
 import {HollowLightningBoltIcon} from "@/assets/newIcon"
 import {MatchingAndExtraction} from "../MatcherAndExtractionCard/MatcherAndExtractionCardType"
 import {YakitRadioButtons} from "@/components/yakitUI/YakitRadioButtons/YakitRadioButtons"
 import {
     ColorSelect,
+    ExtractionResultsContent,
     defMatcherAndExtractionCode,
     filterModeOptions,
     matchersConditionOptions
@@ -17,7 +18,6 @@ import {ExtractorsList, MatchersList} from "./HttpQueryAdvancedConfig"
 import {AdvancedConfigValueProps} from "./HttpQueryAdvancedConfigType"
 import {StringToUint8Array} from "@/utils/str"
 import {showYakitModal} from "@/components/yakitUI/YakitModal/YakitModalConfirm"
-import {CopyableField} from "@/utils/inputUtil"
 import {yakitFailed, yakitNotify} from "@/utils/notification"
 import {VariableList} from "@/pages/httpRequestBuilder/HTTPRequestBuilder"
 import {OutlinePlusIcon} from "@/assets/icon/outline"
@@ -282,23 +282,13 @@ export const VariablePanel: React.FC<VariablePanelProps> = React.memo((props) =>
                 showYakitModal({
                     title: "渲染后变量内容",
                     footer: <></>,
+                    width: "60%",
                     content: (
-                        <div className={styles["render-variables-modal-content"]}>
-                            <Descriptions size={"small"} column={1} bordered={true}>
-                                {rsp.Results.filter((i) => {
-                                    return !(i.Key === "" && i.Value === "")
-                                }).map((data, index) => {
-                                    return (
-                                        <Descriptions.Item
-                                            label={<CopyableField text={data.Key} maxWidth={100} />}
-                                            key={`${data.Key}-${data.Value}`}
-                                        >
-                                            <CopyableField text={data.Value} maxWidth={300} />
-                                        </Descriptions.Item>
-                                    )
-                                })}
-                            </Descriptions>
-                        </div>
+                        <ExtractionResultsContent
+                            list={(rsp.Results || []).filter((i) => {
+                                return !(i.Key === "" && i.Value === "")
+                            })}
+                        />
                     )
                 })
             })

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
@@ -91,7 +91,7 @@ export const MatchersPanel: React.FC<MatchersPanelProps> = React.memo((props) =>
                                 e.stopPropagation()
                                 const restValue = {
                                     matchers: [],
-                                    filterMode: "drop",
+                                    filterMode: "onlyMatch",
                                     hitColor: "red",
                                     matchersCondition: "and"
                                 }

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
@@ -358,6 +358,7 @@ export const VariablePanel: React.FC<VariablePanelProps> = React.memo((props) =>
                         </YakitButton>
                     </>
                 }
+                className={styles["params-panel"]}
             >
                 <VariableList
                     ref={variableRef}

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/FuzzerConfigPanels.tsx
@@ -1,21 +1,29 @@
-import React from "react"
+import React, {useRef} from "react"
 import styles from "./HttpQueryAdvancedConfig.module.scss"
 import YakitCollapse from "@/components/yakitUI/YakitCollapse/YakitCollapse"
 import {YakitButton} from "@/components/yakitUI/YakitButton/YakitButton"
 import {useCreation, useMemoizedFn} from "ahooks"
-import {Divider, Form} from "antd"
+import {Descriptions, Divider, Form} from "antd"
 import {HollowLightningBoltIcon} from "@/assets/newIcon"
 import {MatchingAndExtraction} from "../MatcherAndExtractionCard/MatcherAndExtractionCardType"
 import {YakitRadioButtons} from "@/components/yakitUI/YakitRadioButtons/YakitRadioButtons"
 import {
     ColorSelect,
+    defMatcherAndExtractionCode,
     filterModeOptions,
     matchersConditionOptions
 } from "../MatcherAndExtractionCard/MatcherAndExtractionCard"
 import {ExtractorsList, MatchersList} from "./HttpQueryAdvancedConfig"
 import {AdvancedConfigValueProps} from "./HttpQueryAdvancedConfigType"
+import {StringToUint8Array} from "@/utils/str"
+import {showYakitModal} from "@/components/yakitUI/YakitModal/YakitModalConfirm"
+import {CopyableField} from "@/utils/inputUtil"
+import {yakitFailed, yakitNotify} from "@/utils/notification"
+import {VariableList} from "@/pages/httpRequestBuilder/HTTPRequestBuilder"
+import {OutlinePlusIcon} from "@/assets/icon/outline"
 
 const {YakitPanel} = YakitCollapse
+const {ipcRenderer} = window.require("electron")
 
 interface MatchersPanelProps {
     onAddMatchingAndExtractionCard: (type: MatchingAndExtraction) => void
@@ -221,6 +229,151 @@ export const ExtractorsPanel: React.FC<ExtractorsPanelProps> = React.memo((props
                     onRemove={onRemoveExtractors}
                     onEdit={onEditExtractors}
                 />
+            </YakitPanel>
+        </>
+    )
+})
+const variableModeOptions = [
+    {
+        value: "nuclei-dsl",
+        label: "nuclei"
+    },
+    {
+        value: "fuzztag",
+        label: "fuzztag"
+    },
+    {
+        value: "raw",
+        label: "raw"
+    }
+]
+interface VariablePanelProps {
+    defaultHttpResponse: string
+    onAdd: (s: string) => void
+}
+export const VariablePanel: React.FC<VariablePanelProps> = React.memo((props) => {
+    const {defaultHttpResponse, onAdd, ...restProps} = props
+    const form = Form.useFormInstance()
+    const params = Form.useWatch("params", form) || []
+
+    const variableRef = useRef<any>()
+
+    const onReset = useMemoizedFn(() => {
+        form.setFieldsValue({
+            params: [{Key: "", Value: "", Type: "raw"}]
+        })
+    })
+    /** @description 变量预览 */
+    const onRenderVariables = useMemoizedFn((e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+        e.stopPropagation()
+        ipcRenderer
+            .invoke("RenderVariables", {
+                Params: form.getFieldValue("params") || [],
+                HTTPResponse: StringToUint8Array(defaultHttpResponse || defMatcherAndExtractionCode)
+            })
+            .then((rsp: {Results: {Key: string; Value: string}[]}) => {
+                showYakitModal({
+                    title: "渲染后变量内容",
+                    footer: <></>,
+                    content: (
+                        <div className={styles["render-variables-modal-content"]}>
+                            <Descriptions size={"small"} column={1} bordered={true}>
+                                {rsp.Results.filter((i) => {
+                                    return !(i.Key === "" && i.Value === "")
+                                }).map((data, index) => {
+                                    return (
+                                        <Descriptions.Item
+                                            label={<CopyableField text={data.Key} maxWidth={100} />}
+                                            key={`${data.Key}-${data.Value}`}
+                                        >
+                                            <CopyableField text={data.Value} maxWidth={300} />
+                                        </Descriptions.Item>
+                                    )
+                                })}
+                            </Descriptions>
+                        </div>
+                    )
+                })
+            })
+            .catch((err) => {
+                yakitNotify("error", "预览失败:" + err)
+            })
+    })
+    const onAddPrams = useMemoizedFn(() => {
+        onAdd("设置变量")
+        const index = params.findIndex((ele: {Key: string; Value: string}) => !ele || (!ele.Key && !ele.Value))
+        if (index === -1) {
+            form.setFieldsValue({
+                params: [...params, {Key: "", Value: "", Type: "raw"}]
+            })
+            variableRef.current?.setVariableActiveKey([
+                ...(variableRef.current?.variableActiveKey || []),
+                `${params?.length || 0}`
+            ])
+        } else {
+            yakitFailed(`请将已添加【变量${index}】设置完成后再进行添加`)
+        }
+    })
+    const onRemove = useMemoizedFn((index: number) => {
+        const newParams = params.filter((_, i) => i !== index)
+        form.setFieldsValue({
+            params: [...newParams]
+        })
+    })
+    return (
+        <>
+            <YakitPanel
+                {...restProps}
+                header='设置变量'
+                key='设置变量'
+                extra={
+                    <>
+                        <YakitButton
+                            type='text'
+                            colors='danger'
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                onReset()
+                            }}
+                            size='small'
+                        >
+                            重置
+                        </YakitButton>
+                        <Divider type='vertical' style={{margin: 0}} />
+                        <YakitButton type='text' onClick={onRenderVariables} size='small'>
+                            预览
+                        </YakitButton>
+                        <Divider type='vertical' style={{margin: 0}} />
+                        <YakitButton
+                            type='text'
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                onAddPrams()
+                            }}
+                            className={styles["btn-padding-right-0"]}
+                            size='small'
+                        >
+                            添加
+                            <OutlinePlusIcon />
+                        </YakitButton>
+                    </>
+                }
+            >
+                <VariableList
+                    ref={variableRef}
+                    field='params'
+                    onDel={onRemove}
+                    extra={(i, info) => (
+                        <Form.Item name={[info.name, "Type"]} noStyle wrapperCol={{span: 24}}>
+                            <YakitRadioButtons
+                                style={{marginLeft: 4}}
+                                buttonStyle='solid'
+                                options={variableModeOptions}
+                                size={"small"}
+                            />
+                        </Form.Item>
+                    )}
+                ></VariableList>
             </YakitPanel>
         </>
     )

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.module.scss
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.module.scss
@@ -11,10 +11,6 @@
     background-color: var(--yakit-card-background-color);
 
     :global {
-        .ant-radio-button-wrapper {
-            padding: 3px 10px;
-        }
-
         .ant-form-item {
             margin-bottom: 12px;
         }
@@ -25,10 +21,6 @@
         .ant-form-item-with-help .ant-form-item-explain {
             font-size: 12px;
         }
-    }
-
-    .btn-padding-right-0 {
-        padding-right: 0;
     }
 
     .chevron-down-icon {
@@ -102,114 +94,6 @@
         width: 100%;
     }
 
-    .matchers-panel {
-        display: flex;
-        align-items: center;
-
-        .matchers-number {
-            @include HTTPFuzzerPageShare.circle-number;
-            margin: 0 4px;
-        }
-    }
-
-    .matchers-heard {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        margin-bottom: 8px;
-
-        .matchers-heard-left {
-            display: flex;
-            align-items: center;
-        }
-    }
-
-    .matchersList-item {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 2px 8px;
-        border: 1px solid var(--yakit-border-color);
-        border-radius: 4px;
-        background: #ffffff;
-
-        &:hover {
-            .matchersList-item-operate {
-                visibility: visible;
-            }
-        }
-
-        .matchersList-item-heard {
-            display: flex;
-            align-items: center;
-            gap: 4px;
-
-            .item-id {
-                color: var(--yakit-helper-text-color);
-            }
-
-            .item-number {
-                @include HTTPFuzzerPageShare.circle-number;
-            }
-        }
-
-        .matchersList-item-operate {
-            display: flex;
-            align-items: center;
-            justify-content: flex-end;
-            gap: 4px;
-            visibility: hidden;
-
-            svg {
-                width: 16px;
-                height: 16px;
-                cursor: pointer;
-            }
-
-            .trash-icon {
-                color: var(--yakit-danger-5);
-                @include HTTPFuzzerPageShare.base-icon-card;
-
-                &:hover {
-                    color: var(--yakit-danger-4);
-                }
-
-                &:active,
-                &:focus {
-                    color: var(--yakit-danger-6);
-                }
-            }
-
-            .hollow-lightningBolt-icon,
-            .terminal-icon {
-                color: var(--yakit-body-text-color);
-                @include HTTPFuzzerPageShare.base-icon-card;
-            }
-
-            .hollow-lightningBolt-icon {
-                svg {
-                    stroke-width: 0.8px;
-                }
-            }
-
-            .pencilAlit-icon-disabled {
-                color: var(--yakit-disable-text-color);
-
-                svg {
-                    cursor: not-allowed;
-                }
-            }
-        }
-
-        .matchersList-item-operate-hover {
-            visibility: visible;
-        }
-    }
-
-    .matchersList-item + .matchersList-item {
-        margin-top: 4px;
-    }
-
     .to-end {
         text-align: center;
         color: var(--yakit-disable-text-color);
@@ -217,15 +101,136 @@
         padding-top: 12px;
         padding-bottom: 24px;
     }
-    .panel-wrapper {
-        :global {
-            .ant-collapse-header {
-                border-top: 0 !important;
-            }
+}
+.btn-padding-right-0 {
+    padding-right: 0;
+}
+.panel-wrapper {
+    :global {
+        .ant-collapse-header {
+            border-top: 0 !important;
         }
     }
 }
+.params-panel {
+    :global {
+        .ant-radio-button-wrapper {
+            padding: 3px 10px;
+        }
+    }
+}
+.matchers-panel {
+    display: flex;
+    align-items: center;
 
+    .matchers-number {
+        @include HTTPFuzzerPageShare.circle-number;
+        margin: 0 4px;
+    }
+}
+
+.matchers-heard {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    :global {
+        .ant-radio-button-wrapper {
+            padding: 3px 10px;
+        }
+    }
+
+    .matchers-heard-left {
+        display: flex;
+        align-items: center;
+    }
+}
+
+.matchersList-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 2px 8px;
+    border: 1px solid var(--yakit-border-color);
+    border-radius: 4px;
+    background: #ffffff;
+
+    &:hover {
+        .matchersList-item-operate {
+            visibility: visible;
+        }
+    }
+
+    .matchersList-item-heard {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+
+        .item-id {
+            color: var(--yakit-helper-text-color);
+        }
+
+        .item-number {
+            @include HTTPFuzzerPageShare.circle-number;
+        }
+    }
+
+    .matchersList-item-operate {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 4px;
+        visibility: hidden;
+
+        svg {
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+        }
+
+        .trash-icon {
+            color: var(--yakit-danger-5);
+            @include HTTPFuzzerPageShare.base-icon-card;
+
+            &:hover {
+                color: var(--yakit-danger-4);
+            }
+
+            &:active,
+            &:focus {
+                color: var(--yakit-danger-6);
+            }
+        }
+
+        .hollow-lightningBolt-icon,
+        .terminal-icon {
+            color: var(--yakit-body-text-color);
+            @include HTTPFuzzerPageShare.base-icon-card;
+        }
+
+        .hollow-lightningBolt-icon {
+            svg {
+                stroke-width: 0.8px;
+            }
+        }
+
+        .pencilAlit-icon-disabled {
+            color: var(--yakit-disable-text-color);
+
+            svg {
+                cursor: not-allowed;
+            }
+        }
+    }
+
+    .matchersList-item-operate-hover {
+        visibility: visible;
+    }
+}
+
+.matchersList-item + .matchersList-item {
+    margin-top: 4px;
+}
 @keyframes show {
     from {
         // width: 100px;

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.module.scss
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.module.scss
@@ -338,14 +338,6 @@
         }
     }
 }
-.render-variables-modal-content {
-    padding: 24px;
-    max-height: 80vh;
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-}
 .variable-item {
     border: 1px solid var(--yakit-border-color);
     border-radius: 4px;

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.module.scss
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.module.scss
@@ -11,6 +11,9 @@
     background-color: var(--yakit-card-background-color);
 
     :global {
+        .ant-radio-button-wrapper {
+            padding: 3px 10px;
+        }
         .ant-form-item {
             margin-bottom: 12px;
         }

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.tsx
@@ -14,7 +14,7 @@ import {YakitInputNumber} from "@/components/yakitUI/YakitInputNumber/YakitInput
 import {YakitSelect} from "@/components/yakitUI/YakitSelect/YakitSelect"
 import {YakitSwitch} from "@/components/yakitUI/YakitSwitch/YakitSwitch"
 import {getRemoteValue, setRemoteValue} from "@/utils/kv"
-import {yakitFailed} from "@/utils/notification"
+import {yakitFailed, yakitNotify} from "@/utils/notification"
 import {useInViewport, useMemoizedFn} from "ahooks"
 import {Form, Tooltip, Space, Divider} from "antd"
 import React, {useState, useRef, useEffect, useMemo, ReactNode} from "react"
@@ -143,7 +143,7 @@ export const HttpQueryAdvancedConfig: React.FC<HttpQueryAdvancedConfigProps> = R
     }, [inViewport])
 
     useEffect(() => {
-        ipcRenderer.on("fetch-open-matcher-and-extraction", openDrawer)
+        emiter.on("openMatcherAndExtraction", openDrawer)
         getRemoteValue(WEB_FUZZ_Advanced_Config_ActiveKey).then((data) => {
             try {
                 // setTimeout(() => {
@@ -155,15 +155,20 @@ export const HttpQueryAdvancedConfig: React.FC<HttpQueryAdvancedConfigProps> = R
             }
         })
         return () => {
-            ipcRenderer.removeListener("fetch-open-matcher-and-extraction", openDrawer)
+            emiter.off("openMatcherAndExtraction", openDrawer)
         }
     }, [])
 
-    const openDrawer = useMemoizedFn((e, res: {httpResponseCode: string}) => {
-        if (inViewportCurrent && !visibleDrawer) {
-            setVisibleDrawer(true)
+    const openDrawer = useMemoizedFn((val) => {
+        try {
+            const res = JSON.parse(val)
+            if (inViewportCurrent && !visibleDrawer) {
+                setVisibleDrawer(true)
+            }
+            setHttpResponse(res.httpResponseCode)
+        } catch (error) {
+            yakitNotify("error", "openMatcherAndExtraction 解析数据失败")
         }
-        setHttpResponse(res.httpResponseCode)
     })
 
     useEffect(() => {

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.tsx
@@ -865,6 +865,7 @@ export const HttpQueryAdvancedConfig: React.FC<HttpQueryAdvancedConfigProps> = R
                                 key='设置变量'
                                 defaultHttpResponse={defaultHttpResponse}
                                 onAdd={onAddExtra}
+                                pageId={id}
                             />
                             <YakitPanel
                                 header='GET 参数'

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.tsx
@@ -1231,29 +1231,37 @@ export const MatchersList: React.FC<MatchersListProps> = React.memo((props) => {
     const {matchersList} = matcherValue
     return (
         <>
-            <Form.Item name='matchers' noStyle>
-                {matchersList.map((matcherItem, index) => (
-                    <div className={styles["matchersList-item"]} key={`ID:${index}`}>
-                        <div className={styles["matchersList-item-heard"]}>
-                            <span className={styles["item-id"]}>ID&nbsp;{index}</span>
-                            <span>[{matcherTypeList.find((e) => e.value === matcherItem.MatcherType)?.label}]</span>
-                            <span className={styles["item-number"]}>{matcherItem.Group?.length}</span>
-                        </div>
-                        <MatchersAndExtractorsListItemOperate
-                            onRemove={() => onRemove(index)}
-                            onEdit={() => onEdit(index)}
-                            popoverContent={
-                                <MatcherItem
-                                    matcherItem={matcherItem}
-                                    onEdit={() => {}}
-                                    notEditable={true}
-                                    httpResponse=''
-                                />
-                            }
-                        />
-                    </div>
-                ))}
-            </Form.Item>
+            <Form.List name='matchers'>
+                {() => (
+                    <>
+                        {matchersList.map((matcherItem, index) => (
+                            <Form.Item noStyle key={`ID:${index}`}>
+                                <div className={styles["matchersList-item"]} key={`ID:${index}`}>
+                                    <div className={styles["matchersList-item-heard"]}>
+                                        <span className={styles["item-id"]}>ID&nbsp;{index}</span>
+                                        <span>
+                                            [{matcherTypeList.find((e) => e.value === matcherItem.MatcherType)?.label}]
+                                        </span>
+                                        <span className={styles["item-number"]}>{matcherItem.Group?.length}</span>
+                                    </div>
+                                    <MatchersAndExtractorsListItemOperate
+                                        onRemove={() => onRemove(index)}
+                                        onEdit={() => onEdit(index)}
+                                        popoverContent={
+                                            <MatcherItem
+                                                matcherItem={matcherItem}
+                                                onEdit={() => {}}
+                                                notEditable={true}
+                                                httpResponse=''
+                                            />
+                                        }
+                                    />
+                                </div>
+                            </Form.Item>
+                        ))}
+                    </>
+                )}
+            </Form.List>
             {matchersList?.length === 0 && (
                 <>
                     <YakitButton
@@ -1283,29 +1291,39 @@ export const ExtractorsList: React.FC<ExtractorsListProps> = React.memo((props) 
     const {extractorList} = extractorValue
     return (
         <>
-            <Form.Item name='extractors' noStyle>
-                {extractorList.map((extractorItem, index) => (
-                    <div className={styles["matchersList-item"]} key={`${extractorItem.Name}-${index}`}>
-                        <div className={styles["matchersList-item-heard"]}>
-                            <span className={styles["item-id"]}>{extractorItem.Name || `data_${index}`}</span>
-                            <span>[{extractorTypeList.find((e) => e.value === extractorItem.Type)?.label}]</span>
-                            <span className={styles["item-number"]}>{extractorItem.Groups?.length}</span>
-                        </div>
-                        <MatchersAndExtractorsListItemOperate
-                            onRemove={() => onRemove(index)}
-                            onEdit={() => onEdit(index)}
-                            popoverContent={
-                                <ExtractorItem
-                                    extractorItem={extractorItem}
-                                    onEdit={() => {}}
-                                    notEditable={true}
-                                    httpResponse=''
-                                />
-                            }
-                        />
-                    </div>
-                ))}
-            </Form.Item>
+            <Form.List name='extractors'>
+                {() => (
+                    <>
+                        {extractorList.map((extractorItem, index) => (
+                            <Form.Item noStyle key={`${extractorItem.Name}-${index}`}>
+                                <div className={styles["matchersList-item"]}>
+                                    <div className={styles["matchersList-item-heard"]}>
+                                        <span className={styles["item-id"]}>
+                                            {extractorItem.Name || `data_${index}`}
+                                        </span>
+                                        <span>
+                                            [{extractorTypeList.find((e) => e.value === extractorItem.Type)?.label}]
+                                        </span>
+                                        <span className={styles["item-number"]}>{extractorItem.Groups?.length}</span>
+                                    </div>
+                                    <MatchersAndExtractorsListItemOperate
+                                        onRemove={() => onRemove(index)}
+                                        onEdit={() => onEdit(index)}
+                                        popoverContent={
+                                            <ExtractorItem
+                                                extractorItem={extractorItem}
+                                                onEdit={() => {}}
+                                                notEditable={true}
+                                                httpResponse=''
+                                            />
+                                        }
+                                    />
+                                </div>
+                            </Form.Item>
+                        ))}
+                    </>
+                )}
+            </Form.List>
             {extractorList?.length === 0 && (
                 <>
                     <YakitButton

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.tsx
@@ -25,15 +25,12 @@ import styles from "./HttpQueryAdvancedConfig.module.scss"
 import {showYakitModal} from "@/components/yakitUI/YakitModal/YakitModalConfirm"
 import {StringToUint8Array, Uint8ArrayToString} from "@/utils/str"
 import {
-    ColorSelect,
     ExtractorItem,
     MatcherAndExtractionDrawer,
     MatcherItem,
     defMatcherAndExtractionCode,
     extractorTypeList,
-    filterModeOptions,
-    matcherTypeList,
-    matchersConditionOptions
+    matcherTypeList
 } from "../MatcherAndExtractionCard/MatcherAndExtractionCard"
 import {YakitRadioButtons} from "@/components/yakitUI/YakitRadioButtons/YakitRadioButtons"
 import classNames from "classnames"
@@ -55,6 +52,7 @@ import {YakitModal} from "@/components/yakitUI/YakitModal/YakitModal"
 import {YakitFormDraggerContent} from "@/components/yakitUI/YakitForm/YakitForm"
 import {OutlineBadgecheckIcon} from "@/assets/icon/outline"
 import {CacheDropDownGV} from "@/yakitGV"
+import {MatchersPanel} from "./FuzzerConfigPanels"
 
 const {ipcRenderer} = window.require("electron")
 const {YakitPanel} = YakitCollapse
@@ -256,6 +254,9 @@ export const HttpQueryAdvancedConfig: React.FC<HttpQueryAdvancedConfigProps> = R
     })
 
     const onAddMatchingAndExtractionCard = useMemoizedFn((type: MatchingAndExtraction) => {
+        if (activeKey?.findIndex((ele) => ele === "匹配器") === -1) {
+            onSwitchCollapse([...activeKey, "匹配器"])
+        }
         if (outsideShowResponseMatcherAndExtraction) {
             if (onShowResponseMatcherAndExtraction) onShowResponseMatcherAndExtraction(type, "ID:0")
         } else {
@@ -278,13 +279,6 @@ export const HttpQueryAdvancedConfig: React.FC<HttpQueryAdvancedConfigProps> = R
         }
     }, [])
 
-    const onRemoveMatcher = useMemoizedFn((i) => {
-        const v = form.getFieldsValue()
-        onSetValue({
-            ...v,
-            matchers: matchersList.filter((m, n) => n !== i)
-        })
-    })
     const onEditMatcher = useMemoizedFn((index) => {
         if (outsideShowResponseMatcherAndExtraction) {
             if (onShowResponseMatcherAndExtraction) onShowResponseMatcherAndExtraction("matchers", `ID:${index}`)
@@ -914,83 +908,12 @@ export const HttpQueryAdvancedConfig: React.FC<HttpQueryAdvancedConfigProps> = R
                             onChange={(key) => onSwitchCollapse(key)}
                             destroyInactivePanel={true}
                         >
-                            <YakitPanel
-                                header={
-                                    <div className={styles["matchers-panel"]}>
-                                        匹配器
-                                        <div className={styles["matchers-number"]}>{matchersList?.length}</div>
-                                    </div>
-                                }
+                            <MatchersPanel
                                 key='匹配器'
-                                extra={
-                                    <>
-                                        <YakitButton
-                                            type='text'
-                                            colors='danger'
-                                            onClick={(e) => {
-                                                e.stopPropagation()
-                                                const restValue = {
-                                                    matchers: [],
-                                                    filterMode: "drop",
-                                                    hitColor: "red",
-                                                    matchersCondition: "and"
-                                                }
-                                                onReset(restValue)
-                                            }}
-                                            size='small'
-                                        >
-                                            重置
-                                        </YakitButton>
-                                        <Divider type='vertical' style={{margin: 0}} />
-                                        <YakitButton
-                                            type='text'
-                                            size='small'
-                                            onClick={(e) => {
-                                                e.stopPropagation()
-                                                if (activeKey?.findIndex((ele) => ele === "匹配器") === -1) {
-                                                    onSwitchCollapse([...activeKey, "匹配器"])
-                                                }
-                                                onAddMatchingAndExtractionCard("matchers")
-                                            }}
-                                            className={styles["btn-padding-right-0"]}
-                                        >
-                                            添加/调试
-                                            <HollowLightningBoltIcon />
-                                        </YakitButton>
-                                    </>
-                                }
-                                className={styles["panel-wrapper"]}
-                            >
-                                <div className={styles["matchers-heard"]}>
-                                    <div className={styles["matchers-heard-left"]}>
-                                        <Form.Item name='filterMode' noStyle>
-                                            <YakitRadioButtons
-                                                buttonStyle='solid'
-                                                options={filterModeOptions}
-                                                size='small'
-                                            />
-                                        </Form.Item>
-                                        {filterMode === "onlyMatch" && (
-                                            <Form.Item name='hitColor' noStyle>
-                                                <ColorSelect size='small' />
-                                            </Form.Item>
-                                        )}
-                                    </div>
-                                    <Form.Item name='matchersCondition' noStyle>
-                                        <YakitRadioButtons
-                                            buttonStyle='solid'
-                                            options={matchersConditionOptions}
-                                            size='small'
-                                        />
-                                    </Form.Item>
-                                </div>
-                                <MatchersList
-                                    matcherValue={{filterMode, matchersList, matchersCondition, hitColor}}
-                                    onAdd={() => onAddMatchingAndExtractionCard("matchers")}
-                                    onRemove={onRemoveMatcher}
-                                    onEdit={onEditMatcher}
-                                />
-                            </YakitPanel>
+                                onAddMatchingAndExtractionCard={onAddMatchingAndExtractionCard}
+                                onEditMatcher={onEditMatcher}
+                                onSetValue={onSetValue}
+                            />
                             <YakitPanel
                                 header={
                                     <div className={styles["matchers-panel"]}>
@@ -1455,7 +1378,7 @@ interface MatchersListProps {
     onEdit: (index: number) => void
 }
 /**匹配器 */
-const MatchersList: React.FC<MatchersListProps> = React.memo((props) => {
+export const MatchersList: React.FC<MatchersListProps> = React.memo((props) => {
     const {matcherValue, onAdd, onRemove, onEdit} = props
     const {matchersList} = matcherValue
     return (

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.tsx
@@ -866,6 +866,7 @@ export const HttpQueryAdvancedConfig: React.FC<HttpQueryAdvancedConfigProps> = R
                                 defaultHttpResponse={defaultHttpResponse}
                                 onAdd={onAddExtra}
                                 pageId={id}
+                                onSetValue={onSetValue}
                             />
                             <YakitPanel
                                 header='GET 参数'

--- a/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HttpQueryAdvancedConfig/HttpQueryAdvancedConfig.tsx
@@ -52,7 +52,7 @@ import {YakitModal} from "@/components/yakitUI/YakitModal/YakitModal"
 import {YakitFormDraggerContent} from "@/components/yakitUI/YakitForm/YakitForm"
 import {OutlineBadgecheckIcon} from "@/assets/icon/outline"
 import {CacheDropDownGV} from "@/yakitGV"
-import {MatchersPanel} from "./FuzzerConfigPanels"
+import {ExtractorsPanel, MatchersPanel} from "./FuzzerConfigPanels"
 
 const {ipcRenderer} = window.require("electron")
 const {YakitPanel} = YakitCollapse
@@ -254,8 +254,8 @@ export const HttpQueryAdvancedConfig: React.FC<HttpQueryAdvancedConfigProps> = R
     })
 
     const onAddMatchingAndExtractionCard = useMemoizedFn((type: MatchingAndExtraction) => {
-        if (activeKey?.findIndex((ele) => ele === "匹配器") === -1) {
-            onSwitchCollapse([...activeKey, "匹配器"])
+        if (activeKey?.findIndex((ele) => ele === type) === -1) {
+            onSwitchCollapse([...activeKey, type])
         }
         if (outsideShowResponseMatcherAndExtraction) {
             if (onShowResponseMatcherAndExtraction) onShowResponseMatcherAndExtraction(type, "ID:0")
@@ -279,29 +279,14 @@ export const HttpQueryAdvancedConfig: React.FC<HttpQueryAdvancedConfigProps> = R
         }
     }, [])
 
-    const onEditMatcher = useMemoizedFn((index) => {
+    /**修改匹配器和提取器 */
+    const onEdit = useMemoizedFn((index, type: MatchingAndExtraction) => {
         if (outsideShowResponseMatcherAndExtraction) {
             if (onShowResponseMatcherAndExtraction) onShowResponseMatcherAndExtraction("matchers", `ID:${index}`)
         } else {
             setVisibleDrawer(true)
             setDefActiveKey(`ID:${index}`)
-            setType("matchers")
-        }
-    })
-    const onRemoveExtractors = useMemoizedFn((i) => {
-        const v = form.getFieldsValue()
-        onSetValue({
-            ...v,
-            extractors: extractorList.filter((m, n) => n !== i)
-        })
-    })
-    const onEditExtractors = useMemoizedFn((index) => {
-        if (outsideShowResponseMatcherAndExtraction) {
-            if (onShowResponseMatcherAndExtraction) onShowResponseMatcherAndExtraction("extractors", `ID:${index}`)
-        } else {
-            setVisibleDrawer(true)
-            setDefActiveKey(`ID:${index}`)
-            setType("extractors")
+            setType(type)
         }
     })
     const retryActive: string[] = useMemo(() => {
@@ -911,59 +896,15 @@ export const HttpQueryAdvancedConfig: React.FC<HttpQueryAdvancedConfigProps> = R
                             <MatchersPanel
                                 key='匹配器'
                                 onAddMatchingAndExtractionCard={onAddMatchingAndExtractionCard}
-                                onEditMatcher={onEditMatcher}
+                                onEdit={onEdit}
                                 onSetValue={onSetValue}
                             />
-                            <YakitPanel
-                                header={
-                                    <div className={styles["matchers-panel"]}>
-                                        数据提取器
-                                        <div className={styles["matchers-number"]}>{extractorList?.length}</div>
-                                    </div>
-                                }
+                            <ExtractorsPanel
                                 key='数据提取器'
-                                extra={
-                                    <>
-                                        <YakitButton
-                                            type='text'
-                                            colors='danger'
-                                            onClick={(e) => {
-                                                e.stopPropagation()
-                                                const restValue = {
-                                                    extractors: []
-                                                }
-                                                onReset(restValue)
-                                            }}
-                                            size='small'
-                                        >
-                                            重置
-                                        </YakitButton>
-                                        <Divider type='vertical' style={{margin: 0}} />
-                                        <YakitButton
-                                            type='text'
-                                            size='small'
-                                            onClick={(e) => {
-                                                e.stopPropagation()
-                                                if (activeKey?.findIndex((ele) => ele === "数据提取器") === -1) {
-                                                    onSwitchCollapse([...activeKey, "数据提取器"])
-                                                }
-                                                onAddMatchingAndExtractionCard("extractors")
-                                            }}
-                                            className={styles["btn-padding-right-0"]}
-                                        >
-                                            添加/调试
-                                            <HollowLightningBoltIcon />
-                                        </YakitButton>
-                                    </>
-                                }
-                            >
-                                <ExtractorsList
-                                    extractorValue={{extractorList}}
-                                    onAdd={() => onAddMatchingAndExtractionCard("extractors")}
-                                    onRemove={onRemoveExtractors}
-                                    onEdit={onEditExtractors}
-                                />
-                            </YakitPanel>
+                                onAddMatchingAndExtractionCard={onAddMatchingAndExtractionCard}
+                                onEdit={onEdit}
+                                onSetValue={onSetValue}
+                            />
                             <YakitPanel
                                 header='设置变量'
                                 key='设置变量'
@@ -1430,7 +1371,7 @@ interface ExtractorsListProps {
     onEdit: (index: number) => void
 }
 /**数据提取器 */
-const ExtractorsList: React.FC<ExtractorsListProps> = React.memo((props) => {
+export const ExtractorsList: React.FC<ExtractorsListProps> = React.memo((props) => {
     const {extractorValue, onAdd, onRemove, onEdit} = props
     const {extractorList} = extractorValue
     return (

--- a/app/renderer/src/main/src/pages/fuzzer/MatcherAndExtractionCard/MatcherAndExtractionCard.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/MatcherAndExtractionCard/MatcherAndExtractionCard.tsx
@@ -568,7 +568,7 @@ export const MatcherAndExtraction: React.FC<MatcherAndExtractionProps> = React.m
 
 export const MatcherCollapse: React.FC<MatcherCollapseProps> = React.memo((props) => {
     const {type, matcher, setMatcher, notEditable, defActiveKey, httpResponse, isSmallMode} = props
-    const [activeKey, setActiveKey] = useState<string>(defActiveKey)
+    const [activeKey, setActiveKey] = useState<string>(defActiveKey || "ID:0")
     useUpdateEffect(() => {
         setActiveKey(defActiveKey)
     }, [defActiveKey])
@@ -836,7 +836,7 @@ const MatcherAndExtractionValueList: React.FC<MatcherAndExtractionValueListProps
 export const ExtractorCollapse: React.FC<ExtractorCollapseProps> = React.memo((props) => {
     const {type, extractor, setExtractor, defActiveKey, notEditable, httpResponse, isSmallMode} = props
 
-    const [activeKey, setActiveKey] = useState<string>(defActiveKey)
+    const [activeKey, setActiveKey] = useState<string>(defActiveKey || "ID:0")
     const [editNameVisible, setEditNameVisible] = useState<boolean>(false)
     const [currentIndex, setCurrentIndex] = useState<number>()
 

--- a/app/renderer/src/main/src/pages/fuzzer/MatcherAndExtractionCard/MatcherAndExtractionCard.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/MatcherAndExtractionCard/MatcherAndExtractionCard.tsx
@@ -36,7 +36,7 @@ import {YakitRadioButtons} from "@/components/yakitUI/YakitRadioButtons/YakitRad
 import {YakitButton} from "@/components/yakitUI/YakitButton/YakitButton"
 import {Descriptions} from "antd"
 import classNames from "classnames"
-import {useCreation, useMemoizedFn, useSize} from "ahooks"
+import {useCreation, useMemoizedFn, useSize, useUpdateEffect} from "ahooks"
 import {yakitNotify} from "@/utils/notification"
 import {YakitSwitch} from "@/components/yakitUI/YakitSwitch/YakitSwitch"
 import {YakitModalConfirm, showYakitModal} from "@/components/yakitUI/YakitModal/YakitModalConfirm"
@@ -568,11 +568,11 @@ export const MatcherAndExtraction: React.FC<MatcherAndExtractionProps> = React.m
 
 export const MatcherCollapse: React.FC<MatcherCollapseProps> = React.memo((props) => {
     const {type, matcher, setMatcher, notEditable, defActiveKey, httpResponse, isSmallMode} = props
-    const [activeKey, setActiveKey] = useState<string>("ID:0")
-    useEffect(() => {
+    const [activeKey, setActiveKey] = useState<string>(defActiveKey)
+    useUpdateEffect(() => {
         setActiveKey(defActiveKey)
     }, [defActiveKey])
-    useEffect(() => {
+    useUpdateEffect(() => {
         const length = matcher.matchersList.length
         setActiveKey(`ID:${length - 1}`)
     }, [matcher.matchersList.length])
@@ -836,14 +836,14 @@ const MatcherAndExtractionValueList: React.FC<MatcherAndExtractionValueListProps
 export const ExtractorCollapse: React.FC<ExtractorCollapseProps> = React.memo((props) => {
     const {type, extractor, setExtractor, defActiveKey, notEditable, httpResponse, isSmallMode} = props
 
-    const [activeKey, setActiveKey] = useState<string>("ID:0")
+    const [activeKey, setActiveKey] = useState<string>(defActiveKey)
     const [editNameVisible, setEditNameVisible] = useState<boolean>(false)
     const [currentIndex, setCurrentIndex] = useState<number>()
 
-    useEffect(() => {
+    useUpdateEffect(() => {
         setActiveKey(defActiveKey)
     }, [defActiveKey])
-    useEffect(() => {
+    useUpdateEffect(() => {
         const length = extractor.extractorList.length
         setActiveKey(`ID:${length - 1}`)
     }, [extractor.extractorList.length])

--- a/app/renderer/src/main/src/pages/fuzzer/MatcherAndExtractionCard/MatcherAndExtractionCard.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/MatcherAndExtractionCard/MatcherAndExtractionCard.tsx
@@ -1156,22 +1156,13 @@ export const ExtractionResultsContent: React.FC<ExtractionResultsContentProps> =
     const {list = []} = props
     return (
         <div className={classNames(styles["extract-results"], "yakit-descriptions")}>
-            {/* <Descriptions size={"small"} bordered={true} column={1}>
-                {list.map((i) => {
-                    return (
-                        <Descriptions.Item
-                            key={`${i.Key}-${i.Value}`}
-                            label={<CopyableField maxWidth={150} text={i.Key} />}
-                        >
-                            <CopyableField maxWidth={400} text={i.Value} />
-                        </Descriptions.Item>
-                    )
-                    // return <p key={i.Key}>{`${i.Key}: ${i.Value}`}</p>
-                })}
-            </Descriptions> */}
             <Descriptions bordered size='small' column={2}>
                 {list.map((item, index) => (
-                    <Descriptions.Item label={<YakitCopyText showText={item.Key} />} span={2}>
+                    <Descriptions.Item
+                        label={<YakitCopyText showText={item.Key} />}
+                        key={`${item.Key}-${item.Value}`}
+                        span={2}
+                    >
                         {item.Value ? <YakitCopyText showText={item.Value} /> : ""}
                     </Descriptions.Item>
                 ))}

--- a/app/renderer/src/main/src/pages/fuzzer/components/HTTPFuzzerPageTable/HTTPFuzzerPageTable.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/components/HTTPFuzzerPageTable/HTTPFuzzerPageTable.tsx
@@ -448,11 +448,15 @@ export const HTTPFuzzerPageTable: React.FC<HTTPFuzzerPageTableProps> = React.mem
                                                           if (onDebug) {
                                                               onDebug(Uint8ArrayToString(record.ResponseRaw))
                                                           } else {
-                                                              ipcRenderer.invoke("send-open-matcher-and-extraction", {
+                                                              const value = {
                                                                   httpResponseCode: Uint8ArrayToString(
                                                                       record.ResponseRaw
                                                                   )
-                                                              })
+                                                              }
+                                                              emiter.emit(
+                                                                  "openMatcherAndExtraction",
+                                                                  JSON.stringify(value)
+                                                              )
                                                           }
                                                       }}
                                                       style={{
@@ -905,7 +909,7 @@ export const HTTPFuzzerPageTable: React.FC<HTTPFuzzerPageTableProps> = React.mem
                             extra={[
                                 currentSelectItem?.IsTooLargeResponse && (
                                     <YakitDropdownMenu
-                                        key="allRes"
+                                        key='allRes'
                                         menu={{
                                             data: [
                                                 {key: "tooLargeResponseHeaderFile", label: "查看Header"},

--- a/app/renderer/src/main/src/pages/httpRequestBuilder/HTTPRequestBuilder.tsx
+++ b/app/renderer/src/main/src/pages/httpRequestBuilder/HTTPRequestBuilder.tsx
@@ -472,7 +472,7 @@ export const VariableList: React.FC<VariableListProps> = React.forwardRef(
                                         type='outline2'
                                         onClick={() => {
                                             add({Key: "", Value: "", Type: "raw"})
-                                            setVariableActiveKey([
+                                            onSetActiveKey([
                                                 ...(variableActiveKey || []),
                                                 `${variableActiveKey?.length}`
                                             ])

--- a/app/renderer/src/main/src/pages/httpRequestBuilder/HTTPRequestBuilder.tsx
+++ b/app/renderer/src/main/src/pages/httpRequestBuilder/HTTPRequestBuilder.tsx
@@ -52,8 +52,8 @@ export const getDefaultHTTPRequestBuilderParams = (): HTTPRequestBuilderParams =
         Path: ["/"],
         PostParams: [],
         RawHTTPRequest: new Uint8Array(),
-        IsHttpFlowId:false,
-        HTTPFlowId:[]
+        IsHttpFlowId: false,
+        HTTPFlowId: []
     }
 }
 
@@ -424,7 +424,7 @@ export const VariableList: React.FC<VariableListProps> = React.forwardRef(
                                     <YakitPanel
                                         key={`${key + ""}`}
                                         header={`变量 ${name}`}
-                                        className={styles['variable-list-panel']}
+                                        className={styles["variable-list-panel"]}
                                         extra={
                                             <div className={styles["extra-wrapper"]}>
                                                 <TrashIcon
@@ -447,7 +447,7 @@ export const VariableList: React.FC<VariableListProps> = React.forwardRef(
                                     <YakitButton
                                         type='outline2'
                                         onClick={() => {
-                                            add({Key: "", Value: ""})
+                                            add({Key: "", Value: "", Type: "raw"})
                                             setVariableActiveKey([
                                                 ...(variableActiveKey || []),
                                                 `${variableActiveKey?.length}`

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -101,7 +101,7 @@ import {onToManageGroup} from "@/pages/securityTool/yakPoC/YakPoC"
 import {defPluginBatchExecuteExtraFormValue} from "@/pages/plugins/pluginBatchExecutor/pluginBatchExecutor"
 import {apiFetchQueryYakScriptGroupLocal} from "@/pages/plugins/utils"
 import {PluginGroupType} from "@/pages/plugins/group/PluginGroups"
-import { ExpandAndRetractExcessiveState } from "@/pages/plugins/operator/expandAndRetract/ExpandAndRetract"
+import {ExpandAndRetractExcessiveState} from "@/pages/plugins/operator/expandAndRetract/ExpandAndRetract"
 
 const TabRenameModalContent = React.lazy(() => import("./TabRenameModalContent"))
 const PageItem = React.lazy(() => import("./renderSubPage/RenderSubPage"))
@@ -1372,10 +1372,10 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
                 if (item.Data.length === 0) {
                     const m = showYakitModal({
                         title: "导入插件",
-                        type:'white',
+                        type: "white",
                         content: <DownloadAllPlugin onClose={() => m.destroy()} />,
-                        bodyStyle:{padding:24},
-                        footer:null
+                        bodyStyle: {padding: 24},
+                        footer: null
                     })
                     return m
                 }
@@ -2215,6 +2215,8 @@ const SubTabList: React.FC<SubTabListProps> = React.memo((props) => {
     useUpdateEffect(() => {
         if (type !== "sequence") {
             emiter.emit("onRefWebFuzzer")
+            /**VariableList组件从数据中心刷新最新的展开项,从序列切换到其他tab时，inViewport不会发生变化，所以采取信号发送 */
+            emiter.emit("onRefVariableActiveKey")
         }
     }, [type])
     const onSetType = useMemoizedFn((res) => {

--- a/app/renderer/src/main/src/store/pageInfo.ts
+++ b/app/renderer/src/main/src/store/pageInfo.ts
@@ -85,7 +85,8 @@ export const defaultWebFuzzerPageInfo: WebFuzzerPageInfoProps = {
     pageId: "",
     advancedConfigValue: cloneDeep(defaultAdvancedConfigValue),
     advancedConfigShow: null,
-    request: defaultPostTemplate
+    request: defaultPostTemplate,
+    variableActiveKeys: undefined
 }
 
 export interface WebFuzzerPageInfoProps {
@@ -93,6 +94,8 @@ export interface WebFuzzerPageInfoProps {
     advancedConfigValue: AdvancedConfigValueProps
     request: string
     advancedConfigShow?: AdvancedConfigShowProps | null
+    //高级配置中变量的二级Panel 展开项
+    variableActiveKeys?: string[]
 }
 
 export const defaultPocPageInfo: PocPageInfoProps = {

--- a/app/renderer/src/main/src/utils/eventBus/events/webFuzzer.ts
+++ b/app/renderer/src/main/src/utils/eventBus/events/webFuzzer.ts
@@ -20,4 +20,6 @@ export type WebFuzzerEventProps = {
     sequenceSendSwitchTypeToFuzzer: string
     /**发送到MainOperatorContent层中切换【序列】/(【规则】/配置) */
     sendSwitchSequenceToMainOperatorContent: string
+    /**VariableList组件从数据中心刷新最新的展开项 */
+    onRefVariableActiveKey?: string
 }

--- a/app/renderer/src/main/src/utils/eventBus/events/webFuzzer.ts
+++ b/app/renderer/src/main/src/utils/eventBus/events/webFuzzer.ts
@@ -22,4 +22,6 @@ export type WebFuzzerEventProps = {
     sendSwitchSequenceToMainOperatorContent: string
     /**VariableList组件从数据中心刷新最新的展开项 */
     onRefVariableActiveKey?: string
+    /**打开匹配器和提取器Modal */
+    openMatcherAndExtraction: string
 }

--- a/app/renderer/src/main/src/utils/showModal.tsx
+++ b/app/renderer/src/main/src/utils/showModal.tsx
@@ -108,6 +108,7 @@ export interface BaseDrawerProp extends DrawerProps, React.ComponentProps<any> {
 }
 
 export const BaseDrawer: React.FC<BaseDrawerProp> = (props) => {
+    const {afterVisible,afterInvisible,afterClose,...restProps}=props;
     const [visible, setVisible] = useState(false)
 
     useEffect(() => {
@@ -117,7 +118,7 @@ export const BaseDrawer: React.FC<BaseDrawerProp> = (props) => {
     useEffect(() => {
         if (visible) {
             emiter.emit("setYakitHeaderDraggable", false)
-            if (props.afterVisible) props.afterVisible(setVisible)
+            if (afterVisible) afterVisible(setVisible)
         } else {
             emiter.emit("setYakitHeaderDraggable", true)
         }
@@ -125,9 +126,9 @@ export const BaseDrawer: React.FC<BaseDrawerProp> = (props) => {
 
     const close = () => {
         setVisible(false)
-        if (props.afterInvisible) props.afterInvisible(setVisible)
+        if (afterInvisible) afterInvisible(setVisible)
         setTimeout(() => {
-            if (props.afterClose) props.afterClose(setVisible)
+            if (afterClose) afterClose(setVisible)
         }, 1000)
     }
 
@@ -139,7 +140,7 @@ export const BaseDrawer: React.FC<BaseDrawerProp> = (props) => {
             closable={true}
             width={"50%"}
             maskClosable={true}
-            {...props}
+            {...restProps}
         ></Drawer>
     )
 }

--- a/app/renderer/src/main/src/yakitGV.ts
+++ b/app/renderer/src/main/src/yakitGV.ts
@@ -87,8 +87,6 @@ export enum RemoteGV {
     MITMHotPatchCodeSave = "mitm_hot_patch_code_save",
     /**@name fuzzer序列页面中,页面配置内容的显/隐 */
     FuzzerSequenceSettingShow = "fuzzer_sequence_setting_show",
-    /**@name WebFuzzer页面中变量Panel下多个变量的展开收起activeKey */
-    WebFuzzerVariableActiveKey = "web_fuzzer_variable_active_key"
 }
 
 /** 项目逻辑全局变量 */

--- a/app/renderer/src/main/src/yakitGV.ts
+++ b/app/renderer/src/main/src/yakitGV.ts
@@ -82,9 +82,11 @@ export enum RemoteGV {
     /**@name MITM 用户数据是否保存 */
     MITMUserDataSave = "mitm_user_data_save",
     /**@name WebFuzzer高级配置内容的显/隐 */
-    WebFuzzerAdvancedConfigShow='web_fuzzer_advanced_config_show',
+    WebFuzzerAdvancedConfigShow = "web_fuzzer_advanced_config_show",
     /**@name MITM热加载代码保存 */
-    MITMHotPatchCodeSave="mitm_hot_patch_code_save"
+    MITMHotPatchCodeSave = "mitm_hot_patch_code_save",
+    /**@name fuzzer序列页面中,页面配置内容的显/隐 */
+    FuzzerSequenceSettingShow = "fuzzer_sequence_setting_show"
 }
 
 /** 项目逻辑全局变量 */

--- a/app/renderer/src/main/src/yakitGV.ts
+++ b/app/renderer/src/main/src/yakitGV.ts
@@ -86,7 +86,9 @@ export enum RemoteGV {
     /**@name MITM热加载代码保存 */
     MITMHotPatchCodeSave = "mitm_hot_patch_code_save",
     /**@name fuzzer序列页面中,页面配置内容的显/隐 */
-    FuzzerSequenceSettingShow = "fuzzer_sequence_setting_show"
+    FuzzerSequenceSettingShow = "fuzzer_sequence_setting_show",
+    /**@name WebFuzzer页面中变量Panel下多个变量的展开收起activeKey */
+    WebFuzzerVariableActiveKey = "web_fuzzer_variable_active_key"
 }
 
 /** 项目逻辑全局变量 */


### PR DESCRIPTION
### feat
1. feat:序列增加插件选中页面的匹配器、提取器和变量数据，且实现修改和数据同步
2. feat:fuzzer变量的panels增加展开记录临时缓存与序列中选中页面的变量同步
3. fix:匹配器重置为仅匹配
4. feat:切换序列选中项和点击开始执行按钮，需验证Responses中打开的匹配器和提取器中的值是否应用(当值被修改过)

### code
1. perf:抽离表单中的匹配器、提取器和变量数据,新增MatchersPanel、ExtractorsPanel、VariablePanel
2. perf:打开匹配器和提取器Modal由ipc换成emiter