### PR TITLE
fix(theme): 调整多处组件样式与颜色

### DIFF
--- a/app/renderer/src/main/src/assets/global.scss
+++ b/app/renderer/src/main/src/assets/global.scss
@@ -4,7 +4,7 @@ $colors: (
     red: (
         backgroundColor: var(--Colors-Use-Error-Primary),
         opacityBackgroundColor: var(--Colors-Use-Error-Pressed),
-        textColor: var(--yakit-colors-Error-100),
+        textColor: var(--Colors-Use-Error-On-Primary),
         fontWeight: bold
     ),
     green: (
@@ -56,9 +56,9 @@ $colors: (
         fontWeight: normal
     ),
     grey: (
-        backgroundColor: var(--Colors-Use-Neutral-Disable),
-        opacityBackgroundColor: var(--Colors-Use-Neutral-Text-4-Help-text),
-        textColor: var(--Colors-Use-Neutral-Text-1-Title),
+        backgroundColor: var(--Colors-Use-Grey-Primary),
+        opacityBackgroundColor: var(--Colors-Use-Grey-Bg-Hover),
+        textColor: var(--Colors-Use-Grey-On-Primary),
         fontWeight: normal
     )
 );

--- a/app/renderer/src/main/src/components/basics/yakitLoading.module.scss
+++ b/app/renderer/src/main/src/components/basics/yakitLoading.module.scss
@@ -37,7 +37,7 @@
                 text-align: center;
                 font-size: 16px;
                 line-height: 24px;
-                color: var(--Colors-Use-Neutral-Text-1-Title);
+                color: var(--Colors-Use-Neutral-Text-3-Secondary);
             }
         }
 

--- a/app/renderer/src/main/src/components/businessUI/PluginTabs/PluginTabs.module.scss
+++ b/app/renderer/src/main/src/components/businessUI/PluginTabs/PluginTabs.module.scss
@@ -125,7 +125,7 @@
                     position: absolute;
                     top: 0;
                     left: 0;
-                    border-left: 1px solid (--Colors-Use-Neutral-Border);
+                    border-left: 1px solid var(--Colors-Use-Neutral-Border);
                     z-index: 0;
                     content: "";
                 }
@@ -324,7 +324,7 @@
                 // 选中
                 .ant-tabs-tab.ant-tabs-tab-active {
                     border: 0;
-                    background: var(--Colors-Use-Main-Hover);
+                    background: var(--Colors-Use-Main-Bg);
                     color: var(--Colors-Use-Main-On-Primary);
                     &::after {
                         content: "";
@@ -332,15 +332,15 @@
                         width: 100%;
                         bottom: -1px;
                         left: 0;
-                        border-bottom: 2px solid var(--Colors-Use-Main-Border);
+                        border-bottom: 3px solid var(--Colors-Use-Main-Primary);
                     }
                     .ant-tabs-tab-btn {
-                        color: var(--Colors-Use-Main-On-Primary);
+                        color: var(--Colors-Use-Main-Primary);
                         text-shadow: unset;
                     }
                     .anticon {
                         svg {
-                            color: var(--Colors-Use-Main-On-Primary);
+                            color: var(--Colors-Use-Main-Primary);
                         }
                     }
                 }

--- a/app/renderer/src/main/src/components/layout/RemoteEngine/RemoteEngine.module.scss
+++ b/app/renderer/src/main/src/components/layout/RemoteEngine/RemoteEngine.module.scss
@@ -102,7 +102,7 @@
 
                 .icon-style {
                     margin: 0 4px;
-                    color: var(--Colors-Use-Neutral-Text-1-Title);
+                    color: var(--Colors-Use-Neutral-Text-3-Secondary);
                     svg {
                         width: 16px;
                         height: 16px;

--- a/app/renderer/src/main/src/components/yakitUI/YakitAutoComplete/YakitAutoComplete.module.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitAutoComplete/YakitAutoComplete.module.scss
@@ -10,7 +10,7 @@
 
 // ========================== middle ==========================
 .yakit-auto-complete-wrapper {
-    --yakit-box-shadow-color: var(--Colors-Use-Basic-Shadow);
+    --yakit-box-shadow-color: var(--Colors-Use-Main-Focus);
     --yakit-border-hover-color: var(--Colors-Use-Main-Hover);
     --yakit-border-focus-color: var(--Colors-Use-Main-Primary);
     --yakit-font-color: var(--Colors-Use-Main-Primary);
@@ -32,8 +32,12 @@
 
         .ant-select:not(.ant-select-customize-input) .ant-select-selector .ant-select-selection-search-input {
             height: 26px;
-            font-size: 14px;
+            font-size: 12px;
             color: var(--Colors-Use-Neutral-Text-1-Title);
+        }
+
+        .ant-select-disabled:not(.ant-select-customize-input) .ant-select-selector .ant-select-selection-search-input {
+            color: var(--Colors-Use-Neutral-Disable)
         }
 
         .ant-select:not(.ant-select-disabled):hover .ant-select-selector {
@@ -47,7 +51,8 @@
         .ant-select-single .ant-select-selector .ant-select-selection-item,
         .ant-select-single .ant-select-selector .ant-select-selection-placeholder {
             line-height: 14px;
-            color:  var(--Colors-Use-Neutral-Disable);
+            font-size: 12px;
+            color: var(--Colors-Use-Neutral-Disable);
         }
     }
 }

--- a/app/renderer/src/main/src/components/yakitUI/YakitButton/yakitButton.module.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitButton/yakitButton.module.scss
@@ -34,14 +34,20 @@
         border-color: fetch-color($type, "color-6");
     }
     &[disabled] {
-        border: 1px solid var(--Colors-Use-Neutral-Border);
-        background: var(--Colors-Use-Neutral-Bg-Hover);
-        color: var(--Colors-Use-Neutral-Disable);
+        // border: 1px solid var(--Colors-Use-Neutral-Border);
+        // background: var(--Colors-Use-Neutral-Bg-Hover);
+        // color: var(--Colors-Use-Neutral-Disable);
+        background: var(--Colors-Use-Main-Border);
+        color: var(--Colors-Use-Basic-Background);
+        border: none;
     }
     &[disabled]:hover {
-        border: 1px solid var(--Colors-Use-Neutral-Border);
-        background: var(--Colors-Use-Neutral-Bg-Hover);
-        color: var(--Colors-Use-Neutral-Disable);
+        // border: 1px solid var(--Colors-Use-Neutral-Border);
+        // background: var(--Colors-Use-Neutral-Bg-Hover);
+        // color: var(--Colors-Use-Neutral-Disable);
+        background: var(--Colors-Use-Main-Border);
+        color: var(--Colors-Use-Basic-Background);
+        border: none;
     }
 }
 
@@ -50,7 +56,8 @@
 
     background: var(--Colors-Use-Neutral-Bg);
     color: var(--Colors-Use-Neutral-Text-1-Title);
-    border-color: var(--Colors-Use-Neutral-Border);
+    // border-color: var(--Colors-Use-Neutral-Border);
+    border: none;
     svg {
         color: var(--Colors-Use-Neutral-Text-3-Secondary);
     }
@@ -97,7 +104,7 @@
         }
     }
     &[disabled] {
-        background: var(--Colors-Use-Neutral-Bg);
+        background: var(--Colors-Use-Neutral-Bg-Hover);
         color: var(--Colors-Use-Neutral-Disable);
         border-color: var(--Colors-Use-Neutral-Border);
         svg {
@@ -105,7 +112,7 @@
         }
     }
     &[disabled]:hover {
-        background: var(--Colors-Use-Neutral-Bg);
+        background: var(--Colors-Use-Neutral-Bg-Hover);
         color: var(--Colors-Use-Neutral-Disable);
         border-color: var(--Colors-Use-Neutral-Border);
         svg {

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/StaticYakitEditor.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/StaticYakitEditor.scss
@@ -104,3 +104,7 @@
 .monaco-editor .find-widget{
   color: var(--Colors-Use-Neutral-Text-3-Secondary) !important;
 }
+
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row:hover {
+    background-color: var(--Colors-Use-Neutral-Bg-Hover) !important;
+}

--- a/app/renderer/src/main/src/components/yakitUI/YakitHint/YakitHint.module.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitHint/YakitHint.module.scss
@@ -52,7 +52,7 @@
     box-sizing: border-box;
     width: 100%;
     border: 1px solid var(--Colors-Use-Neutral-Bg-Hover);
-    background: var(--Colors-Use-Basic-Background);
+    background: var(--Colors-Use-Neutral-Bg);
     box-shadow: 0px 8px 16px 0px var(--Colors-Use-Basic-Shadow);
     border-radius: 4px;
 
@@ -106,7 +106,7 @@
                 .default-content {
                     font-size: 14px;
                     line-height: 20px;
-                    color: var(--Colors-Use-Neutral-Text-1-Title);
+                    color: var(--Colors-Use-Neutral-Text-3-Secondary);
                 }
             }
 

--- a/app/renderer/src/main/src/components/yakitUI/YakitInput/YakitInput.module.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitInput/YakitInput.module.scss
@@ -20,7 +20,7 @@
         .ant-input-group-addon {
             border-radius: 4px;
             border-color: var(--Colors-Use-Neutral-Border);
-            background: var(--Colors-Use-Basic-Background);
+            background: var(--Colors-Use-Neutral-Bg);
             color: var(--Colors-Use-Neutral-Text-1-Title);
             width: auto;
         }
@@ -66,6 +66,7 @@
             border-radius: 4px;
             input {
                 color: var(--Colors-Use-Neutral-Text-1-Title);
+                background-color: var(--Colors-Use-Basic-Background) !important;
             }
         }
         .ant-input-suffix{

--- a/app/renderer/src/main/src/components/yakitUI/YakitInputNumber/YakitInputNumber.module.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitInputNumber/YakitInputNumber.module.scss
@@ -60,15 +60,23 @@
         .ant-input-number-handler {
             border-color: var(--input-number-border-color);
             background-color: var(--Colors-Use-Neutral-Bg);
-            span{
+            span {
                 color: var(--Colors-Use-Neutral-Text-3-Secondary);
             }
         }
-        .ant-input-number-group-addon{
+        .ant-input-number-group-addon {
             border-color: var(--input-number-border-color);
             color: var(--Colors-Use-Neutral-Text-1-Title);
             background-color: var(--Colors-Use-Neutral-Bg);
         }
+        // .ant-input-number-disabled {
+        //     background-color: var(--input-number-background-disabled-color);
+        //     cursor: not-allowed;
+        //     border-color: var(--input-number-border-disabled-color);
+        //     svg {
+        //         color: var(--input-number-icon-disabled-color);
+        //     }
+        // }
     }
 }
 .yakit-input-number-wrapper-small {
@@ -163,11 +171,11 @@
 }
 
 // ========================== disabled ==========================
-.yakit-input-number-disabled {
+.yakit-input-number-wrapper-disabled .yakit-input-number-disabled {
     background: var(--input-number-background-disabled-color);
     cursor: not-allowed;
     border-color: var(--input-number-border-disabled-color);
-
+    color: var(--Colors-Use-Neutral-Disable);
     svg {
         color: var(--input-number-icon-disabled-color);
     }

--- a/app/renderer/src/main/src/components/yakitUI/YakitMenu/yakitMenu.module.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitMenu/yakitMenu.module.scss
@@ -196,7 +196,7 @@
         color: var(--menu-active-color);
         background-color: var(--menu-active-background);
         span.anticon {
-            color: var(--Colors-Use-Neutral-Text-1-Title);
+             color: var(--menu-active-color);
         }
         .keys-style {
             color: var(--menu-active-icon-color);

--- a/app/renderer/src/main/src/components/yakitUI/YakitPopconfirm/YakitPopconfirm.module.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitPopconfirm/YakitPopconfirm.module.scss
@@ -71,11 +71,11 @@
 .yakit-popconfirm-right-wrapper {
     :global {
         .ant-popover-arrow {
-            left: 1px;
+            // left: 1px;
 
             .ant-popover-arrow-content {
                 border: 1px solid var(--Colors-Use-Neutral-Border);
-                background-color: var(--Colors-Use-Neutral-Border);
+                background-color: var(--Colors-Use-Basic-Background);
             }
 
             .ant-popover-arrow-content::before {

--- a/app/renderer/src/main/src/components/yakitUI/YakitResizeBox/YakitResizeBox.module.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitResizeBox/YakitResizeBox.module.scss
@@ -4,7 +4,7 @@
     display: flex;
     position: relative;
     overflow: hidden;
-    background-color: var(--Colors-Use-Basic-Background);
+    background-color: var(--Colors-Use-Neutral-Bg);
     .resize-split-line {
         display: flex;
         align-items: center;

--- a/app/renderer/src/main/src/components/yakitUI/YakitSelect/YakitSelect.module.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitSelect/YakitSelect.module.scss
@@ -22,11 +22,11 @@
             display: flex;
             font-size: 12px;
             background-color: var(--Colors-Use-Basic-Background);
-            .ant-select-selector{
+            .ant-select-selector {
                 background-color: var(--Colors-Use-Basic-Background);
                 color: var(--Colors-Use-Neutral-Text-1-Title);
             }
-            .ant-select-arrow{
+            .ant-select-arrow {
                 color: var(--Colors-Use-Neutral-Text-3-Secondary);
             }
         }
@@ -38,9 +38,9 @@
         .ant-select-clear {
             right: 12px;
             background: transparent;
-            .anticon-close-circle{
+            .anticon-close-circle {
                 color: var(--Colors-Use-Neutral-Border);
-                svg{
+                svg {
                     color: var(--Colors-Use-Neutral-Text-4-Help-text);
                 }
             }
@@ -90,8 +90,8 @@
 
         // ========================== disabled ==========================
         .ant-select-disabled.ant-select:not(.ant-select-customize-input) .ant-select-selector {
-            background: var(--select-background-disabled-color);
-            color: var(--select-font-disabled-color);
+            background: var(--Colors-Use-Neutral-Bg-Hover);
+            color: var(--Colors-Use-Neutral-Disable);
             border-color: transparent !important;
         }
     }
@@ -130,12 +130,12 @@
             background: var(--Colors-Use-Main-Bg);
         }
 
-        .yakit-select-notFound{
+        .yakit-select-notFound {
             display: flex;
             align-items: center;
             justify-content: center;
             flex-direction: column;
-            .yakit-select-content{
+            .yakit-select-content {
                 color: var(--Colors-Use-Neutral-Disable);
             }
         }
@@ -264,7 +264,7 @@
         .ant-select-selection-overflow {
             min-height: 20px;
         }
-        .ant-select-selection-placeholder{
+        .ant-select-selection-placeholder {
             color: var(--Colors-Use-Neutral-Disable);
         }
 
@@ -322,7 +322,7 @@
             min-height: 16px;
         }
 
-        .ant-select-selection-placeholder{
+        .ant-select-selection-placeholder {
             color: var(--Colors-Use-Neutral-Disable);
         }
 

--- a/app/renderer/src/main/src/pages/assetViewer/ReportViewerPage.module.scss
+++ b/app/renderer/src/main/src/pages/assetViewer/ReportViewerPage.module.scss
@@ -61,6 +61,13 @@
         &-body {
             height: 100%;
         }
+        &-selected {
+            background-color: red;
+            .list-item-header,
+            .list-item-body {
+                border: 1px solid var(--Colors-Use-Main-Border);
+            }
+        }
     }
     .report-viewer {
         position: relative;
@@ -78,9 +85,9 @@
             align-items: center;
             flex-direction: column;
             justify-content: center;
-            :global{
+            :global {
                 margin: 0;
-                border: none
+                border: none;
             }
         }
         .loading-wrapper {

--- a/app/renderer/src/main/src/pages/assetViewer/ReportViewerPage.tsx
+++ b/app/renderer/src/main/src/pages/assetViewer/ReportViewerPage.tsx
@@ -252,7 +252,9 @@ const ReportList: React.FC<ReportListProp> = (props) => {
                         return (
                             <div onClick={() => onSetSelectReportId(item.Id)} key={item.Id}>
                                 <YakitCard
-                                    className={styles["card"]}
+                                    className={classNames(styles["card"], {
+                                        [styles["card-selected"]]: selectReportId === item.Id
+                                    })}
                                     headClassName={styles["list-item-header"]}
                                     headStyle={{
                                         height: 32,
@@ -278,7 +280,7 @@ const ReportList: React.FC<ReportListProp> = (props) => {
                                     extra={<YakitTag>{formatTimestamp(item.PublishedAt)}</YakitTag>}
                                     style={{
                                         backgroundColor:
-                                            selectReportId == item.Id ? "var(--Colors-Use-Main-Focus)" : undefined
+                                            selectReportId == item.Id ? "var(--Colors-Use-Main-Bg-Hover)" : undefined
                                     }}
                                 >
                                     <Tooltip title='点击选中后，可删除'>

--- a/app/renderer/src/main/src/pages/cve/CVETable.module.scss
+++ b/app/renderer/src/main/src/pages/cve/CVETable.module.scss
@@ -191,13 +191,13 @@
             }
 
             .ant-descriptions-bordered .ant-descriptions-item-label {
-                background-color: var(--Colors-Use-Neutral-Bg);
+                background-color: var(--Colors-Use-Neutral-Bg-Hover);
             }
 
             .ant-descriptions-item-content {
                 height: 40px;
                 padding: 12px 16px 12px 12px;
-                background-color: var(--Colors-Use-Neutral-Bg-Hover);
+                background-color: var(--Colors-Use-Neutral-Bg);
                 color: var(--Colors-Use-Neutral-Text-1-Title);
             }
 

--- a/app/renderer/src/main/src/pages/fingerprintManage/FingerprintManage.module.scss
+++ b/app/renderer/src/main/src/pages/fingerprintManage/FingerprintManage.module.scss
@@ -178,7 +178,7 @@
         }
     }
 
-    .list-local-opt:hover+.list-local-opt {
+    .list-local-opt:hover + .list-local-opt {
         border-top-color: transparent;
     }
 
@@ -202,7 +202,7 @@
         }
     }
 
-    .list-local-opt-active+.list-local-opt {
+    .list-local-opt-active + .list-local-opt {
         border-top-color: transparent;
     }
 }
@@ -275,42 +275,46 @@
     }
 
     :global {
-        .ant-table.ant-table-bordered > .ant-table-container{
+        .ant-table.ant-table-bordered > .ant-table-container {
             border-color: var(--Colors-Use-Neutral-Border);
         }
-        .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table, .ant-table.ant-table-bordered > .ant-table-container > .ant-table-header > table{
+        .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table,
+        .ant-table.ant-table-bordered > .ant-table-container > .ant-table-header > table {
             border-color: var(--Colors-Use-Neutral-Border);
         }
 
         // table相关
-        .ant-table-thead>tr>th,
-        .ant-table-tbody>tr>td {
+        .ant-table-thead > tr > th,
+        .ant-table-tbody > tr > td {
             padding: 8px 16px;
         }
 
-        .ant-table-thead>tr>th {
+        .ant-table-thead > tr > th {
             color: var(--Colors-Use-Neutral-Text-1-Title);
-            background: var(--Colors-Use-Basic-Background);
+            background: var(--Colors-Use-Neutral-Bg);
             font-size: 12px;
             font-weight: 500;
             font-style: normal;
             line-height: 16px;
         }
 
-        .ant-table-thead>tr>th,
-        .ant-table-tbody>tr>td {
+        .ant-table-tbody > tr > td {
+            background: var(--Colors-Use-Basic-Background);
+        }
+
+        .ant-table-thead > tr > th,
+        .ant-table-tbody > tr > td {
             border-bottom: 1px solid var(--Colors-Use-Neutral-Border);
         }
 
-        .ant-table.ant-table-bordered>.ant-table-container>.ant-table-content>table>thead>tr>th,
-        .ant-table.ant-table-bordered>.ant-table-container>.ant-table-content>table>tbody>tr>td {
+        .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table > thead > tr > th,
+        .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table > tbody > tr > td {
             border-right: 1px solid var(--Colors-Use-Neutral-Border);
             color: var(--Colors-Use-Neutral-Text-1-Title);
-            background: var(--Colors-Use-Neutral-Bg);
         }
 
-        .ant-table-tbody>tr.ant-table-row:hover>td,
-        .ant-table-tbody>tr>td.ant-table-cell-row-hover {
+        .ant-table-tbody > tr.ant-table-row:hover > td,
+        .ant-table-tbody > tr > td.ant-table-cell-row-hover {
             background: var(--Colors-Use-Neutral-Bg-Hover) !important;
         }
 

--- a/app/renderer/src/main/src/pages/fuzzer/HTTPFuzzerPage.module.scss
+++ b/app/renderer/src/main/src/pages/fuzzer/HTTPFuzzerPage.module.scss
@@ -16,7 +16,7 @@
     flex-direction: column;
     overflow: hidden;
     padding: 12px;
-    background-color: var(--Colors-Use-Neutral-Bg);
+    background-color: var(--Colors-Use-Basic-Background);
     :global {
         .ant-result-warning .ant-result-icon > .anticon {
             color: var(--Colors-Use-Warning-Primary);
@@ -267,7 +267,7 @@
                 border-right: 1px solid var(--Colors-Use-Neutral-Border);
                 cursor: pointer;
                 &:hover {
-                    background-color: var(--Colors-Use-Neutral-Bg-Hover)
+                    background-color: var(--Colors-Use-Neutral-Bg-Hover);
                 }
                 .tab-icon {
                     width: 16px;

--- a/app/renderer/src/main/src/pages/fuzzer/MatcherAndExtractionCard/MatcherAndExtraction.module.scss
+++ b/app/renderer/src/main/src/pages/fuzzer/MatcherAndExtractionCard/MatcherAndExtraction.module.scss
@@ -18,7 +18,7 @@
     min-height: 300px;
     .matching-extraction-editor {
         padding-top: 16px;
-        background-color: var(--Colors-Use-Basic-Background);
+        background-color: var(--Colors-Use-Neutral-Bg-Hover);
         height: 100%;
         :global {
             .monaco-editor .scroll-decoration {

--- a/app/renderer/src/main/src/pages/fuzzer/components/HTTPFuzzerPageTable/HTTPFuzzerPageTable.module.scss
+++ b/app/renderer/src/main/src/pages/fuzzer/components/HTTPFuzzerPageTable/HTTPFuzzerPageTable.module.scss
@@ -13,7 +13,7 @@
         @extend .display-flex-center;
         justify-content: center;
         gap: 12px;
-        color: var(--Colors-Use-Neutral-Text-1-Title);
+        color: var(--Colors-Use-Neutral-Text-3-Secondary);
 
         svg {
             cursor: pointer;

--- a/app/renderer/src/main/src/pages/httpRequestBuilder/HTTPRequestBuilder.module.scss
+++ b/app/renderer/src/main/src/pages/httpRequestBuilder/HTTPRequestBuilder.module.scss
@@ -16,6 +16,11 @@
 
 .variable-list {
     color: var(--Colors-Use-Neutral-Bg);
+
+    &:hover{
+        background-color: var(--Colors-Use-Neutral-Bg-Hover);
+    }
+
     .variable-list-panel {
         &:hover {
             .variable-list-remove {

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.module.scss
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.module.scss
@@ -35,7 +35,6 @@ $keyColor: map-keys($colors);
     .tab-menu-sub-group-name-#{"" + $name} {
         background-color: map-get($currentColor, "backgroundColor");
         color: map-get($currentColor, "textColor");
-
     }
 
     .tab-menu-sub-group-number-#{"" + $name} {
@@ -82,15 +81,15 @@ $keyColor: map-keys($colors);
 }
 
 .dragging {
-    background-color: var(--Colors-Use-Neutral-Border);
+    background-color: var(--Colors-Use-Basic-Background);
     border-color: var(--Colors-Use-Neutral-Border);
     &::before {
         @extend .white-link;
         bottom: -1px;
         border-width: 2px;
     }
-    &::after{
-        border-color: var(--Colors-Use-Neutral-Border)
+    &::after {
+        border-color: var(--Colors-Use-Neutral-Border);
     }
 }
 
@@ -608,7 +607,7 @@ $keyColor: map-keys($colors);
     // overflow: hidden;
     overflow-y: overlay;
     overflow-x: hidden;
-    
+
     position: relative;
     :global {
         .ant-modal-mask {

--- a/app/renderer/src/main/src/pages/mitm/MITMServerStartForm/MITMServerStartForm.module.scss
+++ b/app/renderer/src/main/src/pages/mitm/MITMServerStartForm/MITMServerStartForm.module.scss
@@ -379,7 +379,7 @@
             border-top: 0;
         }
         .ant-collapse > .ant-collapse-item > .ant-collapse-header {
-            background: var(--Colors-Use-Neutral-Bg-Hover);
+            background: var(--Colors-Use-Neutral-Bg);
             border-radius: 4px 4px 0px 0px;
             border-bottom: 1px solid transparent;
         }
@@ -444,7 +444,7 @@
 }
 
 .collapse-panel-condition {
-    background-color: var(--Colors-Use-Neutral-Bg-Hover);
+    background-color: var(--Colors-Use-Neutral-Bg);
     padding: 12px 8px;
 }
 

--- a/app/renderer/src/main/src/pages/plugins/operator/expandAndRetract/ExpandAndRetract.module.scss
+++ b/app/renderer/src/main/src/pages/plugins/operator/expandAndRetract/ExpandAndRetract.module.scss
@@ -13,7 +13,7 @@
     z-index: 12;
     &:hover {
         cursor: pointer;
-        background-color: var(--Colors-Use-Neutral-Bg-Hover);
+        background-color: var(--Colors-Use-Neutral-Bg);
         border-bottom-color: var(--Colors-Use-Main-Border);
         .expand-and-retract-header-icon-body {
             width: 76px;
@@ -35,11 +35,11 @@
     background-color: var(--Colors-Use-Main-Bg);
 }
 .expand-and-retract-header-finished {
-    background-color: var(--Colors-Use-Neutral-Bg);
+    background-color: var(--Colors-Use-Success-Bg);
 }
 
 .expand-and-retract-header-error {
-    background-color: var(--Colors-Use-Neutral-Bg);
+    background-color: var(--Colors-Use-Error-Bg);
 }
 
 .expand-and-retract-header-icon-body {

--- a/app/renderer/src/main/src/pages/shortcutKey/ShortcutKey.module.scss
+++ b/app/renderer/src/main/src/pages/shortcutKey/ShortcutKey.module.scss
@@ -139,10 +139,10 @@
             }
         }
         .list-item-active {
-            background-color: var(--Colors-Use-Main-Focus);
-            color: var(--Colors-Use-Neutral-Text-1-Title);
+            background-color: var(--Colors-Use-Main-Primary);
+            color: var(--Colors-Use-Main-On-Primary);
             &:hover {
-                background-color: var(--Colors-Use-Main-Bg-Hover);
+                background-color: var(--Colors-Use-Main-Primary);
             }
         }
     }

--- a/app/renderer/src/main/src/theme/componentsTheme/alert.scss
+++ b/app/renderer/src/main/src/theme/componentsTheme/alert.scss
@@ -17,7 +17,7 @@
     }
 }
 .ant-alert-warning{
-    background-color: var(--Colors-Use-Warning-Bg);
+    background-color: var(--Colors-Use-Warning-Bg-Hover);
     border: 1px solid var(--Colors-Use-Warning-Border);
     .ant-alert-content{
         .ant-alert-message{

--- a/app/renderer/src/main/src/theme/componentsTheme/descriptions.scss
+++ b/app/renderer/src/main/src/theme/componentsTheme/descriptions.scss
@@ -32,7 +32,7 @@
     }
 
     .ant-descriptions-bordered .ant-descriptions-item-label {
-        background-color: var(--Colors-Use-Neutral-Bg);
+        background-color: var(--Colors-Use-Neutral-Bg-Hover);
     }
 
     .ant-descriptions-item-content {

--- a/app/renderer/src/main/src/theme/componentsTheme/typography.scss
+++ b/app/renderer/src/main/src/theme/componentsTheme/typography.scss
@@ -1,7 +1,7 @@
 .ant-typography{
     mark{
-        background-color: var(--Colors-Use-Warning-Bg);
-        color: var(--Colors-Use-Warning-Primary);
+        background-color: var(--Colors-Use-Yellow-Border);
+        color: var(--Colors-Use-Neutral-Text-1-Title);
     }
     code{
         background-color: var(--Colors-Use-Neutral-Bg);


### PR DESCRIPTION
- menu 菜单 icon 颜色
- 报告选中状态背景与边框颜色
- typography mark 字体颜色与背景颜色
- input 组件前缀背景颜色
- CVE 数据库更新 modal 背景颜色
- complete 组件 placeholder 字体大小
- 快捷键设置侧边栏选中颜色
- web fuzzer 二级菜单组颜色
- web fuzzer 左侧规则下拉菜单悬浮背景颜色
- CVE 管理表格背景颜色
- 指纹库表格背景颜色
- tab 组件背景颜色与边框大小
- inputNumber 组件 disable 状态字体颜色
- web fuzzer 二级菜单 hover 颜色
- yakitAutoComplete 组件阴影颜色
- web fuzzer 表格 icon 颜色
- 插件执行状态背景颜色
- MITM 高级配置过滤器下拉菜单背景颜色
- alert 组件 warning 状态背景颜色
- yakitButton 按钮 primary 类型 disable 样式
- 引擎连接过程二级标题字体颜色
- Popconfirm 组件箭头颜色与位置
- yakinputt 组件背景颜色
- descriptions 组件表格 label 背景颜色
- 插件详情右侧菜单边框颜色
- web fuzzer 界面右侧区域背景颜色
- yakitButton 组件 secondary2 类型背景颜色与边框
- payload左侧背景颜色
- yakitAutoComplete组件disable状态字体颜色
- 远程模式提示按钮颜色
- 暗黑模式下代码片段提示鼠标悬浮背景色
- webFuzzer匹配器编辑器上方背景颜色
- yakitSelect组件disable背景颜色