### PR TITLE
fix: link-engine-qs

### DIFF
--- a/app/main/handlers/engineStatus.js
+++ b/app/main/handlers/engineStatus.js
@@ -169,10 +169,9 @@ module.exports = (win, callback, getClient, newClient) => {
                 const resultParams = isEnpriTraceAgent ? [...extraParams, "--disable-output"] : extraParams
 
                 const subprocess = childProcess.spawn(getLocalYaklangEngine(), resultParams, {
-                    // stdio: ["ignore", "ignore", "ignore"]
                     detached: false,
                     windowsHide: true,
-                    stdio: ["ignore", log, log],
+                    stdio: ["ignore", "pipe", "pipe"],
                     env: {
                         ...process.env,
                         YAKIT_HOME: YakitProjectPath
@@ -205,6 +204,21 @@ module.exports = (win, callback, getClient, newClient) => {
                             }, 1000)
                         }
                     })
+                })
+
+                subprocess.stdout.on("data", (data) => {
+                    try {
+                        toLog(`${data.toString()}`)
+                        // const match = data.toString().match(/\[\w+:\d+]\s+(.*)/)[1]
+                        if (typeof log !== "string") fs.write(log, data, (err) => {})
+                    } catch (error) {}
+                })
+                subprocess.stderr.on("data", (data) => {
+                    try {
+                        toLog(`${data.toString()}`)
+                        // const match = data.toString().match(/\[\w+:\d+]\s+(.*)/)[1]
+                        if (typeof log !== "string") fs.write(log, data, (err) => {})
+                    } catch (error) {}
                 })
                 resolve()
             } catch (e) {

--- a/app/main/handlers/engineStatus.js
+++ b/app/main/handlers/engineStatus.js
@@ -3,22 +3,9 @@ const childProcess = require("child_process")
 const _sudoPrompt = require("sudo-prompt")
 const {GLOBAL_YAK_SETTING} = require("../state")
 const {testRemoteClient} = require("../ipc")
-const {getLocalYaklangEngine, engineLog, YakitProjectPath} = require("../filePath")
+const {getLocalYaklangEngine, YakitProjectPath} = require("../filePath")
 const net = require("net")
-const fs = require("fs")
-const path = require("path")
-const {getNowTime} = require("../toolsFunc")
-
-/** 引擎错误日志 */
-const logPath = path.join(engineLog, `engine-log-${getNowTime()}.txt`)
-let out = null
-fs.open(logPath, "a", (err, fd) => {
-    if (err) {
-        console.log("获取本地引擎日志错误：", err)
-    } else {
-        out = fd
-    }
-})
+const {engineLogOutputFileAndUI, engineLogOutputUI} = require("../logFile")
 
 let dbFile = undefined
 
@@ -44,8 +31,6 @@ function isPortAvailable(port) {
     })
 }
 
-function isPortOpen(port) {}
-
 const isWindows = process.platform === "win32"
 
 /** @name 生成windows系统的管理员权限命令 */
@@ -64,35 +49,22 @@ const isWindows = process.platform === "win32"
 //     }
 // }
 
-const engineStdioOutputFactory = (win) => (buf) => {
-    if (win) {
-        win.webContents.send("live-engine-stdio", buf.toString("utf-8"))
-    }
-}
-
-const engineLogOutputFactory = (win) => (message) => {
-    if (win) {
-        console.info(message)
-        win.webContents.send("live-engine-log", message + "\n")
-    }
-}
-
 const ECHO_TEST_MSG = "Hello Yakit!"
 
 module.exports = (win, callback, getClient, newClient) => {
-    // 输出到欢迎页面的 output 中
-    const toStdout = engineStdioOutputFactory(win)
-    // 输出到日志中
-    const toLog = engineLogOutputFactory(win)
-
     /** 获取本地引擎版本号 */
     ipcMain.handle("fetch-yak-version", () => {
         try {
+            engineLogOutputFileAndUI(win, `----- 获取正在连接引擎的版本号 -----`)
             getClient().Version({}, async (err, data) => {
-                if (win && data.Version) win.webContents.send("fetch-yak-version-callback", data.Version)
-                else win.webContents.send("fetch-yak-version-callback", "")
+                if (win && data.Version) {
+                    engineLogOutputFileAndUI(win, `----- 正在连接引擎的版本号: ${data.Version} -----`)
+                    win.webContents.send("fetch-yak-version-callback", data.Version)
+                } else win.webContents.send("fetch-yak-version-callback", "")
             })
         } catch (e) {
+            engineLogOutputFileAndUI(win, `----- 获取正在连接引擎版本号失败 -----`)
+            engineLogOutputFileAndUI(win, `${e}`)
             win.webContents.send("fetch-yak-version-callback", "")
         }
     })
@@ -158,16 +130,16 @@ module.exports = (win, callback, getClient, newClient) => {
         const {port, isEnpriTraceAgent, isIRify} = params
         return new Promise((resolve, reject) => {
             try {
-                toLog("已启动本地引擎进程")
+                engineLogOutputFileAndUI(win, `----- 已启动本地引擎进程 -----`)
                 if (isIRify) {
                     dbFile = ["--profile-db", "irify-profile-rule.db", "--project-db", "default-irify.db"]
                 }
-                const log = out ? out : "ignore"
 
                 const grpcPort = ["grpc", "--port", `${port}`, "--frontend", `${version || "yakit"}`]
                 const extraParams = dbFile ? [...grpcPort, ...dbFile] : grpcPort
                 const resultParams = isEnpriTraceAgent ? [...extraParams, "--disable-output"] : extraParams
 
+                engineLogOutputFileAndUI(win, `启动命令: ${getLocalYaklangEngine()} ${resultParams.join(" ")}`)
                 const subprocess = childProcess.spawn(getLocalYaklangEngine(), resultParams, {
                     detached: false,
                     windowsHide: true,
@@ -184,40 +156,25 @@ module.exports = (win, callback, getClient, newClient) => {
                     subprocess.kill()
                 })
                 subprocess.on("error", (err) => {
-                    toLog(`本地引擎遭遇错误，错误原因为：${err}`)
+                    engineLogOutputFileAndUI(win, `----- 本地引擎遭遇错误，错误原因 -----`)
+                    engineLogOutputFileAndUI(win, err)
                     win.webContents.send("start-yaklang-engine-error", `本地引擎遭遇错误，错误原因为：${err}`)
                     reject(err)
                 })
                 subprocess.on("close", async (e) => {
-                    toLog(`本地引擎退出，退出码为：${e}`)
-                    fs.readFile(engineLog, (err, data) => {
-                        if (err) {
-                            console.log("读取引擎文件失败", err)
-                        } else {
-                            toStdout(data)
-                            setTimeout(() => {
-                                try {
-                                    fs.unlinkSync(engineLog)
-                                } catch (e) {
-                                    console.info(`unlinkSync 'engine.log' local cache failed: ${e}`, e)
-                                }
-                            }, 1000)
-                        }
-                    })
+                    engineLogOutputFileAndUI(win, `----- 本地引擎退出，退出码为：${e} -----`)
                 })
 
                 subprocess.stdout.on("data", (data) => {
                     try {
-                        toLog(`${data.toString()}`)
-                        // const match = data.toString().match(/\[\w+:\d+]\s+(.*)/)[1]
-                        if (typeof log !== "string") fs.write(log, data, (err) => {})
+                        // const match = data.toString("utf-8").match(/\[\w+:\d+]\s+(.*)/)[1]
+                        engineLogOutputFileAndUI(win, `${data.toString("utf-8")}`)
                     } catch (error) {}
                 })
                 subprocess.stderr.on("data", (data) => {
                     try {
-                        toLog(`${data.toString()}`)
-                        // const match = data.toString().match(/\[\w+:\d+]\s+(.*)/)[1]
-                        if (typeof log !== "string") fs.write(log, data, (err) => {})
+                        // const match = data.toString("utf-8").match(/\[\w+:\d+]\s+(.*)/)[1]
+                        engineLogOutputFileAndUI(win, `${data.toString("utf-8")}`)
                     } catch (error) {}
                 })
                 resolve()
@@ -279,8 +236,8 @@ module.exports = (win, callback, getClient, newClient) => {
             hostFormatted = `${hostRaw.substr(0, hostRaw.lastIndexOf(":"))}`
         }
         const addr = `${hostFormatted}:${portFromRaw}`
-        toLog(`原始参数为: ${JSON.stringify(params)}`)
-        toLog(`开始连接引擎地址为：${addr} Host: ${hostRaw} Port: ${portFromRaw}`)
+        engineLogOutputFileAndUI(win, `原始参数为: ${JSON.stringify(params)}`)
+        engineLogOutputFileAndUI(win, `开始连接引擎地址为：${addr} Host: ${hostRaw} Port: ${portFromRaw}`)
         GLOBAL_YAK_SETTING.defaultYakGRPCAddr = addr
 
         callback(
@@ -303,12 +260,9 @@ module.exports = (win, callback, getClient, newClient) => {
         })
     })
 
-    /** 断开引擎(暂未使用) */
-    ipcMain.handle("break-yaklalng-engine", () => {})
-
     /** 输出到欢迎界面的日志中 */
     ipcMain.handle("output-log-to-welcome-console", (e, msg) => {
-        toLog(`${msg}`)
+        engineLogOutputUI(win, `${msg}`, true)
     })
 
     /** 调用命令生成运行节点 */

--- a/app/main/index.js
+++ b/app/main/index.js
@@ -12,6 +12,7 @@ const Screenshots = require("./screenshots")
 const windowStateKeeper = require("electron-window-state")
 const {clearFolder} = require("./toolsFunc")
 const {MenuTemplate} = require("./menu")
+const {fetchEngineLogFile, closeEngineLogFile} = require("./logFile")
 
 /** 获取缓存数据-软件是否需要展示关闭二次确认弹框 */
 const UICloseFlag = "windows-close-flag"
@@ -168,11 +169,16 @@ app.whenReady().then(() => {
 
     // 软件退出的逻辑
     ipcMain.handle("app-exit", async (e, params) => {
-        const {showCloseMessageBox,isIRify} = params
+        const {showCloseMessageBox, isIRify} = params
         if (closeFlag && showCloseMessageBox) {
             dialog
                 .showMessageBox(win, {
-                    icon: nativeImage.createFromPath(path.join(__dirname, isIRify?"../renderer/src/main/src/assets/yakitSS.png":"../assets/yakitlogo.pic.jpg")),
+                    icon: nativeImage.createFromPath(
+                        path.join(
+                            __dirname,
+                            isIRify ? "../renderer/src/main/src/assets/yakitSS.png" : "../assets/yakitlogo.pic.jpg"
+                        )
+                    ),
                     type: "none",
                     title: "提示",
                     defaultId: 0,
@@ -192,6 +198,7 @@ app.whenReady().then(() => {
                     } else if (res.response === 1) {
                         win = null
                         clearing()
+                        closeEngineLogFile()
                         app.exit()
                     } else {
                         e.preventDefault()
@@ -203,6 +210,7 @@ app.whenReady().then(() => {
             await asyncKillDynamicControl()
             win = null
             clearing()
+            closeEngineLogFile()
             app.exit()
         }
     })
@@ -217,6 +225,7 @@ app.whenReady().then(() => {
 
     try {
         registerIPC(win)
+        fetchEngineLogFile()
     } catch (e) {}
 
     //

--- a/app/main/ipc.js
+++ b/app/main/ipc.js
@@ -113,7 +113,10 @@ function testEngineAvaiableVersion(params) {
         try {
             const {port, version} = params
             const yak = new Yak(`127.0.0.1:${port}`, grpc.credentials.createInsecure(), options)
-            yak.Handshake({Name: version}, (err, data) => {
+            const deadline = new Date()
+            // 设置超时时间为3秒
+            deadline.setSeconds(deadline.getSeconds() + 3)
+            yak.Handshake({Name: version}, {deadline}, (err, data) => {
                 if (err) {
                     reject(err)
                     return

--- a/app/main/logFile.js
+++ b/app/main/logFile.js
@@ -1,0 +1,94 @@
+const path = require("path")
+const fs = require("fs")
+const {engineLog} = require("./filePath")
+
+/** 生成时间字符 (YYYYMMDDHHMMSS) */
+const getFormattedDateTime = () => {
+    const date = new Date()
+
+    // 提取各时间单位（注意月份要 +1）
+    const year = date.getFullYear()
+    const month = (date.getMonth() + 1).toString().padStart(2, "0") // 补零到两位
+    const day = date.getDate().toString().padStart(2, "0")
+    const hours = date.getHours().toString().padStart(2, "0")
+    const minutes = date.getMinutes().toString().padStart(2, "0")
+    const seconds = date.getSeconds().toString().padStart(2, "0")
+
+    // 拼接成 YYYYMMDDHHMMSS
+    return `${year}${month}${day}${hours}${minutes}${seconds}`
+}
+
+// #region 引擎日志
+/** 引擎日志文件句柄 */
+let engineLogFile = null
+
+/** 打开引擎日志文件，并获取文件句柄 */
+const fetchEngineLogFile = () => {
+    const engineLogPath = path.join(engineLog, `engine-log-${getFormattedDateTime()}.txt`)
+    fs.open(engineLogPath, "a", (err, fd) => {
+        if (err) {
+            console.error("打开引擎日志错误: ", err)
+            return
+        } else {
+            engineLogFile = fd
+            fs.write(engineLogFile, `---------- 开始记录引擎相关日志 ----------\n`, (err) => {})
+        }
+    })
+}
+
+/** 关闭引擎日志文件 */
+const closeEngineLogFile = () => {
+    if (engineLogFile) {
+        fs.close(engineLogFile, (err) => {
+            if (err) {
+                console.error("关闭引擎日志错误: ", err)
+            }
+        })
+        engineLogFile = null
+    }
+}
+
+/** 引擎日志-往文件里输出信息 */
+const engineLogOutputFile = (message) => {
+    if (engineLogFile) {
+        fs.write(engineLogFile, `${message}\n`, (err) => {
+            if (err) {
+                console.error("写入引擎日志错误: ", err)
+            }
+        })
+    }
+}
+
+/**
+ * 引擎日志-往UI里输出信息
+ * @param {Boolean} isTitle 是否带标题([IFNO] ...)
+ */
+const engineLogOutputUI = (win, message, isTitle) => {
+    const channle = !!isTitle ? "live-engine-log" : "live-engine-stdio"
+    try {
+        if (win) {
+            win.webContents.send(channle, `${message}\n`)
+        }
+    } catch (error) {
+        console.log("engineLogOutputUI", error)
+    }
+}
+
+/**
+ * 引擎日志-往UI和文件里输出信息
+ * @param {Boolean} isTitle 是否带标题([IFNO] ...)
+ */
+const engineLogOutputFileAndUI = (win, message, isTitle) => {
+    engineLogOutputFile(message)
+    engineLogOutputUI(win, message, isTitle)
+}
+// #endregion
+
+module.exports = {
+    engineLogFile,
+    fetchEngineLogFile,
+    closeEngineLogFile,
+    engineLogOutputFile,
+    engineLogOutputUI,
+    engineLogOutputFileAndUI
+}

--- a/app/renderer/src/main/src/NewApp.tsx
+++ b/app/renderer/src/main/src/NewApp.tsx
@@ -38,12 +38,11 @@ function NewApp() {
     const [agreed, setAgreed] = useState(false)
     const {userInfo} = useStore()
     const {setGoogleChromePluginPath} = useGoogleChromePluginPath()
-    //设置echarts 颜色
-    useEffect(() => {
-        setChartsColorList()
-    }, [])
 
+    // 软件初始化配置
     useEffect(() => {
+        // 设置echarts颜色(替换原始颜色)
+        setChartsColorList()
         // 解压命令执行引擎脚本压缩包
         ipcRenderer.invoke("generate-start-engine")
         // 解压Google 插件压缩包

--- a/app/renderer/src/main/src/components/basics/YakitLoading.tsx
+++ b/app/renderer/src/main/src/components/basics/YakitLoading.tsx
@@ -221,6 +221,32 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
                 </>
             )
         }
+        if (yakitStatus === "engine-error") {
+            return (
+                <>
+                    <YakitButton
+                        className={styles["btn-style"]}
+                        size='max'
+                        loading={restartLoading}
+                        onClick={() => btnClickCallback("engine-error")}
+                    >
+                        重置引擎版本
+                    </YakitButton>
+
+                    <YakitButton
+                        className={styles["btn-style"]}
+                        size='max'
+                        type='outline2'
+                        loading={restartLoading}
+                        onClick={() => btnClickCallback(engineMode === "local" ? "remote" : "local")}
+                    >
+                        切换为{engineMode === "local" ? "远程" : "本地"}模式
+                    </YakitButton>
+
+                    <div>{changePortBtn()}</div>
+                </>
+            )
+        }
 
         if (yakitStatus === "control-remote") {
             return (
@@ -334,7 +360,11 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
                         <div className={styles["log-wrapper"]}>
                             <div className={styles["log-body"]}>
                                 {checkLog.map((item, index) => {
-                                    return <div key={item}>{item}</div>
+                                    return (
+                                        <div key={item} className={styles["log-item"]}>
+                                            {item}
+                                        </div>
+                                    )
                                 })}
                             </div>
                         </div>

--- a/app/renderer/src/main/src/components/basics/YakitLoading.tsx
+++ b/app/renderer/src/main/src/components/basics/YakitLoading.tsx
@@ -159,6 +159,12 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
                     >
                         切换为{engineMode === "local" ? "远程" : "本地"}模式
                     </YakitButton>
+
+                    <div>
+                        <YakitButton size='max' type='text' onClick={() => setShowEngineLog(!showEngineLog)}>
+                            {showEngineLog ? "隐藏日志" : "查看日志"}
+                        </YakitButton>
+                    </div>
                 </>
             )
         }
@@ -185,7 +191,13 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
                         切换为{engineMode === "local" ? "远程" : "本地"}模式
                     </YakitButton>
 
-                    <div>{changePortBtn()}</div>
+                    <div>
+                        <YakitButton size='max' type='text' onClick={() => setShowEngineLog(!showEngineLog)}>
+                            {showEngineLog ? "隐藏日志" : "查看日志"}
+                        </YakitButton>
+                        <Divider type='vertical' style={{margin: 0}} />
+                        {changePortBtn()}
+                    </div>
                 </>
             )
         }
@@ -243,7 +255,13 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
                         切换为{engineMode === "local" ? "远程" : "本地"}模式
                     </YakitButton>
 
-                    <div>{changePortBtn()}</div>
+                    <div>
+                        <YakitButton size='max' type='text' onClick={() => setShowEngineLog(!showEngineLog)}>
+                            {showEngineLog ? "隐藏日志" : "查看日志"}
+                        </YakitButton>
+                        <Divider type='vertical' style={{margin: 0}} />
+                        {changePortBtn()}
+                    </div>
                 </>
             )
         }
@@ -286,7 +304,13 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
             )
         }
 
-        return <></>
+        return (
+            <div>
+                <YakitButton size='max' type='text' onClick={() => setShowEngineLog(!showEngineLog)}>
+                    {showEngineLog ? "隐藏日志" : "查看日志"}
+                </YakitButton>
+            </div>
+        )
     }, [yakitStatus, restartLoading, remoteControlRefreshLoading, engineMode, showEngineLog])
 
     /** 加载页随机宣传语 */

--- a/app/renderer/src/main/src/components/basics/yakitLoading.module.scss
+++ b/app/renderer/src/main/src/components/basics/yakitLoading.module.scss
@@ -102,6 +102,9 @@
                     width: 500px;
                     max-height: 180px;
                     overflow: hidden auto;
+                    .log-item{
+                        white-space: break-spaces;
+                    }
                 }
             }
         }

--- a/app/renderer/src/main/src/components/layout/LocalEngine/LocalEngine.tsx
+++ b/app/renderer/src/main/src/components/layout/LocalEngine/LocalEngine.tsx
@@ -263,7 +263,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
                     grpcFetchLocalYakVersionHash()
                 ])
 
-                if (res1 === "" || !Array.isArray(res2) || res2.length === 0) {
+                if (!res1 || !Array.isArray(res2) || res2.length === 0) {
                     setLog((old) => old.concat(["未知异常情况，无法检测来源，准备连接引擎"]))
                     handleLinkLocalEnging()
                 } else {

--- a/app/renderer/src/main/src/components/layout/LocalEngine/LocalEngineType.d.ts
+++ b/app/renderer/src/main/src/components/layout/LocalEngine/LocalEngineType.d.ts
@@ -1,5 +1,5 @@
 import React, {Dispatch, SetStateAction} from "react"
-import {YakitSystem} from "@/yakitGVDefine"
+import {YakitStatusType, YakitSystem} from "@/yakitGVDefine"
 
 export interface LocalEngineProps {
     ref?: React.ForwardedRef<LocalEngineLinkFuncProps>
@@ -15,4 +15,6 @@ export interface LocalEngineLinkFuncProps {
     init: () => any
     /** 检查引擎版本后的本地连接 */
     link: () => any
+    /** 引擎版本问题后的内置版本解压弹框确认 */
+    resetBuiltIn: () => void
 }

--- a/app/renderer/src/main/src/components/layout/LocalEngine/LocalEngineType.d.ts
+++ b/app/renderer/src/main/src/components/layout/LocalEngine/LocalEngineType.d.ts
@@ -3,7 +3,6 @@ import {YakitStatusType, YakitSystem} from "@/yakitGVDefine"
 
 export interface LocalEngineProps {
     ref?: React.ForwardedRef<LocalEngineLinkFuncProps>
-    system: YakitSystem
     setLog: Dispatch<SetStateAction<string[]>>
     onLinkEngine: (port: number) => any
     setYakitStatus: (v: YakitStatusType) => any

--- a/app/renderer/src/main/src/components/layout/UILayout.tsx
+++ b/app/renderer/src/main/src/components/layout/UILayout.tsx
@@ -563,6 +563,11 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
                 handleLinkLocalMode()
                 return
 
+            case "engine-error":
+                setTimeoutLoading(setRestartLoading)
+                if (localEngineRef.current) localEngineRef.current.resetBuiltIn()
+                return
+
             default:
                 return
         }

--- a/app/renderer/src/main/src/components/layout/UILayout.tsx
+++ b/app/renderer/src/main/src/components/layout/UILayout.tsx
@@ -1746,7 +1746,6 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
 
                         <LocalEngine
                             ref={localEngineRef}
-                            system={system}
                             setLog={setCheckLog}
                             onLinkEngine={handleLinkLocalEngine}
                             setYakitStatus={setYakitStatus}

--- a/app/renderer/src/main/src/yakitGVDefine.d.ts
+++ b/app/renderer/src/main/src/yakitGVDefine.d.ts
@@ -38,11 +38,10 @@ export type YakitStatusType =
     | "ready" // 开始尝试连接引擎
     | "control-remote" // 远程控制中(不是远程连接)
     | "control-remote-timeout" // 远程控制连接超时
+    | "engine-error" // 引擎文件问题
     | ""
 /** @name 引擎其他操作 */
-export type EngineOtherOperation = 
-    | "changePort"
-    | ""
+export type EngineOtherOperation = "changePort" | ""
 
 /** @name funcDomain组件-全局setting功能的点击回调事件类型 */
 export type YakitSettingCallbackType = "console" | "break" | "changeProject" | "encryptionProject" | "plaintextProject"


### PR DESCRIPTION
1. 将启动引擎的进程命令输出接入 yakit 日志里
2. 对引擎获取可用端口的功能, 进行输出内容的匹配，将获取更详细错误信息，同时可用端口信息进行封装，更好的定位数据并获取
3. 新增 yakit 状态'engine-error', 该状态下显示重置内置引擎功能, 应对获取可用端口失败的情况