### PR TITLE
Fix typo in button label for Chrome launcher

### DIFF
--- a/app/renderer/src/main/src/pages/mitm/MITMChromeLauncher.tsx
+++ b/app/renderer/src/main/src/pages/mitm/MITMChromeLauncher.tsx
@@ -291,7 +291,7 @@ const MITMChromeLauncher: React.FC<MITMChromeLauncherProp> = (props) => {
                             style={{borderRadius: "40px 0 0 40px"}}
                             onClick={handleStartChromeBefore}
                         >
-                            启动免配置 Chorme
+                            启动免配置 Chrome
                         </div>
                         <div
                             className={style["operation-btn-right"]}


### PR DESCRIPTION
<img width="1004" height="630" alt="PixPin_2025-11-23_10-01-44" src="https://github.com/user-attachments/assets/1393baec-ad13-4024-b328-43f9238502ee" />
Fix this typo