### PR TITLE
fix: close page qs

### DIFF
--- a/app/renderer/src/main/src/components/layout/GlobalState.tsx
+++ b/app/renderer/src/main/src/components/layout/GlobalState.tsx
@@ -1169,7 +1169,7 @@ export const GlobalState: React.FC<GlobalReverseStateProp> = React.memo((props) 
                 title='是否确认关闭节点'
                 content='确认后节点将会关闭，运行在节点上的任务也会停止'
                 footerExtra={
-                    <YakitCheckbox value={noPrompt} onChange={(e) => setNoPrompt(e.target.checked)}>
+                    <YakitCheckbox checked={noPrompt} onChange={(e) => setNoPrompt(e.target.checked)}>
                         下次不再提醒
                     </YakitCheckbox>
                 }

--- a/app/renderer/src/main/src/components/layout/WinUIOp.tsx
+++ b/app/renderer/src/main/src/components/layout/WinUIOp.tsx
@@ -178,7 +178,7 @@ export const TemporaryProjectPop: React.FC<TemporaryProjectPopProp> = (props) =>
             title={props.title || "退出临时项目"}
             footerExtra={
                 <YakitCheckbox
-                    value={temporaryProjectNoPrompt}
+                    checked={temporaryProjectNoPrompt}
                     onChange={(e) => setTemporaryProjectNoPrompt(e.target.checked)}
                 >
                     下次不再提醒


### PR DESCRIPTION
1. 处理checkbox错误使用 value 属性问题
2. 处理Ctrl+w能关闭固定 tab 流量分析
3. 处理刚打开yakit，随便打开一个单页面(例如插件仓库)，然后Ctrl+w关闭页面，虽然聚焦 tab 回到上一个，但是单页面没有被关闭问题