### PR TITLE
Fix/plugin hub list qs

### DIFF
--- a/app/renderer/src/main/src/components/yakChat/chatCS.tsx
+++ b/app/renderer/src/main/src/components/yakChat/chatCS.tsx
@@ -99,7 +99,7 @@ import {
 import {HybridScanControlAfterRequest} from "@/models/HybridScan"
 import useHoldBatchGRPCStream from "@/hook/useHoldBatchGRPCStream/useHoldBatchGRPCStream"
 import {PluginBatchExecuteExtraFormValue} from "@/pages/plugins/pluginBatchExecutor/pluginBatchExecutor"
-import {cloneDeep} from "bizcharts/lib/utils"
+import cloneDeep from "lodash/cloneDeep"
 import {PluginSearchParams} from "@/pages/plugins/baseTemplateType"
 import {HoldGRPCStreamInfo, StreamResult} from "@/hook/useHoldGRPCStream/useHoldGRPCStreamType"
 import {YakitRoute} from "@/enums/yakitRoute"

--- a/app/renderer/src/main/src/defaultConstants/PluginHubPage.ts
+++ b/app/renderer/src/main/src/defaultConstants/PluginHubPage.ts
@@ -1,5 +1,0 @@
-import {PluginHubPageInfoProps} from "@/store/pageInfo"
-
-export const defaultPluginHubPageInfo: PluginHubPageInfoProps = {
-    tabActive: "online"
-}

--- a/app/renderer/src/main/src/enums/plugin.ts
+++ b/app/renderer/src/main/src/enums/plugin.ts
@@ -11,6 +11,6 @@ export enum RemotePluginGV {
 
     /** 商店|我的插件列表-批量下载提示本地存在同名则覆盖的二次确认弹框 */
     BatchDownloadPluginSameNameOverlay = "batch_download_plugin_same_name_overlay",
-    /** 商店|我的插件列表-单个下载提示本地存在同名则覆盖的二次确认弹框 */
+    /** 商店|我的插件列表|插件详情-单个下载提示本地存在同名则覆盖的二次确认弹框 */
     SingleDownloadPluginSameNameOverlay = "single_download_plugin_same_name_overlay"
 }

--- a/app/renderer/src/main/src/pages/home/Home.tsx
+++ b/app/renderer/src/main/src/pages/home/Home.tsx
@@ -85,6 +85,7 @@ import {YakitResizeBox} from "@/components/yakitUI/YakitResizeBox/YakitResizeBox
 import ReactResizeDetector from "react-resize-detector"
 import {SolidBorderDocumentTextIcon} from "@/assets/icon/colors"
 import {CONST_DEFAULT_ENABLE_INITIAL_PLUGIN} from "../mitm/MITMPage"
+import {PluginHubPageInfoProps} from "@/store/pageInfo"
 const {ipcRenderer} = window.require("electron")
 
 interface ToolInfo {
@@ -1361,7 +1362,7 @@ const Home: React.FC<HomeProp> = (props) => {
                                             onClick={() =>
                                                 onMenuParams({
                                                     route: YakitRoute.Plugin_Hub,
-                                                    params: {tabActive: "local"}
+                                                    params: {tabActive: "local"} as PluginHubPageInfoProps
                                                 })
                                             }
                                         >

--- a/app/renderer/src/main/src/pages/invoker/schema.ts
+++ b/app/renderer/src/main/src/pages/invoker/schema.ts
@@ -109,6 +109,7 @@ export interface YakScript {
     /**前端判断使用，该插件是否为本地插件，OnlineBaseUrl与当前最新的私有域不一样则为本地插件 */
     isLocalPlugin?: boolean
     RiskInfo?: YakRiskInfoProps[]
+    IsUpdate?: boolean
 }
 
 export interface Collaborator {

--- a/app/renderer/src/main/src/pages/layout/HeardMenu/HeardMenu.tsx
+++ b/app/renderer/src/main/src/pages/layout/HeardMenu/HeardMenu.tsx
@@ -59,6 +59,7 @@ import {
     routeInfoToKey,
     routeToMenu
 } from "../publicMenu/utils"
+import {grpcFetchLocalPluginDetail} from "@/pages/pluginHub/utils/grpc"
 
 import classNames from "classnames"
 import style from "./HeardMenu.module.scss"
@@ -371,8 +372,7 @@ const HeardMenu: React.FC<HeardMenuProps> = React.memo((props) => {
             return
         }
 
-        ipcRenderer
-            .invoke("GetYakScriptByName", {Name: info.pluginName})
+        grpcFetchLocalPluginDetail({Name: info.pluginName}, true)
             .then((i: YakScript) => {
                 const lastId = +i.Id || 0
                 // 插件不存在于本地数据库中

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -653,7 +653,7 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
     const pluginHub = useMemoizedFn((data: PluginHubPageInfoProps) => {
         const isExist = pageCache.filter((item) => item.route === YakitRoute.Plugin_Hub).length
         if (isExist) {
-            emiter.emit("refreshPluginHubTabActive", data.tabActive)
+            emiter.emit("openPluginHubListAndDetail", JSON.stringify(data || ""))
         }
         const pageNodeInfo: PageProps = {
             ...cloneDeep(defPage),
@@ -674,16 +674,7 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
             singleNode: true
         }
         setPagesData(YakitRoute.Plugin_Hub, pageNodeInfo)
-        openMenuPage(
-            {route: YakitRoute.Plugin_Hub},
-            {
-                pageParams: {
-                    pluginHubPageInfoProps: {
-                        ...data
-                    }
-                }
-            }
-        )
+        openMenuPage({route: YakitRoute.Plugin_Hub})
     })
     /**
      * @name 本地插件
@@ -716,7 +707,7 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
             }
             setPagesData(YakitRoute.Plugin_Local, pages)
         }
-        emiter.emit("onRefLocalPluginList", "")
+        emiter.emit("onRefreshLocalPluginList")
         openMenuPage({route: YakitRoute.Plugin_Local})
     })
     /**

--- a/app/renderer/src/main/src/pages/layout/publicMenu/PublicMenu.tsx
+++ b/app/renderer/src/main/src/pages/layout/publicMenu/PublicMenu.tsx
@@ -36,12 +36,13 @@ import {CodeGV, RemoteGV} from "@/yakitGV"
 import {YakScript} from "@/pages/invoker/schema"
 import {YakitModalConfirm} from "@/components/yakitUI/YakitModal/YakitModalConfirm"
 import {getRemoteValue, setRemoteValue} from "@/utils/kv"
+import {grpcFetchLocalPluginDetail} from "@/pages/pluginHub/utils/grpc"
 
 import classNames from "classnames"
 import styles from "./PublicMenu.module.scss"
 import emiter from "@/utils/eventBus/eventBus"
 import {YakitRoute} from "@/enums/yakitRoute"
-import { usePluginToId } from "@/store/publicMenu"
+import {usePluginToId} from "@/store/publicMenu"
 
 const {ipcRenderer} = window.require("electron")
 
@@ -299,8 +300,7 @@ const PublicMenu: React.FC<PublicMenuProps> = React.memo((props) => {
             return
         }
 
-        ipcRenderer
-            .invoke("GetYakScriptByName", {Name: info.pluginName})
+        grpcFetchLocalPluginDetail({Name: info.pluginName}, true)
             .then((i: YakScript) => {
                 const lastId = +i.Id || 0
                 // 插件不存在于本地数据库中

--- a/app/renderer/src/main/src/pages/mitm/MITMPage.tsx
+++ b/app/renderer/src/main/src/pages/mitm/MITMPage.tsx
@@ -883,7 +883,7 @@ export const ImportLocalPlugin: React.FC<ImportLocalPluginProps> = React.memo((p
         if (sendPluginLocal) {
             // emiter.emit("menuOpenPage", JSON.stringify({route: YakitRoute.Plugin_Local}))
         }
-        emiter.emit("onImportRefLocalPluginList", "")
+        emiter.emit("onImportRefreshLocalPluginList")
     }
 
     const getRenderByLoadMode = useMemoizedFn((type: string) => {
@@ -1039,7 +1039,7 @@ export const ImportLocalPlugin: React.FC<ImportLocalPluginProps> = React.memo((p
             }).then(() => {
                 setVisible(false)
                 // 刷新本地列表
-                emiter.emit("onImportRefLocalPluginList", "")
+                emiter.emit("onImportRefreshLocalPluginList")
                 success("插件导入成功")
             })
         }

--- a/app/renderer/src/main/src/pages/mitm/MITMServerHijacking/MITMPluginLocalList.tsx
+++ b/app/renderer/src/main/src/pages/mitm/MITMServerHijacking/MITMPluginLocalList.tsx
@@ -327,9 +327,9 @@ export const YakitGetOnlinePlugin: React.FC<YakitGetOnlinePluginProps> = React.m
             onRefLocalPluginList()
         })
     }
-    /**下载插件后需要更新 本地插件列表 */
+    /** 下载后需要刷新本地插件列表 */
     const onRefLocalPluginList = useMemoizedFn(() => {
-        emiter.emit("onRefLocalPluginList", "")
+        emiter.emit("onRefreshLocalPluginList", true)
     })
     return (
         <YakitHint

--- a/app/renderer/src/main/src/pages/mitm/MITMYakScriptLoader.tsx
+++ b/app/renderer/src/main/src/pages/mitm/MITMYakScriptLoader.tsx
@@ -11,6 +11,7 @@ import {PluginLocalInfoIcon} from "../customizeMenu/CustomizeMenu"
 import classNames from "classnames"
 import {LightningBoltIcon} from "@/assets/newIcon"
 import {YakitPopconfirm} from "@/components/yakitUI/YakitPopconfirm/YakitPopconfirm"
+import {grpcFetchLocalPluginDetail} from "../pluginHub/utils/grpc"
 
 const {ipcRenderer} = window.require("electron")
 
@@ -63,18 +64,20 @@ export const MITMYakScriptLoader = React.memo((p: MITMYakScriptLoaderProps) => {
     })
     const getScriptInfo = useMemoizedFn((s: YakScript, isSendToPatch?: boolean) => {
         if (!s.ScriptName) return
-        ipcRenderer.invoke("GetYakScriptByName", {Name: s.ScriptName}).then((res: YakScript) => {
-            setI({
-                ...res,
-                HeadImg: "",
-                OnlineOfficial: false,
-                OnlineIsPrivate: false,
-                UUID: ""
+        grpcFetchLocalPluginDetail({Name: s.ScriptName}, true)
+            .then((res: YakScript) => {
+                setI({
+                    ...res,
+                    HeadImg: "",
+                    OnlineOfficial: false,
+                    OnlineIsPrivate: false,
+                    UUID: ""
+                })
+                if (isSendToPatch) {
+                    p.onSendToPatch && p.onSendToPatch(res)
+                }
             })
-            if (isSendToPatch) {
-                p.onSendToPatch && p.onSendToPatch(res)
-            }
-        })
+            .catch(() => {})
     })
     return (
         <div className={style["mitm-plugin-local-item"]}>

--- a/app/renderer/src/main/src/pages/pluginEditor/editorInfo/EditorInfo.tsx
+++ b/app/renderer/src/main/src/pages/pluginEditor/editorInfo/EditorInfo.tsx
@@ -202,7 +202,6 @@ export const EditorInfoForm: React.FC<EditorInfoFormProps> = memo(
                 setEnablePluginSelector(false)
                 updateFormData({Tags: cloneDeep(newTags), PluginSelectorTypes: []})
             }
-            setType(type)
         }, [type])
         /** ---------- 插件类型变化时的数据更新 End ---------- */
 
@@ -277,7 +276,7 @@ export const EditorInfoForm: React.FC<EditorInfoFormProps> = memo(
                         name='Type'
                         rules={[{required: true, message: "脚本类型必填"}]}
                     >
-                        <PluginTypeSelect size='large' disabled={!!isEdit} />
+                        <PluginTypeSelect size='large' disabled={!!isEdit} onChange={(value) => setType(value)} />
                     </Form.Item>
 
                     <Form.Item

--- a/app/renderer/src/main/src/pages/pluginHub/hubExtraOperate/HubExtraOperate.tsx
+++ b/app/renderer/src/main/src/pages/pluginHub/hubExtraOperate/HubExtraOperate.tsx
@@ -307,7 +307,6 @@ export const HubExtraOperate: React.FC<HubExtraOperateProps> = memo(
                             yakitNotify("info", "插件下载中，请稍后")
                             return
                         }
-                        yakitNotify("info", "开始下载插件")
                         onDownload()
                     } else {
                         handleAutoDownload()
@@ -329,7 +328,6 @@ export const HubExtraOperate: React.FC<HubExtraOperateProps> = memo(
             // 下载
             if (type === "download") {
                 if (isOnline) {
-                    yakitNotify("info", "开始下载插件")
                     handleDownload()
                 } else {
                     yakitNotify("error", "无法下载/更新，该插件是纯本地插件")

--- a/app/renderer/src/main/src/pages/pluginHub/pluginHubDetail/PluginHubDetail.tsx
+++ b/app/renderer/src/main/src/pages/pluginHub/pluginHubDetail/PluginHubDetail.tsx
@@ -1,13 +1,7 @@
 import React, {ForwardedRef, forwardRef, memo, useEffect, useImperativeHandle, useMemo, useRef, useState} from "react"
-import {useDebounceFn, useMemoizedFn} from "ahooks"
+import {useDebounceFn, useMemoizedFn, useUpdateEffect} from "ahooks"
 import PluginTabs from "@/components/businessUI/PluginTabs/PluginTabs"
-import {
-    PluginStarsRequest,
-    apiFetchLocalPluginInfo,
-    apiFetchOnlinePluginInfo,
-    apiGetYakScriptById,
-    apiPluginStars
-} from "@/pages/plugins/utils"
+import {PluginStarsRequest, apiFetchOnlinePluginInfo, apiGetYakScriptById, apiPluginStars} from "@/pages/plugins/utils"
 import {API} from "@/services/swagger/resposeType"
 import {YakScript} from "@/pages/invoker/schema"
 import {YakitSpin} from "@/components/yakitUI/YakitSpin/YakitSpin"
@@ -37,6 +31,8 @@ import {PluginComment} from "@/pages/plugins/baseComment"
 import {LocalPluginExecute} from "@/pages/plugins/local/LocalPluginExecute"
 import {ModifyPluginCallback} from "@/pages/pluginEditor/pluginEditor/PluginEditor"
 import {ModifyYakitPlugin} from "@/pages/pluginEditor/modifyYakitPlugin/ModifyYakitPlugin"
+import {RemotePluginGV} from "@/enums/plugin"
+import {NoPromptHint} from "../utilsUI/UtilsTemplate"
 
 import classNames from "classnames"
 import styles from "./PluginHubDetail.module.scss"
@@ -76,6 +72,24 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
             )
         })
 
+        useUpdateEffect(() => {
+            if (isLogin) {
+                setOnlinePlugin((val) => {
+                    if (!val) return undefined
+                    else {
+                        return {...val, isAuthor: userinfo.user_id === val.user_id}
+                    }
+                })
+            } else {
+                setOnlinePlugin((val) => {
+                    if (!val) return undefined
+                    else {
+                        return {...val, isAuthor: false}
+                    }
+                })
+            }
+        }, [isLogin])
+
         // 私有域
         const privateDomain = useRef<string>("")
         const fetchPrivateDomain = useMemoizedFn(() => {
@@ -87,11 +101,38 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
                             privateDomain.current = value.BaseUrl
                         } catch (error) {}
                     }
+                    if (["online", "comment", "log"].includes(activeKey)) setLoading(true)
+                    apiFetchOnlinePluginInfo({uuid: currentRequest.current?.uuid}, true)
+                        .then((res) => {
+                            setOnlinePlugin({
+                                ...res,
+                                starsCountString: thousandthConversion(res.stars),
+                                commentCountString: thousandthConversion(res.comment_num),
+                                downloadedTotalString: thousandthConversion(res.downloaded_total)
+                            })
+                        })
+                        .catch(() => {
+                            onError(true, false, "请从左侧列表重新选择插件")
+                        })
+                        .finally(() => {
+                            setTimeout(() => {
+                                setLoading(false)
+                            }, 300)
+                        })
                 })
                 .catch(() => {})
         })
         useEffect(() => {
-            fetchPrivateDomain()
+            getRemoteValue(RemoteGV.HttpSetting)
+                .then((res) => {
+                    if (res) {
+                        try {
+                            const value = JSON.parse(res)
+                            privateDomain.current = value.BaseUrl
+                        } catch (error) {}
+                    }
+                })
+                .catch(() => {})
             emiter.on("onSwitchPrivateDomain", fetchPrivateDomain)
             emiter.on("editorLocalSaveToDetail", handleUpdateLocalPlugin)
             return () => {
@@ -201,7 +242,12 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
         const fetchLocalPlugin: () => Promise<YakScript> = useMemoizedFn(() => {
             return new Promise((resolve, reject) => {
                 if (!currentRequest.current || !currentRequest.current.name) return reject("false")
-                apiFetchLocalPluginInfo(currentRequest.current.name, true).then(resolve).catch(reject)
+                grpcFetchLocalPluginDetail(
+                    {Name: currentRequest.current.name, UUID: currentRequest.current?.uuid || undefined},
+                    true
+                )
+                    .then(resolve)
+                    .catch(reject)
             })
         })
 
@@ -225,10 +271,14 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
                 .then((res) => {
                     if (name !== currentRequest.current?.name) return
                     const [online, local] = res
-                    let activeTab = ""
+                    let onlineTab: boolean = false
+                    let localTab: boolean = false
+                    // 用于判断线上和线下插件是否为一个作者，可能存在同名但线下没有 uuid 的情况
+                    let onlineInfoUUID: string = ""
 
                     if (online.status === "fulfilled") {
-                        activeTab = "online"
+                        onlineTab = true
+                        onlineInfoUUID = online.value?.uuid
                         setOnlinePlugin({
                             ...online.value,
                             starsCountString: thousandthConversion(online.value.stars),
@@ -238,22 +288,32 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
                     }
                     if (online.status === "rejected") {
                         setOnlinePlugin(undefined)
-                        // const {reason} = online as PromiseRejectedResult
-                        // if (reason !== "false") yakitNotify("error", `获取线上插件错误: ${reason}`)
                     }
 
                     if (local.status === "fulfilled") {
-                        activeTab = "exectue"
-                        setLocalPlugin({...local.value})
+                        if ((!local.value.UUID && onlineInfoUUID) || onlineInfoUUID !== local.value?.UUID) {
+                            setLocalPlugin(undefined)
+                        } else {
+                            localTab = true
+                            setLocalPlugin({...local.value})
+                        }
                     }
                     if (local.status === "rejected") {
                         setLocalPlugin(undefined)
-                        // const {reason} = local as PromiseRejectedResult
-                        // if (reason !== "false") yakitNotify("error", `获取本地插件错误: ${reason}`)
                     }
 
-                    if (activeTab) {
-                        if (!banUpdateActiveTab) setActiveKey(activeTab)
+                    if (onlineTab || localTab) {
+                        if (!banUpdateActiveTab) {
+                            let tab = localTab ? "exectue" : onlineTab ? "online" : ""
+                            setActiveKey(tab)
+                        } else {
+                            if (["exectue", "local"].includes(activeKey) && onlineTab && !localTab) {
+                                setActiveKey("online")
+                            }
+                            if (["online", "comment", "log"].includes(activeKey) && !onlineTab && localTab) {
+                                setActiveKey("exectue")
+                            }
+                        }
                         onError(false)
                     } else {
                         onError(true, true, "未获取到插件信息，请刷新重试!")
@@ -272,22 +332,41 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
         /** ---------- 获取插件信息逻辑 End ---------- */
 
         /** ---------- 插件操作逻辑 Start ---------- */
+        useEffect(() => {
+            // 单个下载的同名覆盖二次确认框缓存
+            getRemoteValue(RemotePluginGV.SingleDownloadPluginSameNameOverlay)
+                .then((res) => {
+                    singleSameNameCache.current = res === "true"
+                })
+                .catch((err) => {})
+        }, [])
+        const singleSameNameCache = useRef<boolean>(false)
+        const [singleSameNameHint, setSingleSameNameHint] = useState<boolean>(false)
+        const handleSingleSameNameHint = useMemoizedFn((isOK: boolean, cache: boolean) => {
+            if (isOK) {
+                singleSameNameCache.current = cache
+                const data = onlinePlugin?.uuid
+                if (data) onDownload(data)
+                else {
+                    if (operateRef && operateRef.current) operateRef.current.downloadedNext(false)
+                    setDownloadLoading(false)
+                }
+            } else {
+                if (operateRef && operateRef.current) operateRef.current.downloadedNext(false)
+                setDownloadLoading(false)
+            }
+            setSingleSameNameHint(false)
+        })
+
         const operateRef = useRef<HubExtraOperateRef>(null)
         const [downloadLoading, setDownloadLoading] = useState<boolean>(false)
         // 下载插件
-        const onDownload = useMemoizedFn(() => {
-            if (!onlinePlugin) {
-                if (operateRef && operateRef.current) operateRef.current.downloadedNext(false)
-                return
-            }
-            if (downloadLoading) return
-            setDownloadLoading(true)
-
+        const onDownload = useMemoizedFn((uuid: string) => {
+            yakitNotify("info", "开始下载插件")
             let flag: boolean = false
-            const currentUUID = onlinePlugin.uuid
-            grpcDownloadOnlinePlugin({uuid: onlinePlugin.uuid})
+            grpcDownloadOnlinePlugin({uuid: uuid})
                 .then((res) => {
-                    if (onlinePlugin.uuid !== currentUUID) return
+                    if (onlinePlugin?.uuid !== uuid) return
                     setLocalPlugin({...res})
                     flag = true
                     setOnlinePlugin((plugin) => {
@@ -301,16 +380,40 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
                     yakitNotify("success", "下载插件成功")
                 })
                 .catch((err) => {
-                    if (onlinePlugin.uuid !== currentUUID) return
+                    if (onlinePlugin?.uuid !== uuid) return
                     yakitNotify("error", `下载插件失败: ${err}`)
                     flag = false
                 })
                 .finally(() => {
-                    if (onlinePlugin.uuid !== currentUUID) return
+                    if (onlinePlugin?.uuid !== uuid) return
                     setTimeout(() => {
                         if (operateRef && operateRef.current) operateRef.current.downloadedNext(flag)
                         setDownloadLoading(false)
                     }, 200)
+                })
+        })
+        const handleDownload = useMemoizedFn(() => {
+            if (!onlinePlugin || !onlinePlugin?.uuid) {
+                if (operateRef && operateRef.current) operateRef.current.downloadedNext(false)
+                return
+            }
+            if (downloadLoading) return
+            setDownloadLoading(true)
+
+            grpcFetchLocalPluginDetail({Name: onlinePlugin.script_name, UUID: onlinePlugin.uuid}, true)
+                .then((res) => {
+                    const {ScriptName, UUID} = res
+                    if (ScriptName === onlinePlugin.script_name && UUID !== onlinePlugin.uuid) {
+                        if (!singleSameNameCache.current) {
+                            if (singleSameNameHint) return
+                            setSingleSameNameHint(true)
+                            return
+                        }
+                    }
+                    onDownload(onlinePlugin.uuid)
+                })
+                .catch((err) => {
+                    onDownload(onlinePlugin.uuid)
                 })
         })
 
@@ -343,8 +446,7 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
             if (type === "upload") {
                 if (!localPlugin) return
                 // 获取最新的本地信息
-                ipcRenderer
-                    .invoke("GetYakScriptByName", {Name: localPlugin.ScriptName})
+                grpcFetchLocalPluginDetail({Name: localPlugin.ScriptName}, true)
                     .then((i: YakScript) => {
                         setLocalPlugin({...i, isLocalPlugin: privateDomain.current !== i.OnlineBaseUrl})
                         // 刷新本地列表
@@ -522,7 +624,7 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
                     getContainer={wrapperId}
                     online={onlinePlugin}
                     local={localPlugin}
-                    onDownload={onDownload}
+                    onDownload={handleDownload}
                     onEdit={handleOpenEditHint}
                     onCallback={operateCallback}
                 />
@@ -549,7 +651,7 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
                         loading={downloadLoading}
                         icon={<OutlineClouddownloadIcon />}
                         title={onlinePlugin.downloadedTotalString || ""}
-                        onClick={onDownload}
+                        onClick={handleDownload}
                     />
                 </div>
             )
@@ -750,6 +852,15 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
                         onCallback={handleEditHintCallback}
                     />
                 )}
+
+                {/* 单个下载同名覆盖提示 */}
+                <NoPromptHint
+                    visible={singleSameNameHint}
+                    title='同名覆盖提示'
+                    content='本地有插件同名，下载将会覆盖，是否下载'
+                    cacheKey={RemotePluginGV.SingleDownloadPluginSameNameOverlay}
+                    onCallback={handleSingleSameNameHint}
+                />
             </div>
         )
     })

--- a/app/renderer/src/main/src/pages/pluginHub/pluginHubDetail/PluginHubDetail.tsx
+++ b/app/renderer/src/main/src/pages/pluginHub/pluginHubDetail/PluginHubDetail.tsx
@@ -142,28 +142,11 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
                 })
                 .catch(() => {})
             emiter.on("onSwitchPrivateDomain", fetchPrivateDomain)
-            emiter.on("editorLocalSaveToDetail", handleUpdateLocalPlugin)
             return () => {
                 emiter.off("onSwitchPrivateDomain", fetchPrivateDomain)
-                emiter.off("editorLocalSaveToDetail", handleUpdateLocalPlugin)
             }
         }, [])
 
-        // 通过本地 ID 更新本地插件信息
-        const handleUpdateLocalPlugin = useMemoizedFn((id: string) => {
-            if (!localPlugin) return
-            const ID = Number(id) || 0
-            if (!ID) return
-            if (Number(localPlugin.Id) === ID) {
-                grpcFetchLocalPluginDetailByID(ID, true)
-                    .then((res) => {
-                        setLocalPlugin({...res})
-                    })
-                    .catch((err) => {
-                        yakitNotify("error", "更新本地插件信息失败: " + err)
-                    })
-            }
-        })
         /** ---------- 基础全局功能 End ---------- */
 
         useImperativeHandle(
@@ -458,7 +441,7 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
                     .then((i: YakScript) => {
                         setLocalPlugin({...i, isLocalPlugin: privateDomain.current !== i.OnlineBaseUrl})
                         // 刷新本地列表
-                        emiter.emit("onRefLocalPluginList", "")
+                        emiter.emit("onRefreshLocalPluginList")
                     })
                     .catch((e) => {
                         yakitNotify("error", "查询插件最新数据失败: " + e)
@@ -473,7 +456,7 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
                             downloadedTotalString: thousandthConversion(res.downloaded_total)
                         })
                         // 刷新我的列表
-                        emiter.emit("onRefUserPluginList", "")
+                        emiter.emit("onRefreshOwnPluginList")
                     })
                     .catch((err) => {})
             }
@@ -567,6 +550,7 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
                         UUID: info.uuid || undefined
                     })
                     setLocalPlugin({...plugin})
+                    if (!plugin.UUID && !!onlinePlugin) setOnlinePlugin(undefined)
                 }
                 if (opType === "upload" || opType === "submit") {
                     if (currentRequest.current) {

--- a/app/renderer/src/main/src/pages/pluginHub/pluginHubList/HubListLocal.tsx
+++ b/app/renderer/src/main/src/pages/pluginHub/pluginHubList/HubListLocal.tsx
@@ -16,8 +16,7 @@ import {
     convertDeleteLocalPluginsByWhereRequestParams,
     apiDeleteLocalPluginsByWhere,
     apiQueryYakScriptTotal,
-    excludeNoExistfilter,
-    apiQueryYakScriptByYakScriptName
+    excludeNoExistfilter
 } from "@/pages/plugins/utils"
 import {yakitNotify} from "@/utils/notification"
 import cloneDeep from "lodash/cloneDeep"
@@ -56,7 +55,6 @@ import {DefaultExportRequest, DefaultLocalPlugin, PluginOperateHint} from "../de
 import useGetSetState from "../hooks/useGetSetState"
 import {PluginGroup, TagsAndGroupRender, YakFilterRemoteObj} from "@/pages/mitm/MITMServerHijacking/MITMPluginLocalList"
 import {Tooltip} from "antd"
-import {SavePluginInfoSignalProps} from "@/pages/plugins/editDetails/PluginEditDetails"
 import {ModifyYakitPlugin} from "@/pages/pluginEditor/modifyYakitPlugin/ModifyYakitPlugin"
 import {ModifyPluginCallback} from "@/pages/pluginEditor/pluginEditor/PluginEditor"
 import {grpcFetchLocalPluginDetail} from "../utils/grpc"
@@ -65,8 +63,6 @@ import {KeyParamsFetchPluginDetail} from "@/pages/pluginEditor/base"
 import classNames from "classnames"
 import SearchResultEmpty from "@/assets/search_result_empty.png"
 import styles from "./PluginHubList.module.scss"
-
-const {ipcRenderer} = window.require("electron")
 
 interface HubListLocalProps extends HubListBaseProps {
     rootElementId?: string
@@ -126,80 +122,31 @@ export const HubListLocal: React.FC<HubListLocalProps> = memo((props) => {
     /** ---------- 列表相关变量 End ---------- */
 
     /** ---------- 列表相关方法 Start ---------- */
-    // 编辑插件保存后的刷新列表数据
-    const handleEditedToRefreshList = useMemoizedFn((info: string) => {
-        try {
-            const plugin: SavePluginInfoSignalProps = JSON.parse(info)
-            apiQueryYakScriptByYakScriptName({pluginName: plugin.pluginName})
-                .then((data: YakScript) => {
-                    const newItem = {...data, isLocalPlugin: privateDomain.current !== data.OnlineBaseUrl}
-                    // 本地列表是按更新时间排序的，如果当前列表没有该数据，刷新类别，数据会在第一页第一个
-                    const index = response.Data.findIndex((ele) => ele.ScriptName === data.ScriptName)
-                    if (index === -1) {
-                        fetchList(true)
-                    } else {
-                        dispatch({
-                            type: "update",
-                            payload: {
-                                item: {...newItem}
-                            }
-                        })
-                    }
-                })
-                .catch(() => {})
-        } catch (error) {}
-    })
-
-    //  重置后初始化搜索列表
-    const handleResetInitList = useMemoizedFn(() => {
-        setSearch(cloneDeep(defaultSearch))
-        setFilters(cloneDeep(defaultFilter))
-        fetchFilterGroup()
-        fetchList(true)
-    })
+    // 刷新搜索条件数据和无条件列表总数
+    const onRefreshFilterAndTotal = useDebounceFn(
+        useMemoizedFn(() => {
+            fetchInitTotal()
+            fetchFilterGroup()
+        }),
+        {wait: 300}
+    ).run
 
     useEffect(() => {
         fetchPrivateDomain(() => {
-            fetchList(true)
+            handleRefreshList(true)
         })
-        fetchFilterGroup()
     }, [])
 
     useUpdateEffect(() => {
-        fetchFilterGroup()
         fetchList(true)
     }, [isLogin])
     useUpdateEffect(() => {
-        fetchFilterGroup()
+        if (inViewPort) onRefreshFilterAndTotal()
     }, [inViewPort])
     /** 搜索条件 */
     useUpdateEffect(() => {
         fetchList(true)
     }, [filters])
-
-    useEffect(() => {
-        const refreshPrivateDomain = () => {
-            fetchPrivateDomain(() => {
-                fetchList(true)
-            })
-        }
-        const refreshList = () => {
-            setTimeout(() => {
-                fetchList(true)
-            }, 200)
-        }
-        emiter.on("onSwitchPrivateDomain", refreshPrivateDomain)
-        emiter.on("onRefLocalPluginList", refreshList)
-        emiter.on("savePluginInfoSignal", handleEditedToRefreshList)
-        emiter.on("onImportRefLocalPluginList", handleResetInitList)
-
-        return () => {
-            emiter.off("onSwitchPrivateDomain", refreshPrivateDomain)
-            emiter.off("onRefLocalPluginList", refreshList)
-            emiter.off("savePluginInfoSignal", handleEditedToRefreshList)
-            emiter.off("onImportRefLocalPluginList", handleResetInitList)
-        }
-    }, [])
 
     // 选中搜索条件可能在搜索数据组中不存在时进行清除
     useEffect(() => {
@@ -288,8 +235,7 @@ export const HubListLocal: React.FC<HubListLocalProps> = memo((props) => {
     })
     /** 刷新 */
     const onRefresh = useMemoizedFn(() => {
-        fetchFilterGroup()
-        fetchList(true)
+        handleRefreshList(true)
     })
 
     /** 单项勾选 */
@@ -340,37 +286,7 @@ export const HubListLocal: React.FC<HubListLocalProps> = memo((props) => {
                 delHintCache.current = res === "true"
             })
             .catch((err) => {})
-
-        emiter.on("detailDeleteLocalPlugin", handleDetailDeleteToLocal)
-        return () => {
-            emiter.off("detailDeleteLocalPlugin", handleDetailDeleteToLocal)
-        }
     }, [])
-    // 详情删除本地插件触发列表的局部更新
-    const handleDetailDeleteToLocal = useMemoizedFn((info: string) => {
-        if (!info) return
-        try {
-            const plugin: {name: string; id: string} = JSON.parse(info)
-            if (!plugin.name) return
-            const index = selectList.findIndex((ele) => ele.ScriptName === plugin.name)
-            const data: YakScript = {
-                ...DefaultLocalPlugin,
-                Id: Number(plugin.id) || 0,
-                ScriptName: plugin.name || ""
-            }
-            if (index !== -1) {
-                optCheck(data, false)
-            }
-            fetchInitTotal()
-            fetchFilterGroup()
-            dispatch({
-                type: "remove",
-                payload: {
-                    itemList: [data]
-                }
-            })
-        } catch (error) {}
-    })
 
     // 是否出现二次确认框
     const delHintCache = useRef<boolean>(false)
@@ -427,8 +343,7 @@ export const HubListLocal: React.FC<HubListLocalProps> = memo((props) => {
             }
         } catch (error) {}
         onCheck(false)
-        fetchFilterGroup()
-        fetchList(true)
+        handleRefreshList(true)
         setTimeout(() => {
             setBatchDelLoading(false)
         }, 200)
@@ -463,8 +378,7 @@ export const HubListLocal: React.FC<HubListLocalProps> = memo((props) => {
                 if (index !== -1) {
                     optCheck(info, false)
                 }
-                fetchInitTotal()
-                fetchFilterGroup()
+                onRefreshFilterAndTotal()
                 dispatch({
                     type: "remove",
                     payload: {
@@ -530,7 +444,7 @@ export const HubListLocal: React.FC<HubListLocalProps> = memo((props) => {
                         m.destroy()
                         setTimeout(() => {
                             // 刷新我的列表
-                            emiter.emit("onRefUserPluginList", "")
+                            emiter.emit("onRefreshOwnPluginList", true)
                             fetchList(true)
                         }, 200)
                     }}
@@ -711,6 +625,26 @@ export const HubListLocal: React.FC<HubListLocalProps> = memo((props) => {
     })
 
     /** ---------- 通信监听 Start ---------- */
+    // 刷新列表(是否刷新高级筛选数据)
+    const handleRefreshList = useDebounceFn(
+        useMemoizedFn((updateFilterGroup?: boolean) => {
+            if (updateFilterGroup) fetchFilterGroup()
+            fetchList(true)
+        }),
+        {wait: 200}
+    ).run
+
+    const handleSwitchPrivateDomain = useMemoizedFn(() => {
+        handleRefreshList()
+    })
+
+    // 重置所有搜索条件后的列表刷新
+    const handleInitFilterRefreshList = useMemoizedFn(() => {
+        setSearch(cloneDeep(defaultSearch))
+        setFilters(cloneDeep(defaultFilter))
+        handleRefreshList(true)
+    })
+
     // 触发详情列表的局部更新
     const [recalculation, setRecalculation] = useState<boolean>(false)
     // 更新本地插件信息，存在则进行局部更新，不存在则刷新列表
@@ -723,7 +657,6 @@ export const HubListLocal: React.FC<HubListLocalProps> = memo((props) => {
 
             const index = response.Data.findIndex((ele) => ele.ScriptName === plugin.ScriptName || ele.Id === plugin.Id)
             if (index === -1) {
-                fetchInitTotal()
                 fetchFilterGroup()
                 fetchList(true)
             } else {
@@ -740,10 +673,45 @@ export const HubListLocal: React.FC<HubListLocalProps> = memo((props) => {
         } catch (error) {}
     })
 
+    // 详情删除本地插件触发列表的局部更新
+    const handleDetailDeleteToLocal = useMemoizedFn((info: string) => {
+        if (!info) return
+        try {
+            const plugin: {name: string; id: number} = JSON.parse(info)
+            if (!plugin.name) return
+            const index = selectList.findIndex((ele) => ele.ScriptName === plugin.name || ele.Id === Number(plugin.id))
+            const data: YakScript = {
+                ...DefaultLocalPlugin,
+                Id: Number(plugin.id) || 0,
+                ScriptName: plugin.name || ""
+            }
+            if (index !== -1) {
+                optCheck(data, false)
+            }
+            fetchInitTotal()
+            fetchFilterGroup()
+            dispatch({
+                type: "remove",
+                payload: {
+                    itemList: [data]
+                }
+            })
+        } catch (error) {}
+    })
+
     useEffect(() => {
+        emiter.on("onSwitchPrivateDomain", handleSwitchPrivateDomain)
+        emiter.on("onRefreshLocalPluginList", handleRefreshList)
+        emiter.on("onImportRefreshLocalPluginList", handleInitFilterRefreshList)
         emiter.on("editorLocalSaveToLocalList", handleUpdatePluginInfo)
+        emiter.on("detailDeleteLocalPlugin", handleDetailDeleteToLocal)
+
         return () => {
+            emiter.off("onSwitchPrivateDomain", handleSwitchPrivateDomain)
+            emiter.off("onRefreshLocalPluginList", handleRefreshList)
+            emiter.off("onImportRefreshLocalPluginList", handleInitFilterRefreshList)
             emiter.off("editorLocalSaveToLocalList", handleUpdatePluginInfo)
+            emiter.off("detailDeleteLocalPlugin", handleDetailDeleteToLocal)
         }
     }, [])
     /** ---------- 通信监听 Start ---------- */

--- a/app/renderer/src/main/src/pages/pluginHub/pluginHubList/HubListLocal.tsx
+++ b/app/renderer/src/main/src/pages/pluginHub/pluginHubList/HubListLocal.tsx
@@ -589,8 +589,7 @@ export const HubListLocal: React.FC<HubListLocalProps> = memo((props) => {
     })
     // 单个上传成功后
     const handleSingleUploadAfter = useMemoizedFn((info: YakScript) => {
-        ipcRenderer
-            .invoke("GetYakScriptByName", {Name: info.ScriptName})
+        grpcFetchLocalPluginDetail({Name: info.ScriptName}, true)
             .then((i: YakScript) => {
                 const newItem = {...i, isLocalPlugin: privateDomain.current !== i.OnlineBaseUrl}
                 dispatch({

--- a/app/renderer/src/main/src/pages/pluginHub/pluginHubList/HubListOwn.tsx
+++ b/app/renderer/src/main/src/pages/pluginHub/pluginHubList/HubListOwn.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/pages/plugins/utils"
 import {getRemoteValue} from "@/utils/kv"
 import {yakitNotify} from "@/utils/notification"
-import {cloneDeep} from "bizcharts/lib/utils"
+import cloneDeep from "lodash/cloneDeep"
 import useListenWidth from "../hooks/useListenWidth"
 import {HubButton} from "../hubExtraOperate/funcTemplate"
 import {NoPromptHint} from "../utilsUI/UtilsTemplate"
@@ -101,16 +101,23 @@ export const HubListOwn: React.FC<HubListOwnProps> = memo((props) => {
     /** ---------- 列表相关变量 End ---------- */
 
     /** ---------- 列表相关方法 Start ---------- */
+    // 刷新搜索条件数据和无条件列表总数
+    const onRefreshFilterAndTotal = useDebounceFn(
+        useMemoizedFn(() => {
+            fetchInitTotal()
+            fetchFilterGroup()
+        }),
+        {wait: 300}
+    ).run
+
     useEffect(() => {
         if (isLogin) {
-            fetchFilterGroup()
-            fetchList(true)
+            handleRefreshList(true)
         }
     }, [isLogin])
     useUpdateEffect(() => {
         if (inViewPort && fetchIsLogin()) {
-            fetchInitTotal()
-            fetchFilterGroup()
+            onRefreshFilterAndTotal()
         }
     }, [inViewPort])
     /** 搜索条件 */
@@ -118,22 +125,6 @@ export const HubListOwn: React.FC<HubListOwnProps> = memo((props) => {
         if (!fetchIsLogin()) return
         fetchList(true)
     }, [filters])
-
-    useEffect(() => {
-        const onRefreshList = () => {
-            if (!fetchIsLogin()) return
-            setTimeout(() => {
-                fetchList(true)
-            }, 200)
-        }
-
-        emiter.on("onRefUserPluginList", onRefreshList)
-        emiter.on("recycleRestoreToOwnList", onRefreshList)
-        return () => {
-            emiter.off("onRefUserPluginList", onRefreshList)
-            emiter.off("recycleRestoreToOwnList", onRefreshList)
-        }
-    }, [])
 
     // 选中搜索条件可能在搜索数据组中不存在时进行清除
     useEffect(() => {
@@ -149,7 +140,7 @@ export const HubListOwn: React.FC<HubListOwnProps> = memo((props) => {
             .catch(() => {})
     })
 
-    // 搜搜条件分组数据
+    // 搜索条件分组数据
     const fetchFilterGroup = useMemoizedFn(() => {
         apiFetchGroupStatisticsMine()
             .then((res) => {
@@ -206,7 +197,7 @@ export const HubListOwn: React.FC<HubListOwnProps> = memo((props) => {
     })
     /** 刷新 */
     const onRefresh = useMemoizedFn(() => {
-        fetchList(true)
+        handleRefreshList(true)
     })
 
     /** 单项勾选 */
@@ -241,6 +232,77 @@ export const HubListOwn: React.FC<HubListOwnProps> = memo((props) => {
         {wait: 300, leading: true}
     ).run
     /** ---------- 列表相关方法 End ---------- */
+
+    /** ---------- 通信监听 Start ---------- */
+    // 刷新列表(是否刷新高级筛选数据)
+    const handleRefreshList = useDebounceFn(
+        useMemoizedFn((updateFilterGroup?: boolean) => {
+            if (!fetchIsLogin()) return
+            if (updateFilterGroup) fetchFilterGroup()
+            fetchList(true)
+        }),
+        {wait: 200}
+    ).run
+
+    // 详情删除线上插件触发列表的局部更新
+    const handleDetailDeleteToOnline = useMemoizedFn((info: string) => {
+        if (!info) return
+        try {
+            const plugin: {name: string; uuid: string} = JSON.parse(info)
+            if (!plugin.name && !plugin.uuid) return
+            const index = selectList.findIndex((ele) => ele.uuid === plugin.uuid)
+            const data: YakitPluginOnlineDetail = {
+                ...DefaultOnlinePlugin,
+                uuid: plugin.uuid || "",
+                script_name: plugin.name || ""
+            }
+            if (index !== -1) {
+                optCheck(data, false)
+            }
+            onRefreshFilterAndTotal()
+            emiter.emit("ownDeleteToRecycleList")
+            dispatch({
+                type: "remove",
+                payload: {
+                    itemList: [data]
+                }
+            })
+        } catch (error) {}
+    })
+
+    // 详情里改公开|私密后更新列表里的插件信息
+    const handleChangeStatus = useMemoizedFn((content: string) => {
+        if (!content) return
+        try {
+            const plugin: {name: string; uuid: string; is_private: boolean; status: number} = JSON.parse(content)
+            if (!plugin.name && !plugin.uuid) return
+            const el = response.data.find((ele) => ele.uuid === plugin.uuid)
+            if (!el) return
+            const data: YakitPluginOnlineDetail = {
+                ...el,
+                is_private: plugin.is_private,
+                status: plugin.status
+            }
+            dispatch({
+                type: "update",
+                payload: {
+                    item: data
+                }
+            })
+        } catch (error) {}
+    })
+
+    useEffect(() => {
+        emiter.on("onRefreshOwnPluginList", handleRefreshList)
+        emiter.on("detailDeleteOwnPlugin", handleDetailDeleteToOnline)
+        emiter.on("detailChangeStatusOwnPlugin", handleChangeStatus)
+        return () => {
+            emiter.off("onRefreshOwnPluginList", handleRefreshList)
+            emiter.off("detailDeleteOwnPlugin", handleDetailDeleteToOnline)
+            emiter.off("detailChangeStatusOwnPlugin", handleChangeStatus)
+        }
+    }, [])
+    /** ---------- 通信监听 Start ---------- */
 
     const listLength = useMemo(() => {
         return Number(response.pagemeta.total) || 0
@@ -311,7 +373,16 @@ export const HubListOwn: React.FC<HubListOwnProps> = memo((props) => {
     // 单个插件下载
     const handleSingleDownload = useMemoizedFn((info: YakitPluginOnlineDetail) => {
         grpcDownloadOnlinePlugin({uuid: info.uuid})
-            .then(() => {})
+            .then((res) => {
+                emiter.emit(
+                    "editorLocalSaveToLocalList",
+                    JSON.stringify({
+                        id: Number(res.Id) || 0,
+                        name: res.ScriptName,
+                        uuid: res.UUID || ""
+                    })
+                )
+            })
             .catch(() => {})
             .finally(() => {
                 setTimeout(() => {
@@ -349,7 +420,9 @@ export const HubListOwn: React.FC<HubListOwnProps> = memo((props) => {
 
         setBatchDownloadLoading(true)
         apiDownloadPluginMine(request)
-            .then(() => {})
+            .then(() => {
+                emiter.emit("onRefreshLocalPluginList", true)
+            })
             .catch(() => {})
             .finally(() => {
                 setTimeout(() => {
@@ -394,40 +467,7 @@ export const HubListOwn: React.FC<HubListOwnProps> = memo((props) => {
                 delHintCache.current = res === "true"
             })
             .catch((err) => {})
-
-        emiter.on("detailDeleteOwnPlugin", handleDetailDeleteToOnline)
-        emiter.on("detailChangeStatusOwnPlugin", handleChangeStatus)
-        return () => {
-            emiter.off("detailChangeStatusOwnPlugin", handleChangeStatus)
-            emiter.off("detailDeleteOwnPlugin", handleDetailDeleteToOnline)
-        }
     }, [])
-    // 详情删除线上插件触发列表的局部更新
-    const handleDetailDeleteToOnline = useMemoizedFn((info: string) => {
-        if (!info) return
-        try {
-            const plugin: {name: string; uuid: string} = JSON.parse(info)
-            if (!plugin.name && !plugin.uuid) return
-            const index = selectList.findIndex((ele) => ele.uuid === plugin.uuid)
-            const data: YakitPluginOnlineDetail = {
-                ...DefaultOnlinePlugin,
-                uuid: plugin.uuid || "",
-                script_name: plugin.name || ""
-            }
-            if (index !== -1) {
-                optCheck(data, false)
-            }
-            fetchInitTotal()
-            fetchFilterGroup()
-            emiter.emit("ownDeleteToRecycleList")
-            dispatch({
-                type: "remove",
-                payload: {
-                    itemList: [data]
-                }
-            })
-        } catch (error) {}
-    })
 
     // 是否出现二次确认框
     const delHintCache = useRef<boolean>(false)
@@ -518,8 +558,7 @@ export const HubListOwn: React.FC<HubListOwnProps> = memo((props) => {
                 if (index !== -1) {
                     optCheck(info, false)
                 }
-                fetchInitTotal()
-                fetchFilterGroup()
+                onRefreshFilterAndTotal()
                 emiter.emit("ownDeleteToRecycleList")
                 dispatch({
                     type: "remove",
@@ -538,27 +577,6 @@ export const HubListOwn: React.FC<HubListOwnProps> = memo((props) => {
     /** ---------- 删除插件 End ---------- */
 
     /** ---------- 单个操作(下载|改为公开/私密)的回调 Start ---------- */
-    const handleChangeStatus = useMemoizedFn((content: string) => {
-        if (!content) return
-        try {
-            const plugin: {name: string; uuid: string; is_private: boolean; status: number} = JSON.parse(content)
-            if (!plugin.name && !plugin.uuid) return
-            const el = response.data.find((ele) => ele.uuid === plugin.uuid)
-            if (!el) return
-            const data: YakitPluginOnlineDetail = {
-                ...el,
-                is_private: plugin.is_private,
-                status: plugin.status
-            }
-            dispatch({
-                type: "update",
-                payload: {
-                    item: data
-                }
-            })
-        } catch (error) {}
-    })
-
     const optCallback = useMemoizedFn((type: string, info: YakitPluginOnlineDetail) => {
         if (type === "state") {
             dispatch({

--- a/app/renderer/src/main/src/pages/pluginHub/pluginHubList/HubListRecycle.tsx
+++ b/app/renderer/src/main/src/pages/pluginHub/pluginHubList/HubListRecycle.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/pages/plugins/utils"
 import {getRemoteValue} from "@/utils/kv"
 import {yakitNotify} from "@/utils/notification"
-import {cloneDeep} from "bizcharts/lib/utils"
+import cloneDeep from "lodash/cloneDeep"
 import useListenWidth from "../hooks/useListenWidth"
 import {HubButton} from "../hubExtraOperate/funcTemplate"
 import {NoPromptHint} from "../utilsUI/UtilsTemplate"
@@ -73,6 +73,14 @@ export const HubListRecycle: React.FC<HubListRecycleProps> = memo((props) => {
     /** ---------- 列表相关变量 End ---------- */
 
     /** ---------- 列表相关方法 Start ---------- */
+    // 刷新搜索条件数据和无条件列表总数
+    const onRefreshFilterAndTotal = useDebounceFn(
+        useMemoizedFn(() => {
+            fetchInitTotal()
+        }),
+        {wait: 300}
+    ).run
+
     useEffect(() => {
         if (isLogin) {
             fetchList(true)
@@ -80,7 +88,7 @@ export const HubListRecycle: React.FC<HubListRecycleProps> = memo((props) => {
     }, [isLogin])
     useUpdateEffect(() => {
         if (inViewPort && fetchIsLogin()) {
-            fetchInitTotal()
+            onRefreshFilterAndTotal()
         }
     }, [inViewPort])
 
@@ -346,12 +354,12 @@ export const HubListRecycle: React.FC<HubListRecycleProps> = memo((props) => {
             optCheck(info, false)
         }
         fetchInitTotal()
-        if (type === "restore") emiter.emit("recycleRestoreToOwnList")
+        if (type === "restore") emiter.emit("onRefreshOwnPluginList", true)
     })
     // 批量删除和还原后对别的逻辑的影响处理
     const onBatchDelOrRestoreAfter = useMemoizedFn((type?: string) => {
         onCheck(false)
-        if (type === "restore") emiter.emit("recycleRestoreToOwnList")
+        if (type === "restore") emiter.emit("onRefreshOwnPluginList", true)
         setLoading(false)
         fetchList(true)
     })

--- a/app/renderer/src/main/src/pages/pluginHub/pluginHubList/PluginHubList.tsx
+++ b/app/renderer/src/main/src/pages/pluginHub/pluginHubList/PluginHubList.tsx
@@ -50,17 +50,38 @@ export const PluginHubList: React.FC<PluginHubListProps> = memo((props) => {
         return undefined
     })
 
+    // 处理指定页面和详情类型功能
+    const handleSpecifiedPageAndDetail = useMemoizedFn((data: PluginHubPageInfoProps) => {
+        const {tabActive, detailInfo, refeshList} = data
+        onSetActive(tabActive || "online")
+        if (detailInfo) {
+            setTimeout(() => {
+                onClickPlugin({type: tabActive, ...detailInfo})
+            }, 200)
+        }
+        if (refeshList !== undefined) {
+            switch (tabActive) {
+                case "online":
+                    emiter.emit("onRefreshOnlinePluginList", refeshList)
+                    break
+                case "own":
+                    emiter.emit("onRefreshOwnPluginList", refeshList)
+                    break
+                case "local":
+                    emiter.emit("onRefreshLocalPluginList", refeshList)
+                    break
+
+                default:
+                    break
+            }
+        }
+    })
+
     useEffect(() => {
         const data = initPageInfo()
         if (data) {
             removePagesDataCacheById(YakitRoute.Plugin_Hub, YakitRoute.Plugin_Hub)
-            const {tabActive, detailInfo} = data
-            onSetActive(tabActive || "online")
-            if (detailInfo) {
-                setTimeout(() => {
-                    onClickPlugin({type: tabActive, ...detailInfo})
-                }, 200)
-            }
+            handleSpecifiedPageAndDetail(data)
         } else {
             onSetActive("online")
         }
@@ -114,13 +135,9 @@ export const PluginHubList: React.FC<PluginHubListProps> = memo((props) => {
      */
     const handleOpenHubListAndDetail = useMemoizedFn((info: string) => {
         try {
-            const {tabActive, detailInfo} = JSON.parse(info) as unknown as PluginHubPageInfoProps
-            if (tabActive) {
-                onSetActive(tabActive)
-            }
-            if (detailInfo) {
-                onClickPlugin({type: tabActive, ...detailInfo})
-            }
+            const data = JSON.parse(info) as unknown as PluginHubPageInfoProps
+            if (!data) return
+            handleSpecifiedPageAndDetail(data)
         } catch (error) {}
     })
 

--- a/app/renderer/src/main/src/pages/pluginHub/pluginHubList/funcTemplate.tsx
+++ b/app/renderer/src/main/src/pages/pluginHub/pluginHubList/funcTemplate.tsx
@@ -38,15 +38,11 @@ import {formatDate} from "@/utils/timeUtil"
 import {YakitPluginOnlineDetail} from "@/pages/plugins/online/PluginsOnlineType"
 import {yakitNotify} from "@/utils/notification"
 import {
-    DownloadOnlinePluginsRequest,
     PluginStarsRequest,
     PluginsRecycleRequest,
-    apiDownloadPluginMine,
-    apiDownloadPluginOnline,
     apiPluginStars,
     apiReductionRecyclePlugin,
-    apiUpdatePluginPrivateMine,
-    onToEditPlugin
+    apiUpdatePluginPrivateMine
 } from "@/pages/plugins/utils"
 import {showYakitModal} from "@/components/yakitUI/YakitModal/YakitModalConfirm"
 import {useStore} from "@/store"
@@ -56,7 +52,6 @@ import {CheckboxChangeEvent} from "antd/lib/checkbox"
 import {SolidThumbupIcon} from "@/assets/icon/solid"
 import {YakScript} from "@/pages/invoker/schema"
 import {YakitMenuItemType} from "@/components/yakitUI/YakitMenu/YakitMenu"
-import {YakitRoute} from "@/enums/yakitRoute"
 
 import YakitLogo from "@/assets/yakitLogo.png"
 import UnLogin from "@/assets/unLogin.png"

--- a/app/renderer/src/main/src/pages/pluginHub/pluginHubList/funcTemplate.tsx
+++ b/app/renderer/src/main/src/pages/pluginHub/pluginHubList/funcTemplate.tsx
@@ -379,12 +379,28 @@ export const HubGridList: <T>(props: HubGridListProps<T>) => any = memo((props) 
 
     const listRef = useRef<HTMLDivElement>(null)
     const listSize = useSize(listRef)
+    /**
+     * @name 记录列表的列数
+     * @description 主要用于防止隐藏到显示时，列数重置为2时引起的滚动定位计算错误问题
+     */
+    const oldGridCol = useRef<number>(2)
     /** 每行的列数 */
     const gridCol = useMemo(() => {
+        if (listSize?.width === 0) return oldGridCol.current
         const width = listSize?.width || 600
-        if (width >= 900 && width < 1200) return 3
-        if (width >= 1200 && width < 1500) return 4
-        if (width >= 1500) return 5
+        if (width >= 900 && width < 1200) {
+            oldGridCol.current = 3
+            return 3
+        }
+        if (width >= 1200 && width < 1500) {
+            oldGridCol.current = 4
+            return 4
+        }
+        if (width >= 1500) {
+            oldGridCol.current = 5
+            return 5
+        }
+        oldGridCol.current = 2
         return 2
     }, [listSize])
 
@@ -426,7 +442,7 @@ export const HubGridList: <T>(props: HubGridListProps<T>) => any = memo((props) 
     useEffect(() => {
         // 滚动定位
         if (!previousInView.current && inView) {
-            scrollTo(Math.floor((showIndex || 0) / gridCol))
+            scrollTo(Math.floor((showIndex || 0) / oldGridCol.current))
         }
         // 数据重置或刷新
         if (previousInView.current && inView && showIndex === 0) {

--- a/app/renderer/src/main/src/pages/pluginHub/utils/grpc.ts
+++ b/app/renderer/src/main/src/pages/pluginHub/utils/grpc.ts
@@ -55,3 +55,22 @@ export const grpcFetchLocalPluginDetail: APIFunc<FetchLocalPluginDetail, YakScri
             })
     })
 }
+
+/** @name 通过插件ID查询本地插件详情信息 */
+export const grpcFetchLocalPluginDetailByID: APIFunc<string | number, YakScript> = (id, hiddenError) => {
+    return new Promise(async (resolve, reject) => {
+        if (!id) {
+            if (!hiddenError) yakitNotify("error", "查询插件的ID不能为空")
+            reject("查询插件的ID不能为空")
+            return
+        }
+
+        ipcRenderer
+            .invoke("GetYakScriptById", {Id: id})
+            .then(resolve)
+            .catch((e) => {
+                if (!hiddenError) yakitNotify("error", "查询本地插件详情失败:" + e)
+                reject(e)
+            })
+    })
+}

--- a/app/renderer/src/main/src/pages/plugins/editDetails/PluginEditDetails.tsx
+++ b/app/renderer/src/main/src/pages/plugins/editDetails/PluginEditDetails.tsx
@@ -552,7 +552,6 @@ export const PluginEditDetails: React.FC<PluginEditDetailsProps> = (props) => {
                     yakitNotify("success", "创建 / 保存 插件成功")
                     setTimeout(() => ipcRenderer.invoke("change-main-menu"), 100)
                     onLocalAndOnlineSend(data)
-                    emiter.emit("editorLocalSaveToDetail", `${Number(data.Id) || 0}`)
                     resolve(data)
                 })
                 .catch((e: any) => {
@@ -1041,13 +1040,13 @@ export const PluginEditDetails: React.FC<PluginEditDetailsProps> = (props) => {
     const onUpdatePageList = useMemoizedFn((key: string) => {
         switch (key) {
             case "online":
-                emiter.emit("onRefOnlinePluginList", "")
+                emiter.emit("onRefreshOnlinePluginList")
                 break
             case "owner":
-                emiter.emit("onRefUserPluginList", "")
+                emiter.emit("onRefreshOwnPluginList")
                 break
             case "local":
-                emiter.emit("onRefLocalPluginList", "")
+                emiter.emit("onRefreshLocalPluginList")
                 break
 
             default:

--- a/app/renderer/src/main/src/pages/plugins/editDetails/PluginEditDetails.tsx
+++ b/app/renderer/src/main/src/pages/plugins/editDetails/PluginEditDetails.tsx
@@ -65,6 +65,7 @@ import {CustomPluginExecuteFormValue} from "../operator/localPluginExecuteDetail
 import {defaultAddYakitScriptPageInfo} from "@/defaultConstants/AddYakitScript"
 import {WebsiteGV} from "@/enums/website"
 import {PluginSwitchToTag} from "@/pages/pluginEditor/defaultconstants"
+import {grpcFetchLocalPluginDetailByID} from "@/pages/pluginHub/utils/grpc"
 
 import "../plugins.scss"
 import styles from "./pluginEditDetails.module.scss"
@@ -154,8 +155,7 @@ export const PluginEditDetails: React.FC<PluginEditDetailsProps> = (props) => {
 
     /** 通过ID获取插件旧数据 */
     const fetchPluginInfo = useMemoizedFn((id: number) => {
-        ipcRenderer
-            .invoke("GetYakScriptById", {Id: id})
+        grpcFetchLocalPluginDetailByID(id, true)
             .then(async (res: YakScript) => {
                 // console.log("编辑插件-获取插件信息", res)
                 if (res.Type === "yak") fetchOldData(res.ScriptName)

--- a/app/renderer/src/main/src/pages/plugins/group/LocalPluginList.tsx
+++ b/app/renderer/src/main/src/pages/plugins/group/LocalPluginList.tsx
@@ -294,7 +294,7 @@ export const LocalPluginList: React.FC<PluginLocalGroupsListProps> = React.memo(
             if (activeGroup.id !== "全部") {
                 refreshLocalPluginList()
             }
-            emiter.emit("onRefLocalPluginList", "") // 刷新本地插件列表
+            emiter.emit("onRefreshLocalPluginList") // 刷新本地插件列表
             emiter.emit("onRefPluginGroupMagLocalQueryYakScriptGroup", "")
         })
     }

--- a/app/renderer/src/main/src/pages/plugins/group/OnlinePluginList.tsx
+++ b/app/renderer/src/main/src/pages/plugins/group/OnlinePluginList.tsx
@@ -301,7 +301,7 @@ export const OnlinePluginList: React.FC<PluginOnlineGroupsListProps> = React.mem
             if (activeGroup.id !== "全部") {
                 refreshOnlinePluginList()
             }
-            emiter.emit("onRefLocalPluginList", "") // 刷新线上插件列表
+            emiter.emit("onRefreshLocalPluginList") // 刷新线上插件列表
             emiter.emit("onRefPluginGroupMagOnlineQueryYakScriptGroup", "")
         })
     }

--- a/app/renderer/src/main/src/pages/plugins/local/PluginsLocal.tsx
+++ b/app/renderer/src/main/src/pages/plugins/local/PluginsLocal.tsx
@@ -151,15 +151,15 @@ export const PluginsLocal: React.FC<PluginsLocalProps> = React.memo((props) => {
         getPrivateDomainAndRefList()
     }, [])
     useEffect(() => {
-        emiter.on("onRefLocalPluginList", onRefLocalPluginList)
+        emiter.on("onRefreshLocalPluginList", onRefLocalPluginList)
         emiter.on("savePluginInfoSignal", onRefPlugin)
         emiter.on("onSwitchPrivateDomain", getPrivateDomainAndRefList)
-        emiter.on("onImportRefLocalPluginList", onImportRefLocalPluginList)
+        emiter.on("onImportRefreshLocalPluginList", onImportRefLocalPluginList)
         return () => {
-            emiter.off("onRefLocalPluginList", onRefLocalPluginList)
+            emiter.off("onRefreshLocalPluginList", onRefLocalPluginList)
             emiter.off("savePluginInfoSignal", onRefPlugin)
             emiter.off("onSwitchPrivateDomain", getPrivateDomainAndRefList)
-            emiter.off("onImportRefLocalPluginList", onImportRefLocalPluginList)
+            emiter.off("onImportRefreshLocalPluginList", onImportRefLocalPluginList)
         }
     }, [])
     useEffect(() => {

--- a/app/renderer/src/main/src/pages/plugins/local/PluginsLocal.tsx
+++ b/app/renderer/src/main/src/pages/plugins/local/PluginsLocal.tsx
@@ -73,6 +73,7 @@ import {SavePluginInfoSignalProps} from "../editDetails/PluginEditDetails"
 import "../plugins.scss"
 import styles from "./PluginsLocal.module.scss"
 import {PluginLocalExport, PluginLocalExportForm} from "./PluginLocalExportProps"
+import {grpcFetchLocalPluginDetail} from "@/pages/pluginHub/utils/grpc"
 
 const {ipcRenderer} = window.require("electron")
 
@@ -270,8 +271,7 @@ export const PluginsLocal: React.FC<PluginsLocalProps> = React.memo((props) => {
     /**上传成功后需要修改列表中的数据 */
     const onUploadSuccess = useMemoizedFn(() => {
         if (uploadPluginRef.current) {
-            ipcRenderer
-                .invoke("GetYakScriptByName", {Name: uploadPluginRef.current.ScriptName})
+            grpcFetchLocalPluginDetail({Name: uploadPluginRef.current.ScriptName}, true)
                 .then((i: YakScript) => {
                     const newItem = {...i, isLocalPlugin: privateDomain !== i.OnlineBaseUrl}
                     dispatch({

--- a/app/renderer/src/main/src/pages/plugins/online/PluginsOnline.tsx
+++ b/app/renderer/src/main/src/pages/plugins/online/PluginsOnline.tsx
@@ -287,11 +287,11 @@ const PluginsOnlineList: React.FC<PluginsOnlineListProps> = React.memo((props, r
 
     useEffect(() => {
         emiter.on("onSwitchPrivateDomain", onSwitchPrivateDomainRefOnlinePluginInit)
-        emiter.on("onRefOnlinePluginList", onRefOnlinePluginList)
+        emiter.on("onRefreshOnlinePluginList", onRefOnlinePluginList)
         emiter.on("menuExpandSwitch", onMenuExpandSwitch)
         return () => {
             emiter.off("onSwitchPrivateDomain", onSwitchPrivateDomainRefOnlinePluginInit)
-            emiter.off("onRefOnlinePluginList", onRefOnlinePluginList)
+            emiter.off("onRefreshOnlinePluginList", onRefOnlinePluginList)
             emiter.off("menuExpandSwitch", onMenuExpandSwitch)
         }
     }, [])

--- a/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard.tsx
+++ b/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard.tsx
@@ -450,6 +450,15 @@ export const FormContentItemByType: React.FC<FormContentItemByTypeProps> = React
             double: false,
             data: []
         }
+        if (extraSetting && extraSetting.data) {
+            extraSetting.data = extraSetting.data.map((item) => {
+                return {
+                    key: item?.key,
+                    label: item?.label || item?.key || item?.value,
+                    value: item?.value
+                }
+            })
+        }
     } catch (error) {
         failed("获取参数配置数据错误，请重新打开该页面")
     }

--- a/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeardType.d.ts
+++ b/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeardType.d.ts
@@ -59,7 +59,7 @@ export interface OutputFormComponentsByTypeProps {
 
 export interface FormExtraSettingProps {
     double: boolean
-    data: {label: string; value: string}[]
+    data: {key: string; label: string; value: string}[]
 }
 
 export interface PluginExecuteProgressProps {

--- a/app/renderer/src/main/src/pages/plugins/pluginBatchExecutor/pluginBatchExecutor.tsx
+++ b/app/renderer/src/main/src/pages/plugins/pluginBatchExecutor/pluginBatchExecutor.tsx
@@ -123,10 +123,10 @@ export const PluginBatchExecutor: React.FC<PluginBatchExecutorProps> = React.mem
     }, [userInfo.isLogin])
     useEffect(() => {
         if (inViewport) {
-            emiter.on("onRefLocalPluginList", onRefLocalPluginList)
+            emiter.on("onRefreshLocalPluginList", onRefLocalPluginList)
         }
         return () => {
-            emiter.off("onRefLocalPluginList", onRefLocalPluginList)
+            emiter.off("onRefreshLocalPluginList", onRefLocalPluginList)
         }
     }, [inViewport])
 

--- a/app/renderer/src/main/src/pages/plugins/singlePluginExecution/SinglePluginExecution.tsx
+++ b/app/renderer/src/main/src/pages/plugins/singlePluginExecution/SinglePluginExecution.tsx
@@ -6,7 +6,6 @@ import {YakScript} from "@/pages/invoker/schema"
 import {YakitButton} from "@/components/yakitUI/YakitButton/YakitButton"
 import {OutlinePencilaltIcon, OutlineRefreshIcon} from "@/assets/icon/outline"
 import {
-    apiGetYakScriptById,
     apiGetYakScriptByOnlineID,
     convertLocalPluginsRequestParams,
     onToEditPlugin
@@ -20,6 +19,7 @@ import {Tooltip} from "antd"
 import {PluginLocalListDetails} from "../operator/PluginLocalListDetails/PluginLocalListDetails"
 import {defaultFilter, defaultSearch, pluginTypeToName} from "../builtInData"
 import emiter from "@/utils/eventBus/eventBus"
+import {grpcFetchLocalPluginDetailByID} from "@/pages/pluginHub/utils/grpc"
 
 export const getLinkPluginConfig = (selectList, pluginListSearchInfo, allCheck?: boolean) => {
     // allCheck只有为false的时候才走该判断，undefined和true不走
@@ -80,7 +80,7 @@ export const SinglePluginExecution: React.FC<SinglePluginExecutionProps> = React
     /**获取插件详情，设置插件联动类型，查询私有域,刷新插件列表 */
     const getPluginById = useMemoizedFn(() => {
         setPluginLoading(true)
-        apiGetYakScriptById(yakScriptId)
+        grpcFetchLocalPluginDetailByID(yakScriptId, true)
             .then((res) => {
                 const {PluginSelectorTypes = ""} = res
                 setPlugin(res)

--- a/app/renderer/src/main/src/pages/plugins/user/PluginUser.tsx
+++ b/app/renderer/src/main/src/pages/plugins/user/PluginUser.tsx
@@ -489,9 +489,9 @@ const PluginUserList: React.FC<PluginUserListProps> = React.memo(
             [allCheck, selectList]
         )
         useEffect(() => {
-            emiter.on("onRefUserPluginList", onRefreshUserList)
+            emiter.on("onRefreshOwnPluginList", onRefreshUserList)
             return () => {
-                emiter.off("onRefUserPluginList", onRefreshUserList)
+                emiter.off("onRefreshOwnPluginList", onRefreshUserList)
             }
         }, [])
         // 获取筛选栏展示状态

--- a/app/renderer/src/main/src/pages/plugins/utils.ts
+++ b/app/renderer/src/main/src/pages/plugins/utils.ts
@@ -1515,21 +1515,6 @@ export const onToEditPlugin = (plugin: YakScript, route?: YakitRoute) => {
     }
 }
 
-/**
- * @description 获取插件详情，通过插件id
- */
-export const apiGetYakScriptById: APIFunc<string | number, YakScript> = (Id, hiddenError) => {
-    return new Promise((resolve, reject) => {
-        ipcRenderer
-            .invoke("GetYakScriptById", {Id})
-            .then(resolve)
-            .catch((error) => {
-                if (!hiddenError) yakitNotify("error", `插件本地插件详情失败：${error}`)
-                reject(error)
-            })
-    })
-}
-
 /**本地获取插件组数据 */
 export const apiFetchQueryYakScriptGroupLocal: (All?: boolean, ExcludeType?: string[]) => Promise<GroupCount[]> = (
     All = true,

--- a/app/renderer/src/main/src/pages/plugins/utils.ts
+++ b/app/renderer/src/main/src/pages/plugins/utils.ts
@@ -1016,21 +1016,6 @@ export const apiFetchOnlinePluginInfo: APIFunc<FetchOnlinePluginInfoRequest, API
     })
 }
 
-/**
- * @name 获取指定插件的详情(本地)
- */
-export const apiFetchLocalPluginInfo: APIFunc<string, YakScript> = (scriptName, hiddenError) => {
-    return new Promise((resolve, reject) => {
-        ipcRenderer
-            .invoke("GetYakScriptByName", {Name: scriptName})
-            .then(resolve)
-            .catch((e) => {
-                if (!hiddenError) yakitNotify("error", "查询本地插件错误:" + e)
-                reject(e)
-            })
-    })
-}
-
 export interface PluginLogsRequest extends HTTPRequestParameters, API.LogsRequest {}
 /**
  * @name 获取插件的日志

--- a/app/renderer/src/main/src/pages/plugins/utils.ts
+++ b/app/renderer/src/main/src/pages/plugins/utils.ts
@@ -438,7 +438,7 @@ export const apiDownloadPluginBase: (query?: DownloadOnlinePluginsRequest) => Pr
                 if (isCommunityEdition()) ipcRenderer.invoke("refresh-public-menu")
                 else ipcRenderer.invoke("change-main-menu")
                 // 插件商店、我的插件、插件管理页面 下载插件后需要更新 本地插件列表
-                emiter.emit("onRefLocalPluginList", "")
+                emiter.emit("onRefreshLocalPluginList")
                 resolve(res)
             })
             .catch((e) => {

--- a/app/renderer/src/main/src/routes/newRoute.tsx
+++ b/app/renderer/src/main/src/routes/newRoute.tsx
@@ -114,7 +114,6 @@ import {
     BrutePageInfoProps,
     HTTPHackerPageInfoProps,
     PluginBatchExecutorPageInfoProps,
-    PluginHubPageInfoProps,
     PocPageInfoProps,
     RiskPageInfoProps,
     ScanPortPageInfoProps,
@@ -386,8 +385,6 @@ export interface ComponentParams {
     simpleDetectPageInfo?: SimpleDetectPageInfoProps
     /**新建插件页面 */
     addYakitScriptPageInfo?: AddYakitScriptPageInfoProps
-    /**插件仓库页面 */
-    pluginHubPageInfoProps?: PluginHubPageInfoProps
     /**漏洞与风险统计页面 */
     riskPageInfoProps?: RiskPageInfoProps
     /**MITM劫持页面 */

--- a/app/renderer/src/main/src/store/pageInfo.ts
+++ b/app/renderer/src/main/src/store/pageInfo.ts
@@ -147,6 +147,8 @@ export interface PluginHubPageInfoProps {
     tabActive: PluginSourceType
     /**打开插件的id、uuid和name */
     detailInfo?: KeyParamsFetchPluginDetail
+    /**是否刷新列表(传 true-刷新列表和高级筛选, false-刷新列表, 不传不刷新) */
+    refeshList?: boolean
 }
 
 export interface RiskPageInfoProps {

--- a/app/renderer/src/main/src/store/pageInfo.ts
+++ b/app/renderer/src/main/src/store/pageInfo.ts
@@ -11,6 +11,7 @@ import {createWithEqualityFn} from "zustand/traditional"
 import {HybridScanControlAfterRequest, HybridScanModeType} from "@/models/HybridScan"
 import {defaultAdvancedConfigValue, defaultPostTemplate} from "@/defaultConstants/HTTPFuzzerPage"
 import {PluginSourceType} from "@/pages/pluginHub/type"
+import {KeyParamsFetchPluginDetail} from "@/pages/pluginEditor/base"
 
 /**
  * @description 页面暂存数据
@@ -61,7 +62,7 @@ interface PageParamsInfoProps {
     simpleDetectPageInfo?: SimpleDetectPageInfoProps
     /**新建插件页面 */
     addYakitScriptPageInfo?: AddYakitScriptPageInfoProps
-    /**新建插件仓库页面 */
+    /**打开插件仓库页面 */
     pluginHubPageInfo?: PluginHubPageInfoProps
     /**新建漏洞与风险统计页面 */
     riskPageInfo?: RiskPageInfoProps
@@ -144,6 +145,8 @@ export interface ScanPortPageInfoProps {
 export interface PluginHubPageInfoProps {
     /**切换到插件仓库指定tab */
     tabActive: PluginSourceType
+    /**打开插件的id、uuid和name */
+    detailInfo?: KeyParamsFetchPluginDetail
 }
 
 export interface RiskPageInfoProps {

--- a/app/renderer/src/main/src/utils/eventBus/events/plugins.ts
+++ b/app/renderer/src/main/src/utils/eventBus/events/plugins.ts
@@ -1,21 +1,17 @@
-import {PluginSourceType} from "@/pages/pluginHub/type"
-
 export type PluginsEventProps = {
-    /** 刷新本地插件列表 */
-    onRefLocalPluginList: string
     /** 触发编辑插件功能的插件ID */
     sendEditPluginId: string
-    /** 新建|编辑插件成功后的发送信号(包含本地和线上保存, 传递数据的定义[SavePluginInfoSignalProps]) */
+    /**
+     * 新建|编辑插件成功后的发送信号(包含本地和线上保存, 传递数据的定义[SavePluginInfoSignalProps])
+     * 该通信已无用，注明废弃，下版删除该通信
+     */
     savePluginInfoSignal: string
-    /** 刷新插件商店列表 */
-    onRefOnlinePluginList: string
 
     /** 刷新本地插件详情页面的选中的插件数据 */
     onRefLocalDetailSelectPlugin: string
     /** 修改私有域成功后发送的信号 */
     onSwitchPrivateDomain: string
-    /** 导入刷新本地插件列表 */
-    onImportRefLocalPluginList: string
+
     /** 刷新插件组管理本地插件组列表 */
     onRefPluginGroupMagLocalQueryYakScriptGroup: string
     /** 刷新插件组管理本地插件列表 */
@@ -34,28 +30,29 @@ export type PluginsEventProps = {
     onRefPluginCodecMenu?: string
 
     // ---------- 插件列表相关通信 ----------
-    /** 刷新插件仓库指定tab */
-    refreshPluginHubTabActive: PluginSourceType
+    /** 刷新插件商店列表(传 true 则同步刷新高级筛选条件) */
+    onRefreshOnlinePluginList?: boolean
+    /** 刷新我的列表(传 true 则同步刷新高级筛选条件) */
+    onRefreshOwnPluginList?: boolean
+    /** 刷新本地列表(传 true 则同步刷新高级筛选条件) */
+    onRefreshLocalPluginList?: boolean
 
-    /** 刷新我的插件列表 */
-    onRefUserPluginList: string
+    /** 导入插件后的刷新本地插件列表 */
+    onImportRefreshLocalPluginList?: string
 
-    /** 我的插件 删除操作通知 回收站刷新列表 */
+    /** 我的插件(包括详情里的删除线上) 删除操作通知 回收站刷新列表 */
     ownDeleteToRecycleList?: string
-    /** 回收站 还原操作通知 我的插件刷新列表 */
-    recycleRestoreToOwnList?: string
+
+    /** 打开插件仓库跳转到指定的列表 */
+    openPluginHubListAndDetail: string
 
     // ---------- 插件详情相关通信 ----------
     /** 插件详情删除本地插件 通知本地列表的变量刷新 */
     detailDeleteLocalPlugin: string
-    /** 插件详情删除我的插件 通知我的列表的变量刷新 */
+    /** 插件详情删除线上插件 通知我的列表的变量刷新 */
     detailDeleteOwnPlugin: string
     /** 插件详情更改公开|私密 通知我的列表里状态更新 */
     detailChangeStatusOwnPlugin: string
-
-    // ---------- 插件编辑相关通信 ----------
-    /** 插件编辑-本地保存成功后通知详情更新插件信息 */
-    editorLocalSaveToDetail: string
 
     // ---------- 插件(新建|编辑)相关通信 ----------
     /**

--- a/app/renderer/src/main/src/utils/login.tsx
+++ b/app/renderer/src/main/src/utils/login.tsx
@@ -47,7 +47,7 @@ export const loginOutLocal = (userInfo: UserInfoProps) => {
                 })
                 .finally(() => {
                     ipcRenderer.send("user-sign-out")
-                    emiter.emit("onRefLocalPluginList", "")
+                    emiter.emit("onRefreshLocalPluginList")
                 })
         } else {
             ipcRenderer.send("user-sign-out")


### PR DESCRIPTION
1、解决我的插件列表未登录时的侧边提示问题
2、解决列表选择类型但是没有触发搜索问题
3、更新列表刷新的逻辑(上面发给你过，记得更新到 prd 里)
4、单个插件下载的提示逻辑调整，新增同名提示
5、写妹妹那边的打开指定插件功能
6、重新整合插件列表相关通信逻辑
7、调整编辑页面提交至云端和本地保存时，编辑变成新建后的更新逻辑
8、修复插件详情在退出登录或切换私有域时还有改公开/私密的菜单功能问题
9、修复插件参数-select 展示逻辑问题(后端改动字段后并未和前端说明)
10、新增-插件详情右侧的 tab，在同名不同 uuid 时会有禁用功能
11、修复详情返回列表，列表白屏问题
12、插件列表批量下载，同名覆盖提示
13、fuzzer生成模板-存为插件时，源码没有带入到新建插件页面里
14、新建插件-同步至云端-公开-评分没有通过依旧上传成功问题

合并方式：第一种