### PR TITLE
针对 XML 的请求体&响应体优化

### DIFF
--- a/app/renderer/src/main/package.json
+++ b/app/renderer/src/main/package.json
@@ -109,6 +109,7 @@
         "video-react": "^0.16.0",
         "web-vitals": "^1.0.1",
         "xlsx": "^0.18.5",
+        "xml-formatter": "^3.6.7",
         "xlsx-style": "^0.8.13",
         "xterm-addon-search": "^0.11.0",
         "xterm-addon-search-bar": "^0.2.0",


### PR DESCRIPTION
[[Feature]: 美化功能按钮，针对 XML 的请求体做针对性的优化](https://github.com/yaklang/yakit/issues/3063)
当前的 prettifyPacket 功能在处理 XML 请求体时，美化效果不理想，节点缩进和属性展开不够清晰，难以阅读，尤其在响应式 XML 场景下。

## 改动内容
- 使用 `xml-formatter` 替换原有自定义 XML 格式化逻辑
- 配置如下：
  - 缩进使用 2 个空格
  - 保留所有属性和子节点（`collapseContent: false`）
  - 行分隔符使用 `\n`

## 测试情况
- 本地对请求包和响应包的 XML 数据进行了美化测试

<table>
  <tr>
    <td align="center">修改前</td>
    <td align="center">修改后</td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/5d285636-735c-4369-9a7b-fdcb3b75f28d" width="480" /></td>
    <td><img src="https://github.com/user-attachments/assets/4e9f27b3-8e64-405f-b37c-c0d79c13459f" width="480" /></td>
  </tr>
</table>

# 影响范围
- 仅影响 `prettifyPacket` 模块的 XML 美化
- 不影响其他 packet 类型的格式化

