### PR TITLE
support json-schema in yakparameter 

### DIFF
--- a/app/protos/grpc.proto
+++ b/app/protos/grpc.proto
@@ -3924,6 +3924,7 @@ message YakScriptParam {
   string ExtraSetting = 8;
 
   string MethodType = 9;
+  string JsonSchema = 10;
 }
 
 message YakScript {

--- a/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard.tsx
+++ b/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard.tsx
@@ -723,6 +723,9 @@ export const OutputFormComponentsByType: React.FC<OutputFormComponentsByTypeProp
                     <YakitEditor type={language} readOnly={disabled} />
                 </Form.Item>
             )
+        case "json":
+            console.log("item: ", item );
+            return <></>
         default:
             return <></>
     }

--- a/app/renderer/src/main/src/pages/plugins/pluginsType.d.ts
+++ b/app/renderer/src/main/src/pages/plugins/pluginsType.d.ts
@@ -73,6 +73,7 @@ export interface YakParamProps {
     Group?: string
     /** 后端自定义内容 */
     MethodType?: string
+    JsonSchema?:string
     /** 值 */
     Value?: any
 


### PR DESCRIPTION
需要支持json-schema：

* 在线浏览：https://rjsf-team.github.io/react-jsonschema-form/ 请选择  "If-Then-Else"  
> 需要支持: If-Then-Else  allOf 
* 后端ref: https://github.com/yaklang/yaklang/pull/2159  


# 需要支持的代码
```
yakit.AutoInitYakit()

# Input your code!

cli.Json("a", cli.setJsonSchema(<<<JSON
{
  "type": "object",
  "properties": {
    "animal": {
      "enum": [
        "Cat",
        "Fish"
      ]
    }
  },
  "allOf": [
    {
      "if": {
        "properties": {
          "animal": {
            "const": "Cat"
          }
        }
      },
      "then": {
        "properties": {
          "food": {
            "type": "string",
            "enum": [
              "meat",
              "grass",
              "fish"
            ]
          }
        },
        "required": [
          "food"
        ]
      }
    },
    {
      "if": {
        "properties": {
          "animal": {
            "const": "Fish"
          }
        }
      },
      "then": {
        "properties": {
          "food": {
            "type": "string",
            "enum": [
              "insect",
              "worms"
            ]
          },
          "water": {
            "type": "string",
            "enum": [
              "lake",
              "sea"
            ]
          }
        },
        "required": [
          "food",
          "water"
        ]
      }
    },
    {
      "required": [
        "animal"
      ]
    }
  ]
}
JSON))
cli.check()
```