### PR TITLE
feat(mitm): recognize [规则修改] tag for bare packet view

### DIFF
--- a/app/renderer/src/main/src/components/HTTPFlowDetail.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowDetail.tsx
@@ -1428,7 +1428,7 @@ export const HTTPFlowDetailRequestAndResponse: React.FC<HTTPFlowDetailRequestAnd
     reqEditor?.setScrollTop(0)
     resEditor?.setScrollTop(0)
     const existedTags = flow?.Tags ? flow?.Tags.split('|').filter((i) => !!i && !i.startsWith('YAKIT_COLOR_')) : []
-    if (existedTags.includes('[手动修改]') || existedTags.includes('[响应被丢弃]')) {
+    if (existedTags.includes('[手动修改]') || existedTags.includes('[响应被丢弃]') || existedTags.includes('[规则修改]')) {
       setShowBeforeData(true)
       handleGetHTTPFlowBare('request')
       handleGetHTTPFlowBare('response')

--- a/app/renderer/src/main/src/components/HTTPFlowDetail.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowDetail.tsx
@@ -1428,7 +1428,11 @@ export const HTTPFlowDetailRequestAndResponse: React.FC<HTTPFlowDetailRequestAnd
     reqEditor?.setScrollTop(0)
     resEditor?.setScrollTop(0)
     const existedTags = flow?.Tags ? flow?.Tags.split('|').filter((i) => !!i && !i.startsWith('YAKIT_COLOR_')) : []
-    if (existedTags.includes('[手动修改]') || existedTags.includes('[响应被丢弃]') || existedTags.includes('[规则修改]')) {
+    if (
+      existedTags.includes('[手动修改]') ||
+      existedTags.includes('[响应被丢弃]') ||
+      existedTags.includes('[规则修改]')
+    ) {
       setShowBeforeData(true)
       handleGetHTTPFlowBare('request')
       handleGetHTTPFlowBare('response')


### PR DESCRIPTION
Extend the HTTPFlow detail panel to show [原始请求]/[原始响应] tabs when a flow is tagged with [规则修改] (rule-replaced), in addition to [手动修改] (manually hijacked) and [响应被丢弃] (dropped response).