### PR TITLE
luoluo/fix/monaco-cursor

### DIFF
--- a/app/renderer/src/main/package.json
+++ b/app/renderer/src/main/package.json
@@ -67,7 +67,7 @@
         "react-hotkeys-hook": "^4.4.1",
         "react-infinite-scroll-component": "^6.1.0",
         "react-markdown": "^8.0.7",
-        "react-monaco-editor": "^0.54.0",
+        "react-monaco-editor": "0.50.1",
         "react-resizable": "^3.0.4",
         "react-resize-detector": "^6.7.6",
         "react-scripts": "5.0.1",

--- a/app/renderer/src/main/yarn.lock
+++ b/app/renderer/src/main/yarn.lock
@@ -13510,10 +13510,10 @@ react-markdown@~8.0.0:
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
 
-react-monaco-editor@^0.54.0:
-  version "0.54.0"
-  resolved "https://registry.yarnpkg.com/react-monaco-editor/-/react-monaco-editor-0.54.0.tgz#ec9293249a991b08264be723c1ec0ca3a6d480d8"
-  integrity sha512-9JwO69851mfpuhYLHlKbae7omQWJ/2ICE2lbL0VHyNyZR8rCOH7440u+zAtDgiOMpLwmYdY1sEZCdRefywX6GQ==
+react-monaco-editor@0.50.1:
+  version "0.50.1"
+  resolved "https://registry.yarnpkg.com/react-monaco-editor/-/react-monaco-editor-0.50.1.tgz#3b68ce03e4b316f435b9bcd8ec13ffd4c050c605"
+  integrity sha512-qvYdJhQdkPIrPDMxCrEl0T2x9TfBB+aUbrpFv69FwoTybeyfAjxgJ219MYSsgn3c/g06BgyLX4ENrXM4niZ9ag==
   dependencies:
     prop-types "^15.8.1"
 


### PR DESCRIPTION
1.fix:react-monaco-editor降低到0.47.0，解决光标跳行问题,根本原因是因为react18有问题

目前react-monaco-editor的版本前端锁定v0.50.1，修复鼠标跳行问题
大概原因：v0.50.1后官方使用了react18的creatRoot方式创建元素，导致dom一些操作出现问题
v0.50.1-v0.55.0(目前最新)官方修复了一些问题:
[fix: fixed issue of initializing editor multiple times (](https://github.com/react-monaco-editor/react-monaco-editor/commit/d8bd05954cd8d68b2391ab3e3828f47b969438d6)[#656](https://github.com/react-monaco-editor/react-monaco-editor/pull/656)[)](https://github.com/react-monaco-editor/react-monaco-editor/commit/d8bd05954cd8d68b2391ab3e3828f47b969438d6) (v0.51.0)
[fix: Don't set the Monaco value if it hasn't changed (](https://github.com/react-monaco-editor/react-monaco-editor/commit/6f61db3d9aba223cdffbb729f490d2d30d807dc7)[#690](https://github.com/react-monaco-editor/react-monaco-editor/pull/690)[)](https://github.com/react-monaco-editor/react-monaco-editor/commit/6f61db3d9aba223cdffbb729f490d2d30d807dc7)(v0.52.0)