### PR TITLE
docs(README-EN): add Development Setup section with prerequisites and run steps

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -125,6 +125,40 @@ For more technical content, you can check:
 
 [Whitepaper](https://yaklang.oss-cn-beijing.aliyuncs.com/yakit-technical-white-paper.pdf)
 
+## Development Setup
+
+Prerequisites:
+
+- Node.js 18.x (recommended) and Yarn 1.x
+- Git
+- Windows, macOS, or Linux
+
+Steps:
+
+1. Install dependencies at repo root
+     
+     ```bash
+     yarn
+     ```
+
+2. Install renderer dependencies
+     
+     ```bash
+     yarn install-render
+     ```
+
+3. Start development (starts React renderer and Electron)
+     
+     ```bash
+     yarn dev
+     ```
+
+Useful scripts (from package.json):
+
+- Build renderer only: `yarn build-render`
+- Start Electron only (after renderer runs on 3000): `yarn start-electron`
+- Package (Windows example): `yarn pack-win`
+
 ## Community
 
 If you have any constructive feedback or bug reports regarding our product, we welcome everyone to raise an issue.


### PR DESCRIPTION
- Add concise “Development Setup” with prerequisites (Node 18.x, Yarn 1.x) and steps to run locally (`yarn`, `yarn install-render`, `yarn dev`).
- Include useful scripts hint (build renderer, start electron, pack on Windows).

**Branch:** `feat/docs-development-setup`