### PR TITLE
关闭自由对话正在执行的问题任务

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
   "editor.formatOnType": false,
 
   // code spell checker ，以下是一些自定义的单词列表
-  "cSpell.words": ["emiter", "Yakit", "yaklang", "irify", "memfit", "irifyee", "ahook"],
+  "cSpell.words": ["emiter", "Yakit", "yaklang", "irify", "memfit", "irifyee", "ahooks"],
 
   // 1. 新文件默认使用 LF
   "files.eol": "\n",

--- a/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatContent.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatContent.tsx
@@ -99,7 +99,6 @@ export const AIChatContent: React.FC<AIChatContentProps> = React.memo(
         // const ids = aiChatDataStore.get(activeChat.request.TimelineSessionID || "default")?.coordinatorIDs || []
         await grpcExportAILogs(
           {
-            // CoordinatorIDs: ids,
             SessionID: activeChat.SessionID,
             ExportDataTypes: data.types,
             OutputPath: data.outputPath,

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/AIAgentChatTemplate.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/AIAgentChatTemplate.tsx
@@ -76,7 +76,7 @@ export const AIChatLeftSide: React.FC<AIChatLeftSideProps> = memo((props) => {
     return memoryList?.memories?.length
   }, [memoryList?.memories?.length])
   const getTaskInfo = useMemoizedFn(() => {
-    return chatIPCEvents.fetchTaskChatID()
+    return chatIPCEvents.fetchCurrentTaskPlanID()
   })
 
   const handleCancelExpand = useMemoizedFn(() => {

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/HistoryTaskTree.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/HistoryTaskTree.tsx
@@ -124,7 +124,7 @@ const AIHistoryContinueTask: React.FC<AIHistoryContinueTaskProps> = React.memo((
   }, [isExecuting, taskIndex, sendRecoverParamsRef.current?.taskIndex])
 
   const getTaskInfo = useMemoizedFn(() => {
-    return chatIPCEvents.fetchTaskChatID()
+    return chatIPCEvents.fetchCurrentTaskPlanID()
   })
   const getTaskId = useMemoizedFn(() => {
     const taskInfo = getTaskInfo()

--- a/app/renderer/src/main/src/pages/ai-agent/store/ChatDataStore.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/store/ChatDataStore.ts
@@ -30,7 +30,6 @@ export class ChatDataStore {
         timelineID: '',
         chatID: '',
       },
-      coordinatorIDs: [],
       httpRunTimeIDs: [],
       riskRunTimeIDs: [],
       yakExecResult: { card: [], execFileRecord: new Map(), yakExecResultLogs: [] },

--- a/app/renderer/src/main/src/pages/ai-agent/type/aiChat.d.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/type/aiChat.d.ts
@@ -27,8 +27,6 @@ export interface AIChatData {
     timelineID: string
     chatID: string
   }
-  /** 记录数据里所有的coordinatorIDs */
-  coordinatorIDs: string[]
   /** 记录数据里所有的httpRunTimeIDs */
   httpRunTimeIDs: UseChatIPCState['httpRunTimeIDs']
   /** 记录数据里所有的riskRunTimeIDs */

--- a/app/renderer/src/main/src/pages/ai-agent/useContext/ChatIPCContent/ChatIPCContent.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/useContext/ChatIPCContent/ChatIPCContent.ts
@@ -55,7 +55,8 @@ export const defaultDispatcherOfChatIPC: ChatIPCContextDispatcher = {
   chatIPCEvents: {
     fetchToken: () => '',
     fetchAIRequest: () => undefined,
-    fetchTaskChatID: () => undefined,
+    fetchCurrentCasualTaskID: () => '',
+    fetchCurrentTaskPlanID: () => undefined,
     onSwitchChat: () => {},
     onStart: () => {},
     onSend: () => {},

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActTaskChat/AIReActTaskChat.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActTaskChat/AIReActTaskChat.tsx
@@ -151,7 +151,7 @@ const AIReActTaskChatContent: React.FC<AIReActTaskChatContentProps> = React.memo
   })
 
   const getTaskInfo = useMemoizedFn(() => {
-    return chatIPCEvents.fetchTaskChatID()
+    return chatIPCEvents.fetchCurrentTaskPlanID()
   })
   const getTaskId = useMemoizedFn(() => {
     return getTaskInfo()?.taskID
@@ -362,7 +362,7 @@ const AIManualAddition: React.FC<AIManualAdditionProps> = React.memo((props) => 
     // 加入上下文后，停止任务再恢复任务
     syncIdOfAddAndReExecute.current = randomString(8)
     onAddToContext(syncIdOfAddAndReExecute.current)
-    const info = chatIPCEvents.fetchTaskChatID()
+    const info = chatIPCEvents.fetchCurrentTaskPlanID()
     const taskId = info?.taskID
     const coordinatorId = info?.coordinatorId
     if (!coordinatorId) return
@@ -545,7 +545,7 @@ const AIRenderTaskFooterExtra: React.FC<AIRenderTaskFooterExtraProps> = React.me
     return chatIPCData.cancelTaskLoading
   }, [chatIPCData.cancelTaskLoading])
   const getTaskInfo = useMemoizedFn(() => {
-    return chatIPCEvents.fetchTaskChatID()
+    return chatIPCEvents.fetchCurrentTaskPlanID()
   })
 
   const renderBtn = useMemoizedFn(() => {

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/defaultConstant.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/defaultConstant.ts
@@ -101,7 +101,7 @@ export enum AIStreamContentType {
 }
 
 /** 问题队列-默认值 */
-export const DeafultAIQuestionQueues: AIQuestionQueues = {
+export const DefaultAIQuestionQueues: AIQuestionQueues = {
   total: 0,
   data: [],
 }

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/type.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/type.ts
@@ -256,8 +256,10 @@ export interface UseChatIPCEvents extends Omit<UseHistoryChatEvents, 'loadInit'>
   fetchToken: () => string
   /** 获取当前执行接口流的请求参数 */
   fetchAIRequest: () => AIStartParams | undefined
+  /** 获取当前执行的自由对话问题(这个问题可能引起的是任务规划)对应的任务ID */
+  fetchCurrentCasualTaskID: () => string
   /** 获取当前执行任务规划的问题详情 */
-  fetchTaskChatID: () => TaskChatTaskInfo | undefined
+  fetchCurrentTaskPlanID: () => TaskChatTaskInfo | undefined
   /** 获取当前外界传入的数据类实例 */
   fetchChatDataStore: () => UseChatIPCParams['cacheDataStore']
   /** 切换历史会话展示 */

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/useChatIPC.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/useChatIPC.ts
@@ -36,7 +36,7 @@ import useAIChatLog from './useAIChatLog'
 import cloneDeep from 'lodash/cloneDeep'
 import {
   convertNodeIdToVerbose,
-  DeafultAIQuestionQueues,
+  DefaultAIQuestionQueues,
   DefaultCasualLoadingStatus,
   DefaultMemoryList,
   DefaultPlanHistoryList,
@@ -131,18 +131,6 @@ function useChatIPC(params?: UseChatIPCParams) {
   const [execute, setExecute, getExecute] = useGetSetState(false)
   // #endregion
 
-  // CoordinatorIDs
-  const updateCoordinatorIDs = useMemoizedFn((id: string) => {
-    const ids = getChatDataStore()?.coordinatorIDs
-    if (!ids) {
-      try {
-        cacheDataStore?.updater(chatID.current, { coordinatorIDs: [id] })
-      } catch (error) {}
-    } else {
-      if (!ids.includes(id)) ids.push(id)
-    }
-  })
-
   // #region 接口更新的(文件|文件夹)数据集合
   const [grpcFolders, setGrpcFolders] = useState<AIFileSystemPin[]>([])
   const handleSetGrpcFolders = useMemoizedFn((info: AIFileSystemPin) => {
@@ -172,10 +160,10 @@ function useChatIPC(params?: UseChatIPCParams) {
 
   // #region 问题队列相关逻辑
   // 问题队列(自由对话专属)[todo: 后续存在任务规划的问题队列后，需要放入对应的hook中进行处理和储存]
-  const [questionQueue, setQuestionQueue] = useState<AIQuestionQueues>(cloneDeep(DeafultAIQuestionQueues))
+  const [questionQueue, setQuestionQueue] = useState<AIQuestionQueues>(cloneDeep(DefaultAIQuestionQueues))
 
   const handleResetQuestionQueue = useMemoizedFn(() => {
-    setQuestionQueue(cloneDeep(DeafultAIQuestionQueues))
+    setQuestionQueue(cloneDeep(DefaultAIQuestionQueues))
   })
   // #endregion
 
@@ -287,16 +275,31 @@ function useChatIPC(params?: UseChatIPCParams) {
   // #endregion
 
   // #region 自由对话(ReAct)相关变量和hook
-  const casualChatID = useRef(0)
+  /** 当前执行问题的task_id */
+  const currentCasualTaskID = useRef('')
+  const fetchCurrentCasualTaskID = useMemoizedFn(() => {
+    return currentCasualTaskID.current
+  })
 
   /** 用户主动关闭当前问题的loading状态(自由对话) */
   const [cancelCasualLoading, setCancelCasualLoading] = useState(false)
-
+  /** 自由对话状态变换的计数 */
+  const casualChatID = useRef(0)
   /** 自由对话(ReAct)的loading状态 */
   const [casualStatus, setCasualStatus] = useState<CasualLoadingStatus>(cloneDeep(DefaultCasualLoadingStatus))
-  const handleResetCasualChatLoading = useMemoizedFn(() => {
-    casualChatID.current = 0
-    setCasualStatus(cloneDeep(DefaultCasualLoadingStatus))
+  const handleUpdateCasualStatus = useMemoizedFn((type: 'add' | 'remove' | 'reset') => {
+    if (type === 'reset') {
+      casualChatID.current = 0
+      setCasualStatus(cloneDeep(DefaultCasualLoadingStatus))
+      return
+    }
+
+    if (type === 'add') {
+      casualChatID.current += 1
+    } else if (type === 'remove') {
+      casualChatID.current -= 1
+    }
+    setCasualStatus((old) => ({ ...old, loading: casualChatID.current > 0 }))
   })
 
   const [casualChat, casualChatEvent] = useCasualChat({
@@ -309,24 +312,17 @@ function useChatIPC(params?: UseChatIPCParams) {
 
   // #region 任务规划相关变量和hook
   /** 任务规划对应的问题信息, 供UI使用，因为任务结束后，该变量不会清空 */
-  const taskChatID = useRef<TaskChatTaskInfo>()
-  const fetchTaskChatID = useMemoizedFn(() => {
-    return taskChatID.current
-  })
-  const handleResetTaskChatID = useMemoizedFn(() => {
-    taskChatID.current = undefined
+  const currentTaskPlanID = useRef<TaskChatTaskInfo>()
+  const fetchCurrentTaskPlanID = useMemoizedFn(() => {
+    return currentTaskPlanID.current
   })
 
-  /** 用户主动关闭当前问题的loading状态(任务规划) */
+  /** 用户主动(关闭/恢复)当前问题的loading状态(任务规划) */
   const [cancelTaskLoading, setCancelTaskLoading] = useState(false)
 
-  /** 当前任务规划对应的数据流-CoordinatorId */
-  const planCoordinatorId = useRef('')
   /** 任务规划的loading状态 */
   const [taskStatus, setTaskStatus] = useState<PlanLoadingStatus>(cloneDeep(DefaultPlanLoadingStatus))
-
-  const handleResetTaskChatLoading = useMemoizedFn(() => {
-    planCoordinatorId.current = ''
+  const handleResetTaskStatus = useMemoizedFn(() => {
     setTaskStatus(cloneDeep(DefaultPlanLoadingStatus))
   })
 
@@ -380,6 +376,8 @@ function useChatIPC(params?: UseChatIPCParams) {
       const ipcContent = Uint8ArrayToString(res.Content) || ''
       const data = JSON.parse(ipcContent) as AIAgentGrpcApi.QuestionQueueStatusChange
       if (NodeId === 'react_task_dequeue') {
+        // 记录出队的问题任务id
+        currentCasualTaskID.current = data.react_task_id
         if (!!data.focus_mode) {
           // 记录专注模式状态
           handleFocusModeChange(data.react_task_id, data.focus_mode)
@@ -506,16 +504,18 @@ function useChatIPC(params?: UseChatIPCParams) {
   const handleResetGrpcStatus = useMemoizedFn(() => {
     taskChatEvent.handleCloseGrpc()
     setExecute(false)
-    handleResetCasualChatLoading()
-    handleResetTaskChatLoading()
+    handleUpdateCasualStatus('reset')
+    handleResetTaskStatus()
   })
 
   /** 流接口开始前需要重置的一些状态 */
   const handleResetBeforeStart = useMemoizedFn(() => {
     // 清空专注模式
     handleResetFocusMode()
-    // 清空任务规划相关ID
-    handleResetTaskChatID()
+    // 清空自由对话相关的ID
+    currentCasualTaskID.current = ''
+    // 清空任务规划相关的ID
+    currentTaskPlanID.current = undefined
     taskChatEvent.handleResetPlanTree()
   })
 
@@ -532,9 +532,10 @@ function useChatIPC(params?: UseChatIPCParams) {
     handleResetSystemStream()
     handleResetFocusMode()
     handleResetPlanHistoryList()
-    handleResetCasualChatLoading()
-    handleResetTaskChatID()
-    handleResetTaskChatLoading()
+    currentCasualTaskID.current = ''
+    handleUpdateCasualStatus('reset')
+    currentTaskPlanID.current = undefined
+    handleResetTaskStatus()
 
     setCancelCasualLoading(false)
     setCancelTaskLoading(false)
@@ -636,10 +637,6 @@ function useChatIPC(params?: UseChatIPCParams) {
 
     ipcRenderer.on(`${token}-data`, (e, res: AIOutputEvent) => {
       try {
-        // 记录会话中所有的 CoordinatorId
-        if (res.CoordinatorId) {
-          updateCoordinatorIDs(res.CoordinatorId)
-        }
         if (!!res.SyncID) {
           onSyncIDChange?.(res.SyncID)
         }
@@ -684,19 +681,17 @@ function useChatIPC(params?: UseChatIPCParams) {
         if (res.Type === 'start_plan_and_execution') {
           // 触发任务规划，并传出任务规划流的标识 coordinator_id
           const startInfo = JSON.parse(ipcContent) as AIAgentGrpcApi.AIStartPlanAndExecution
-          if (startInfo.coordinator_id && planCoordinatorId.current !== startInfo.coordinator_id) {
+          if (startInfo.coordinator_id && currentTaskPlanID.current?.coordinatorId !== startInfo.coordinator_id) {
             // 设置任务规划对应的问题ID, 并清除自由对话(ReAct)的loading状态
-            taskChatID.current = {
+            currentTaskPlanID.current = {
               taskID: startInfo['re-act_task'],
               status: AITaskStatus.inProgress,
-              coordinatorId: startInfo.coordinator_id, // 取消任务规划需要的数据id
+              // 取消任务规划需要的数据id
+              coordinatorId: startInfo.coordinator_id,
             }
             // 开始任务规划后，刷新历史任务树
             sendRequest({ IsSyncMessage: true, SyncType: AIInputEventSyncTypeEnum.SYNC_TYPE_PLAN_EXEC_TASKS })
-            casualChatID.current -= 1
-            setCasualStatus((old) => ({ ...old, loading: casualChatID.current > 0 }))
-            // 标记grpc流里属于任务规划的流
-            planCoordinatorId.current = startInfo.coordinator_id
+            handleUpdateCasualStatus('remove')
             // 任务规划的loading开始置为true
             setTaskStatus(() => ({ loading: true, plan: '加载中...', task: '加载中...' }))
             // 触发任务规划UI展示的回调
@@ -711,12 +706,11 @@ function useChatIPC(params?: UseChatIPCParams) {
         if (res.Type === 'end_plan_and_execution') {
           // 结束任务规划，并传出任务规划流的标识 coordinator_id
           const startInfo = JSON.parse(ipcContent) as AIAgentGrpcApi.AIStartPlanAndExecution
-          if (startInfo.coordinator_id && planCoordinatorId.current === startInfo.coordinator_id) {
-            casualChatID.current += 1
-            setCasualStatus((old) => ({ ...old, loading: casualChatID.current > 0 }))
+          if (startInfo.coordinator_id && currentTaskPlanID.current?.coordinatorId === startInfo.coordinator_id) {
+            handleUpdateCasualStatus('add')
             taskChatEvent.handlePlanExecEnd(res)
             /**先修改任务状态loading，再改变任务树的状态 */
-            handleResetTaskChatLoading()
+            handleResetTaskStatus()
             taskChatEvent.handleCloseGrpc()
           }
           return
@@ -725,7 +719,7 @@ function useChatIPC(params?: UseChatIPCParams) {
         if (res.Type === 'memory_context') {
           // 实时记忆列表
           const lists = JSON.parse(ipcContent) as AIAgentGrpcApi.MemoryEntryList
-          if (planCoordinatorId.current === res.CoordinatorId) {
+          if (currentTaskPlanID.current?.coordinatorId === res.CoordinatorId) {
             taskMemorys.current = lists
           } else {
             reactMemorys.current = lists
@@ -778,14 +772,14 @@ function useChatIPC(params?: UseChatIPCParams) {
 
         if (res.Type === 'structured' && ['react_task_enqueue', 'react_task_dequeue'].includes(res.NodeId)) {
           // 展示只通知自由对话里的问题出入队消息
-          if (planCoordinatorId.current === res.CoordinatorId) return
+          if (currentTaskPlanID.current?.coordinatorId === res.CoordinatorId) return
           // 问题入队/问题出队
           handleQuestionQueueStatusChange(res)
           return
         }
         if (res.Type === 'structured' && res.NodeId === 'react_task_cleared') {
           // 展示只通知自由对话里的问题出入队消息
-          if (planCoordinatorId.current === res.CoordinatorId) return
+          if (currentTaskPlanID.current?.coordinatorId === res.CoordinatorId) return
           // 问题队列清空操作
           handleReActTaskCleared(res)
           return
@@ -812,7 +806,7 @@ function useChatIPC(params?: UseChatIPCParams) {
 
         if (res.Type === 'structured' && res.NodeId === 'queue_info') {
           // 因为问题队列也分自由对话和任务规划队列，所以需要先屏蔽处理任务规划的队列信息
-          if (planCoordinatorId.current === res.CoordinatorId) return
+          if (currentTaskPlanID.current?.coordinatorId === res.CoordinatorId) return
           // 问题队列信息由chatIPC-hook进行收集
           const { tasks, total_tasks } = JSON.parse(ipcContent) as AIAgentGrpcApi.QuestionQueues
           setQuestionQueue({
@@ -845,21 +839,22 @@ function useChatIPC(params?: UseChatIPCParams) {
             return
           } else if (res.NodeId === 'react_task_status_changed') {
             // 只负责获取自由对话的任务状态
-            if (planCoordinatorId.current === res.CoordinatorId) return
+            if (currentTaskPlanID.current?.coordinatorId === res.CoordinatorId) return
             /* 问题的状态变化 */
             const { react_task_id, react_task_now_status } = JSON.parse(ipcContent) as AIAgentGrpcApi.ReactTaskChanged
 
-            if (react_task_now_status === 'processing') {
-              casualChatID.current += 1
-              setCasualStatus((old) => ({ ...old, loading: casualChatID.current > 0 }))
-            }
+            if (react_task_now_status === 'processing') handleUpdateCasualStatus('add')
 
             if (['completed', 'aborted'].includes(react_task_now_status)) {
+              if (currentCasualTaskID.current && currentCasualTaskID.current === react_task_id) {
+                // 问题任务完成或者者被中止后，重置当前问题任务id
+                currentCasualTaskID.current = ''
+                setCancelCasualLoading(false)
+              }
               if (focusOfTaskID.current === react_task_id) handleResetFocusMode()
-              casualChatID.current -= 1
-              setCasualStatus((old) => ({ ...old, loading: casualChatID.current > 0 }))
-              if (taskChatID.current?.taskID === react_task_id) {
-                taskChatID.current.status = react_task_now_status as AITaskStatus
+              handleUpdateCasualStatus('remove')
+              if (currentTaskPlanID.current?.taskID === react_task_id) {
+                currentTaskPlanID.current.status = react_task_now_status as AITaskStatus
                 setCancelTaskLoading(false)
               }
             }
@@ -867,7 +862,7 @@ function useChatIPC(params?: UseChatIPCParams) {
           } else if (res.NodeId === 'status') {
             const data = JSON.parse(ipcContent) as { key: string; value: string }
             if (data.key === 're-act-loading-status-key') {
-              if (planCoordinatorId.current === res.CoordinatorId) {
+              if (currentTaskPlanID.current?.coordinatorId === res.CoordinatorId) {
                 // 任务规划-loading展示标题
                 setTaskStatus((old) => {
                   if (old.loading) {
@@ -885,7 +880,7 @@ function useChatIPC(params?: UseChatIPCParams) {
                 })
               }
             } else if (data.key === 'plan-executing-loading-status-key') {
-              if (planCoordinatorId.current === res.CoordinatorId) {
+              if (currentTaskPlanID.current?.coordinatorId === res.CoordinatorId) {
                 // 任务规划-loading展示标题
                 setTaskStatus((old) => {
                   if (old.loading) {
@@ -909,7 +904,7 @@ function useChatIPC(params?: UseChatIPCParams) {
               logEvents.sendStreamLog(event_writer_id)
             }
 
-            if (planCoordinatorId.current === res.CoordinatorId) {
+            if (currentTaskPlanID.current?.coordinatorId === res.CoordinatorId) {
               taskChatEvent.handleSetData(res)
             } else {
               casualChatEvent.handleSetData(res)
@@ -944,7 +939,7 @@ function useChatIPC(params?: UseChatIPCParams) {
             return
           }
 
-          if (planCoordinatorId.current === res.CoordinatorId) {
+          if (currentTaskPlanID.current?.coordinatorId === res.CoordinatorId) {
             taskChatEvent.handleSetData(res)
           } else {
             casualChatEvent.handleSetData(res)
@@ -953,7 +948,7 @@ function useChatIPC(params?: UseChatIPCParams) {
         }
 
         // 自由对话和任务规划共用的类型
-        if (planCoordinatorId.current === res.CoordinatorId) {
+        if (currentTaskPlanID.current?.coordinatorId === res.CoordinatorId) {
           taskChatEvent.handleSetData(res)
         } else {
           casualChatEvent.handleSetData(res)
@@ -1171,7 +1166,8 @@ function useChatIPC(params?: UseChatIPCParams) {
     return {
       fetchToken,
       fetchAIRequest,
-      fetchTaskChatID,
+      fetchCurrentCasualTaskID,
+      fetchCurrentTaskPlanID,
       fetchChatDataStore,
       onSwitchChat,
       onStart,


### PR DESCRIPTION
1. vscode的spell-checker检查新增全局自定义单词
2. 删除导出日志接口参数里的CoordinatorIDs字段，UI逻辑已无用，并删除全局相关定义和使用
3. 将获取当前任务规划ID的方法名更改，并全局替换
4. 将拼写错误的单词进行修正
5. useChatIPC-hook新增记录当前自由对话问题的任务ID，问题可能是任务规划回答，开发定义、逻辑和方法