### PR TITLE
fix:audit history use syntaxflow language highlight

### DIFF
--- a/app/renderer/src/main/src/pages/yakRunnerAuditCode/AuditCode/AuditCode.tsx
+++ b/app/renderer/src/main/src/pages/yakRunnerAuditCode/AuditCode/AuditCode.tsx
@@ -118,6 +118,7 @@ import {YakitPopover} from "@/components/yakitUI/YakitPopover/YakitPopover"
 import {NewHTTPPacketEditor} from "@/utils/editors"
 import {YakitDropdownMenu} from "@/components/yakitUI/YakitDropdownMenu/YakitDropdownMenu"
 import {YakitHint} from "@/components/yakitUI/YakitHint/YakitHint"
+import { SyntaxFlowMonacoSpec } from "@/utils/monacoSpec/syntaxflowEditor"
 
 const {ipcRenderer} = window.require("electron")
 
@@ -1173,6 +1174,7 @@ export const AuditHistoryList: React.FC<AuditHistoryListProps> = React.memo(
                                                     noMinimap={true}
                                                     noHeader={true}
                                                     showDownBodyMenu={false}
+                                                    language={SyntaxFlowMonacoSpec}
                                                 />
                                             </div>
                                         }


### PR DESCRIPTION
代码审计历史的悬浮提示使用了NewHTTPPacketEditor，应该指定语言为"syntaxflow"，不然将会使用默认的http语法高亮。