### PR TITLE
fix(code-scan): use selectTotal instead of GroupNames to validate rule selection

### DIFF
--- a/app/renderer/src/main/src/pages/yakRunnerCodeScan/YakRunnerCodeScan.tsx
+++ b/app/renderer/src/main/src/pages/yakRunnerCodeScan/YakRunnerCodeScan.tsx
@@ -2628,7 +2628,7 @@ const CodeScanAuditExecuteForm: React.FC<CodeScanAuditExecuteFormProps> = React.
         }, [streamInfo])
 
         const onStartAuditFun = useMemoizedFn(async (value) => {
-            if ((pageInfo.GroupNames || []).length === 0) {
+            if ((pageInfo.selectTotal || 0) === 0) {
                 warn("请选择扫描规则")
                 return
             }


### PR DESCRIPTION
Rules can be selected in two ways: by group (stored in GroupNames) or by keyword (stored in RuleIds). The previous validation only checked GroupNames, causing false "please select rules" warnings when rules were selected by keyword. Now uses selectTotal which correctly reflects the count regardless of selection method.