### PR TITLE
fix: history-qs

### DIFF
--- a/app/renderer/src/main/src/utils/optimizeRender.ts
+++ b/app/renderer/src/main/src/utils/optimizeRender.ts
@@ -1,0 +1,30 @@
+import {SetStateAction} from "react"
+
+/**
+ * @name 对于超大内容字符串的拆分定时赋值
+ * @description 拆分段长度 1000 * 1024， mei 1000ms 赋值一次
+ */
+export function asynSettingState(value: string, setValue: React.Dispatch<SetStateAction<string>>): NodeJS.Timeout {
+    const contents = value || ""
+    const strs: string[] = []
+    const maxLength = Math.ceil(contents.length / 1000 / 1024)
+    for (let i = 0; i < maxLength; i++) {
+        strs.push(contents.slice(i * 1000 * 1024, (i + 1) * 1000 * 1024))
+    }
+
+    let number = 0
+    const content = strs[number]
+    setValue(content)
+    number += 1
+    let timer = setInterval(() => {
+        if (number === strs.length) {
+            clearInterval(timer)
+            return
+        }
+        const content = strs[number]
+        setValue((old) => old + content)
+        number += 1
+    }, 1000)
+
+    return timer
+}


### PR DESCRIPTION
1、新增 对于超大内容的分片赋值 State 函数
2、修复 history 上下跳卡顿问题(超大内容渲染的卡顿，销毁卡顿无法解决)
3、history 在未显示时，堆积数据超过200条，则初始化表格