### PR TITLE
Luoluo/feature/wf add extra tab history record

### DIFF
--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.module.scss
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.module.scss
@@ -433,7 +433,7 @@ $keyColor: map-keys($colors);
         user-select: none;
 
         position: absolute;
-        right: 64px;
+        right: 96px;
         z-index: 11;
 
         svg {

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.module.scss
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.module.scss
@@ -266,7 +266,7 @@ $keyColor: map-keys($colors);
             height: 32px;
             background-color: var(--yakit-card-background-color);
 
-            max-width: calc(100% - 64px);
+            max-width: calc(100% - 32px);
             overflow-y: hidden;
             overflow-x: auto;
             scroll-behavior: smooth;
@@ -341,10 +341,10 @@ $keyColor: map-keys($colors);
                 }
             }
             .tab-menu-sub-group-disable-drag {
-                cursor:auto;
+                cursor: auto;
                 .tab-menu-sub-group-name {
                     height: auto;
-                    cursor:auto;
+                    cursor: auto;
                 }
                 .tab-menu-sub-group-children {
                     flex-wrap: wrap;
@@ -355,7 +355,10 @@ $keyColor: map-keys($colors);
         .tab-menu-sub-width {
             max-width: 100%;
         }
-        .tab-menu-sub-maxWidth-64{
+        .tab-menu-sub-maxWidth-64 {
+            max-width: calc(100% - 64px);
+        }
+        .tab-menu-sub-maxWidth-96 {
             max-width: calc(100% - 96px);
         }
         .tab-menu-sub-expand {
@@ -433,7 +436,7 @@ $keyColor: map-keys($colors);
         user-select: none;
 
         position: absolute;
-        right: 96px;
+        right: 64px;
         z-index: 11;
 
         svg {
@@ -447,6 +450,10 @@ $keyColor: map-keys($colors);
             bottom: 0px;
             z-index: 2;
         }
+    }
+
+    .outline-chevron-double-right-wf {
+        right: 96px;
     }
 
     .outline-chevron-double-display-none {
@@ -467,7 +474,7 @@ $keyColor: map-keys($colors);
     position: relative;
     overflow: hidden;
     max-width: 200px;
-    min-width: 64px;
+    min-width: 32px;
     // width: fit-content;
     justify-content: space-between;
     background-color: var(--yakit-card-background-color);
@@ -570,7 +577,7 @@ $keyColor: map-keys($colors);
     }
 }
 
-.tab-menu-sub-item-disable-drag{
+.tab-menu-sub-item-disable-drag {
     flex: 0 1 auto;
 }
 

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.module.scss
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.module.scss
@@ -266,7 +266,7 @@ $keyColor: map-keys($colors);
             height: 32px;
             background-color: var(--yakit-card-background-color);
 
-            max-width: calc(100% - 32px);
+            max-width: calc(100% - 64px);
             overflow-y: hidden;
             overflow-x: auto;
             scroll-behavior: smooth;
@@ -356,7 +356,7 @@ $keyColor: map-keys($colors);
             max-width: 100%;
         }
         .tab-menu-sub-maxWidth-64{
-            max-width: calc(100% - 64px);
+            max-width: calc(100% - 96px);
         }
         .tab-menu-sub-expand {
             max-width: calc(100% - 32px);

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -873,29 +873,29 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
             isCache = true,
             downstreamProxyStr = ""
         } = res || {}
-        const cacheData: FuzzerCacheDataProps = (await getFuzzerCacheData()) || {
-            proxy: [],
-            dnsServers: [],
-            etcHosts: [],
-            advancedConfigShow: null,
-            resNumlimit: DefFuzzerTableMaxData
-        }
-        let newAdvancedConfigValue = {
-            ...advancedConfigValue
-        }
-        if (isCache) {
-            newAdvancedConfigValue.proxy = cacheData.proxy
-            newAdvancedConfigValue.dnsServers = cacheData.dnsServers
-            newAdvancedConfigValue.etcHosts = cacheData.etcHosts
-            newAdvancedConfigValue.resNumlimit = cacheData.resNumlimit
-        }
-        let newAdvancedConfigShow = cacheData.advancedConfigShow
-        let newIsHttps = !!isHttps
-        let newIsGmTLS = !!isGmTLS
-        let newRequest = request || defaultPostTemplate
-        // 有分享内容，数据以分享内容为准
-        if (res.hasOwnProperty("shareContent")) {
-            try {
+        try {
+            const cacheData: FuzzerCacheDataProps = (await getFuzzerCacheData()) || {
+                proxy: [],
+                dnsServers: [],
+                etcHosts: [],
+                advancedConfigShow: null,
+                resNumlimit: DefFuzzerTableMaxData
+            }
+            let newAdvancedConfigValue = {
+                ...advancedConfigValue
+            }
+            if (isCache) {
+                newAdvancedConfigValue.proxy = cacheData.proxy
+                newAdvancedConfigValue.dnsServers = cacheData.dnsServers
+                newAdvancedConfigValue.etcHosts = cacheData.etcHosts
+                newAdvancedConfigValue.resNumlimit = cacheData.resNumlimit
+            }
+            let newAdvancedConfigShow = cacheData.advancedConfigShow
+            let newIsHttps = !!isHttps
+            let newIsGmTLS = !!isGmTLS
+            let newRequest = request || defaultPostTemplate
+            // 有分享内容，数据以分享内容为准
+            if (res.hasOwnProperty("shareContent")) {
                 const shareContent: ShareValueProps = JSON.parse(res.shareContent)
                 newIsHttps = shareContent.advancedConfiguration.isHttps
                 newIsGmTLS = shareContent.advancedConfiguration.isGmTLS
@@ -910,27 +910,29 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
                         rule: true
                     }
                 }
-            } catch (error) {}
-        }
-        if (downstreamProxyStr) {
-            newAdvancedConfigValue.proxy = [downstreamProxyStr]
-        }
-        openMenuPage(
-            {route: YakitRoute.HTTPFuzzer},
-            {
-                openFlag,
-                pageParams: {
-                    request: newRequest,
-                    system: system,
-                    advancedConfigValue: {
-                        ...newAdvancedConfigValue,
-                        isHttps: newIsHttps,
-                        isGmTLS: newIsGmTLS
-                    },
-                    advancedConfigShow: newAdvancedConfigShow
-                }
             }
-        )
+            if (downstreamProxyStr) {
+                newAdvancedConfigValue.proxy = [downstreamProxyStr]
+            }
+            openMenuPage(
+                {route: YakitRoute.HTTPFuzzer},
+                {
+                    openFlag,
+                    pageParams: {
+                        request: newRequest,
+                        system: system,
+                        advancedConfigValue: {
+                            ...newAdvancedConfigValue,
+                            isHttps: newIsHttps,
+                            isGmTLS: newIsGmTLS
+                        },
+                        advancedConfigShow: newAdvancedConfigShow
+                    }
+                }
+            )
+        } catch (error) {
+            yakitNotify('error',`打开WF失败:${error}`)
+        }
     })
     /** websocket fuzzer 和 Fuzzer 类似 */
     const addWebsocketFuzzer = useMemoizedFn(

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -4028,6 +4028,9 @@ const SubTabs: React.FC<SubTabsProps> = React.memo(
         const isShowExpandIcon = useCreation(() => {
             return scroll.scrollLeft > 0 || scroll.scrollRight > 0
         }, [scroll.scrollLeft, scroll.scrollRight])
+        const isWebFuzzerRoute = useCreation(() => {
+            return currentTabKey === YakitRoute.HTTPFuzzer
+        }, [currentTabKey])
         return (
             <DragDropContext
                 onDragEnd={onSubMenuDragEnd}
@@ -4058,7 +4061,9 @@ const SubTabs: React.FC<SubTabsProps> = React.memo(
                                 <div
                                     className={classNames(styles["tab-menu-sub"], {
                                         [styles["tab-menu-sub-width"]]: pageItem.hideAdd === true,
-                                        [styles["tab-menu-sub-maxWidth-64"]]: isShowExpandIcon,
+                                        [styles["tab-menu-sub-maxWidth-64"]]: isWebFuzzerRoute, // WF页面二级菜单的默认占位最大宽度
+                                        [styles["tab-menu-sub-maxWidth-64"]]: isShowExpandIcon && !isWebFuzzerRoute, // 除了WF页面，其他多开页面二级菜单展开后占位最大宽度
+                                        [styles["tab-menu-sub-maxWidth-96"]]: isShowExpandIcon && isWebFuzzerRoute, // WF页面二级菜单展开后占位最大宽度
                                         [styles["tab-menu-sub-expand"]]: isExpand
                                     })}
                                     id={`tab-menu-sub-${pageItem.route}`}
@@ -4107,7 +4112,8 @@ const SubTabs: React.FC<SubTabsProps> = React.memo(
                                 <div
                                     className={classNames(styles["outline-chevron-double-right"], {
                                         [styles["outline-chevron-double-display-none"]]:
-                                            scroll.scrollRight <= 0 || isExpand
+                                            scroll.scrollRight <= 0 || isExpand,
+                                        [styles["outline-chevron-double-right-wf"]]: isWebFuzzerRoute
                                     })}
                                     ref={scrollRightIconRef}
                                 >
@@ -4131,7 +4137,7 @@ const SubTabs: React.FC<SubTabsProps> = React.memo(
                                             />
                                         )
                                     )}
-                                    {currentTabKey === YakitRoute.HTTPFuzzer && (
+                                    {isWebFuzzerRoute && (
                                         <Tooltip title='恢复WebFuzzer标签页' placement={isExpand ? "left" : "top"}>
                                             <OutlineRefreshIcon
                                                 className={styles["extra-operate-icon"]}

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -1625,7 +1625,7 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
                 setRemoteProjectValue(RemoteGV.FuzzerSequenceCacheHistoryList, JSON.stringify(historySequenceList))
             }
         },
-        1000 * 60 * 10 /** 每10分钟执行一次*/,
+        1000 * 60 * 5 /** 每5分钟执行一次*/,
         {immediate: true}
     )
     // fuzzer-tab页数据订阅事件
@@ -4138,7 +4138,7 @@ const SubTabs: React.FC<SubTabsProps> = React.memo(
                                         )
                                     )}
                                     {isWebFuzzerRoute && (
-                                        <Tooltip title='恢复WebFuzzer标签页' placement={isExpand ? "left" : "top"}>
+                                        <Tooltip title='恢复WebFuzzer标签页;5分钟更新一次历史数据' placement={isExpand ? "left" : "top"}>
                                             <OutlineRefreshIcon
                                                 className={styles["extra-operate-icon"]}
                                                 onClick={() => onRestoreHistory(currentTabKey)}

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -2043,12 +2043,12 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
                     const itemWF = listWF[0]
                     await fetchFuzzerList(itemWF)
                 }
-            }
-            if (!!resSequence) {
-                const listSequence = JSON.parse(resSequence)
-                if (listSequence?.length > 0) {
-                    const itemSequence = listSequence[0]
-                    await onSetFuzzerSequenceCacheData(itemSequence)
+                if (!!resSequence) {
+                    const listSequence = JSON.parse(resSequence)
+                    if (listSequence?.length > 0) {
+                        const itemSequence = listSequence[0]
+                        await onSetFuzzerSequenceCacheData(itemSequence)
+                    }
                 }
             } else {
                 yakitNotify("error", "历史记录为空")

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -1627,23 +1627,7 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
     const unFuzzerCacheData = useRef<any>(null)
     // web-fuzzer多开页面缓存数据
     useEffect(() => {
-        if (!isEnpriTraceAgent()) {
-            // 如果路由中已经存在webFuzzer页面，则不需要再从缓存中初始化页面
-            if (pageCache.findIndex((ele) => ele.route === YakitRoute.HTTPFuzzer) === -1) {
-                // 触发获取web-fuzzer的缓存
-                setLoading(true)
-                getRemoteProjectValue(RemoteGV.FuzzerCache)
-                    .then((res: any) => {
-                        try {
-                            const cache = JSON.parse(res)
-                            fetchFuzzerList(cache)
-                        } catch (error) {}
-                    })
-                    .catch((e) => {})
-                    .finally(() => setTimeout(() => setLoading(false), 200))
-            }
-        }
-        getFuzzerSequenceCache()
+        onInitFuzzer()
         // 开启fuzzer-tab页内数据的订阅事件
         if (unFuzzerCacheData.current) {
             unFuzzerCacheData.current()
@@ -1663,7 +1647,25 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
             }
         }
     }, [])
-
+    const onInitFuzzer = useMemoizedFn(() => {
+        if (!isEnpriTraceAgent()) {
+            // 如果路由中已经存在webFuzzer页面，则不需要再从缓存中初始化页面
+            if (pageCache.findIndex((ele) => ele.route === YakitRoute.HTTPFuzzer) === -1) {
+                // 触发获取web-fuzzer的缓存
+                setLoading(true)
+                getRemoteProjectValue(RemoteGV.FuzzerCache)
+                    .then((res: any) => {
+                        try {
+                            const cache = JSON.parse(res)
+                            fetchFuzzerList(cache)
+                        } catch (error) {}
+                    })
+                    .catch((e) => {})
+                    .finally(() => setTimeout(() => setLoading(false), 200))
+            }
+        }
+        getFuzzerSequenceCache()
+    })
     const getFuzzerSequenceCache = useMemoizedFn(() => {
         getRemoteProjectValue(RemoteGV.FuzzerSequenceCache).then((res: any) => {
             try {

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -1672,13 +1672,13 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
                     const res = await getRemoteProjectValue(RemoteGV.FuzzerCache)
                     const cache = JSON.parse(res)
                     await fetchFuzzerList(cache)
+                    await getFuzzerSequenceCache()
                     setTimeout(() => setLoading(false), 200)
                 } catch (error) {
                     setLoading(false)
                     yakitNotify("error", `onInitFuzzer初始化WF数据失败:${error}`)
                 }
             }
-            getFuzzerSequenceCache()
         }
     })
     const getFuzzerSequenceCache = useMemoizedFn(() => {

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -1213,7 +1213,7 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
                     // webFuzzer页面二级tab名称改为WF，特殊
                     verbose =
                         nodeParams?.verbose ||
-                        `WF-[${filterPage.length > 0 ? (filterPage[0].multipleLength || 0) + 1 : 1}]`
+                        `[${filterPage.length > 0 ? (filterPage[0].multipleLength || 0) + 1 : 1}]`
                 }
                 const node: MultipleNodeInfo = {
                     id: tabId,

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContentType.d.ts
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContentType.d.ts
@@ -61,6 +61,7 @@ export interface PageCache {
     singleNode: boolean | undefined
     multipleNode: MultipleNodeInfo[] | any[]
     multipleLength?: number
+    /**@deprecated */
     hideAdd?: boolean
     pageParams?: ComponentParams
     openFlag?: boolean
@@ -94,6 +95,8 @@ export interface TabContentProps {
     openMultipleMenuPage: (route: RouteToPageProps) => void
 
     onRemove: (p: PageCache) => void
+    /**从历史中恢复tab数据 */
+    onRestoreHistory: (v: YakitRoute | string) => void
 }
 
 /**
@@ -104,6 +107,8 @@ export interface TabChildrenProps {
     currentTabKey: YakitRoute | string
     openMultipleMenuPage: (route: RouteToPageProps) => void
     onSetPageCache: (m: MultipleNodeInfo[], i: number) => void
+    /**从历史中恢复tab数据 */
+    onRestoreHistory: (v: YakitRoute | string) => void
 }
 
 /**
@@ -150,6 +155,8 @@ export interface SubTabListProps {
     onSetPageCache: (m: MultipleNodeInfo[], i: number) => void
     pageItem: PageCache
     index: number
+    /**从历史中恢复tab数据 */
+    onRestoreHistory: (v: YakitRoute | string) => void
 }
 
 export interface SubTabsProps {
@@ -167,6 +174,8 @@ export interface SubTabsProps {
 
     openMultipleMenuPage: (route: RouteToPageProps) => void
     onSetPageCache: (m: MultipleNodeInfo[]) => void
+    /**从历史中恢复tab数据 */
+    onRestoreHistory: (v: YakitRoute | string) => void
 }
 /**
  * @description 二级tab item
@@ -187,7 +196,7 @@ export interface SubTabItemProps {
     onContextMenu: (e: React.MouseEvent, subItem: MultipleNodeInfo) => void
     combineColor?: string
     /**是否可以拖拽 */
-    isDragDisabled:boolean
+    isDragDisabled: boolean
 }
 /**
  * @description 组

--- a/app/renderer/src/main/src/pages/risks/YakitRiskTable/YakitRiskTable.tsx
+++ b/app/renderer/src/main/src/pages/risks/YakitRiskTable/YakitRiskTable.tsx
@@ -524,10 +524,6 @@ export const YakitRiskTable: React.FC<YakitRiskTableProps> = React.memo((props) 
             {
                 title: "发现时间",
                 dataKey: "CreatedAt",
-                sorterProps: {
-                    sorter: true,
-                    sorterKey: "created_at"
-                },
                 render: (text) => (text ? formatTimestamp(text) : "-")
             },
             {

--- a/app/renderer/src/main/src/store/fuzzerSequence.ts
+++ b/app/renderer/src/main/src/store/fuzzerSequence.ts
@@ -182,7 +182,7 @@ try {
 
     const saveFuzzerSequenceCache = debounce(
         (selectedState) => {
-            const sequenceCache = selectedState.filter((ele) => ele.cacheData.length > 0)
+            const sequenceCache = getFuzzerSequenceProcessedCacheData(selectedState)
             // console.log("saveFuzzerSequenceCache", sequenceCache)
             setRemoteProjectValue(RemoteGV.FuzzerSequenceCache, JSON.stringify(sequenceCache)).catch((error) => {})
         },
@@ -191,4 +191,10 @@ try {
     )
 } catch (error) {
     yakitNotify("error", "webFuzzer序列化数据缓存数据失败:" + error)
+}
+
+/**处理WF-Sequence需要缓存的数据 */
+export const getFuzzerSequenceProcessedCacheData = (selectedState) => {
+    const sequenceCache = selectedState.filter((ele) => ele.cacheData.length > 0)
+    return sequenceCache
 }

--- a/app/renderer/src/main/src/store/pageInfo.ts
+++ b/app/renderer/src/main/src/store/pageInfo.ts
@@ -462,7 +462,7 @@ export const saveFuzzerCache = debounce(
             const {pageList = []} = selectedState || {
                 pageList: []
             }
-            const cache = getFuzzerCacheData(pageList)
+            const cache = getFuzzerProcessedCacheData(pageList)
             setRemoteProjectValue(RemoteGV.FuzzerCache, JSON.stringify(cache)).catch((error) => {})
         } catch (error) {
             yakitNotify("error", "webFuzzer缓存数据失败:" + error)
@@ -473,7 +473,7 @@ export const saveFuzzerCache = debounce(
 )
 
 /**处理WF需要缓存的数据 */
-export const getFuzzerCacheData = (pageList) => {
+export const getFuzzerProcessedCacheData = (pageList) => {
     const cache = pageList.map((ele) => {
         const advancedConfigValue =
             ele.pageParamsInfo?.webFuzzerPageInfo?.advancedConfigValue || defaultAdvancedConfigValue

--- a/app/renderer/src/main/src/store/pageInfo.ts
+++ b/app/renderer/src/main/src/store/pageInfo.ts
@@ -462,28 +462,7 @@ export const saveFuzzerCache = debounce(
             const {pageList = []} = selectedState || {
                 pageList: []
             }
-            const cache = pageList.map((ele) => {
-                const advancedConfigValue =
-                    ele.pageParamsInfo?.webFuzzerPageInfo?.advancedConfigValue || defaultAdvancedConfigValue
-                return {
-                    groupChildren: [],
-                    groupId: ele.pageGroupId,
-                    id: ele.pageId,
-                    pageParams: {
-                        actualHost: advancedConfigValue.actualHost || "",
-                        id: ele.pageId,
-                        isHttps: advancedConfigValue.isHttps,
-                        request: ele.pageParamsInfo?.webFuzzerPageInfo?.request || defaultPostTemplate,
-                        params: advancedConfigValue.params,
-                        extractors: advancedConfigValue.extractors,
-                        matchers: advancedConfigValue.matchers
-                    },
-                    sortFieId: ele.sortFieId,
-                    verbose: ele.pageName,
-                    expand: ele.expand,
-                    color: ele.color
-                }
-            })
+            const cache = getFuzzerCacheData(pageList)
             setRemoteProjectValue(RemoteGV.FuzzerCache, JSON.stringify(cache)).catch((error) => {})
         } catch (error) {
             yakitNotify("error", "webFuzzer缓存数据失败:" + error)
@@ -493,59 +472,29 @@ export const saveFuzzerCache = debounce(
     {leading: true}
 )
 
-/**
- * 下面注释的代码含义
- * fuzzer-tab页内数据的订阅事件，订阅数据包括request、请求参数、序列组配置信息等
- * 注释原因：
- * 软件打开后，这个订阅就会启动，导致还没连接引擎时就请求引擎相关接口，导致控制台报错
- */
-// try {
-//     const unFuzzerCacheData = usePageInfo.subscribe(
-//         // (state) => state.pages.get(YakitRoute.HTTPFuzzer) || [],
-//         (state) => state.pages.get("httpFuzzer") || [], // 因为循环引用导致开发环境热加载YakitRoute.HTTPFuzzer为undefined
-//         (selectedState, previousSelectedState) => {
-//             saveFuzzerCache(selectedState)
-//         }
-//     )
-
-//     const saveFuzzerCache = debounce(
-//         (selectedState: PageProps) => {
-//             try {
-//                 const {pageList = []} = selectedState || {
-//                     pageList: []
-//                 }
-//                 const cache = pageList.map((ele) => {
-//                     const advancedConfigValue =
-//                         ele.pageParamsInfo?.webFuzzerPageInfo?.advancedConfigValue || defaultAdvancedConfigValue
-//                     return {
-//                         groupChildren: [],
-//                         groupId: ele.pageGroupId,
-//                         id: ele.pageId,
-//                         pageParams: {
-//                             actualHost: advancedConfigValue.actualHost || "",
-//                             id: ele.pageId,
-//                             isHttps: advancedConfigValue.isHttps,
-//                             request: ele.pageParamsInfo?.webFuzzerPageInfo?.request || defaultPostTemplate,
-//                             params: advancedConfigValue.params,
-//                             extractors: advancedConfigValue.extractors
-//                         },
-//                         sortFieId: ele.sortFieId,
-//                         verbose: ele.pageName,
-//                         expand: ele.expand,
-//                         color: ele.color
-//                     }
-//                 })
-//                 // console.log("saveFuzzerCache", cache)
-//                 // console.table(pageList)
-//                 console.log("cache", cache)
-//                 setRemoteProjectValue(RemoteGV.FuzzerCache, JSON.stringify(cache)).catch((error) => {})
-//             } catch (error) {
-//                 yakitNotify("error", "webFuzzer缓存数据失败:" + error)
-//             }
-//         },
-//         500,
-//         {leading: true}
-//     )
-// } catch (error) {
-//     yakitNotify("error", "page-info缓存数据错误:" + error)
-// }
+/**处理WF需要缓存的数据 */
+export const getFuzzerCacheData = (pageList) => {
+    const cache = pageList.map((ele) => {
+        const advancedConfigValue =
+            ele.pageParamsInfo?.webFuzzerPageInfo?.advancedConfigValue || defaultAdvancedConfigValue
+        return {
+            groupChildren: [],
+            groupId: ele.pageGroupId,
+            id: ele.pageId,
+            pageParams: {
+                actualHost: advancedConfigValue.actualHost || "",
+                id: ele.pageId,
+                isHttps: advancedConfigValue.isHttps,
+                request: ele.pageParamsInfo?.webFuzzerPageInfo?.request || defaultPostTemplate,
+                params: advancedConfigValue.params,
+                extractors: advancedConfigValue.extractors,
+                matchers: advancedConfigValue.matchers
+            },
+            sortFieId: ele.sortFieId,
+            verbose: ele.pageName,
+            expand: ele.expand,
+            color: ele.color
+        }
+    })
+    return cache
+}

--- a/app/renderer/src/main/src/yakitGV.ts
+++ b/app/renderer/src/main/src/yakitGV.ts
@@ -62,6 +62,8 @@ export enum RemoteGV {
     FuzzerCacheHistoryList = "fuzzer-list-cache-history-list",
     /** @name webFuzzer页面以及每个页面的数据缓存字段 */
     FuzzerCache = "fuzzer-list-cache",
+    /** @name webFuzzer序列的缓存历史缓存记录 */
+    FuzzerSequenceCacheHistoryList = "fuzzer_sequence_cache-history-list",
     /** @name webFuzzer序列的缓存字段 */
     FuzzerSequenceCache = "fuzzer_sequence_cache",
     /** @name history页面左侧tabs */
@@ -99,15 +101,15 @@ export enum RemoteGV {
     /**@name RiskPage页面中,高级查询内容的显/隐 */
     RiskQueryShow = "risk-query-show",
     /**@name Home开始扫描 */
-    HomeStartScanning="home_start_scanning",
+    HomeStartScanning = "home_start_scanning",
     /**@name xterm全局配置(字体样式、字体大小) */
-    YakitXtermSetting="yakit_xterm_setting",
+    YakitXtermSetting = "yakit_xterm_setting",
     /**@name 端口监听器缓存的监听主机 */
-    ReverseShellReceiverHostList="reverse-shell-receiver-host-list",
+    ReverseShellReceiverHostList = "reverse-shell-receiver-host-list",
     /**@name YakitDraggerContent组件限制文件大小 */
     YakitDraggerContentFileLimit = "yakit_dragger_content_file_limit",
     /**@name mitm禁用初始页 */
-    MITMDisableCACertPage = "mitm_disable_CACertPage",
+    MITMDisableCACertPage = "mitm_disable_CACertPage"
 }
 
 /** 项目逻辑全局变量 */

--- a/app/renderer/src/main/src/yakitGV.ts
+++ b/app/renderer/src/main/src/yakitGV.ts
@@ -109,7 +109,9 @@ export enum RemoteGV {
     /**@name YakitDraggerContent组件限制文件大小 */
     YakitDraggerContentFileLimit = "yakit_dragger_content_file_limit",
     /**@name mitm禁用初始页 */
-    MITMDisableCACertPage = "mitm_disable_CACertPage"
+    MITMDisableCACertPage = "mitm_disable_CACertPage",
+    /**@name 缓存一级菜单选择的tab的key值 */
+    SelectFirstMenuTabKey = "select-first-menu-tab-key",
 }
 
 /** 项目逻辑全局变量 */

--- a/app/renderer/src/main/src/yakitGV.ts
+++ b/app/renderer/src/main/src/yakitGV.ts
@@ -58,6 +58,8 @@ export enum RemoteGV {
     /** @name chat-cs聊天记录 */
     ChatCSStorage = "chat-cs-storage",
 
+    /** @name webFuzzer页面的二级菜单tab数据历史缓存记录 */
+    FuzzerCacheHistoryList = "fuzzer-list-cache-history-list",
     /** @name webFuzzer页面以及每个页面的数据缓存字段 */
     FuzzerCache = "fuzzer-list-cache",
     /** @name webFuzzer序列的缓存字段 */


### PR DESCRIPTION
1.保存所有的tab页，10min覆盖之前的，有tab数据才保存，没有数据不保存
2.关闭时如果当前打开页面是webfuzzer，重新打开yakit的时候会在自动加载二级页签；如果不是，则打开webfuzzer以后再加载二级页签
3.打开yakit默认打开首页
4.没打开webfuzzer前，从其他地方发送到webfuzzer需要加载之前的二级页签，再增加新的页签
5.webfuzzer的名字改短，只留数字，不要WF
6.没有一级菜单选中项的缓存的时候，默认加载WF页面的缓存tab数据
7.一级菜单缓存数据跟yakit缓存走，不跟项目缓存走

选二