### PR TITLE
feat: irify ai

### DIFF
--- a/app/main/handlers/assets.js
+++ b/app/main/handlers/assets.js
@@ -1,4 +1,5 @@
 const { ipcMain, BrowserWindow } = require('electron')
+const isDev = require('electron-is-dev')
 const { htmlTemplateDir } = require('../filePath')
 const compressing = require('compressing')
 const fs = require('fs')
@@ -901,5 +902,152 @@ td {
   }
   ipcMain.handle('PrintReportPdfFromTemplate', async (e, params) => {
     return await asyncPrintReportPdfFromTemplate(params)
+  })
+
+  /** markdown PDF：printId -> { code, theme } */
+  const markdownPdfPrintPayloadMap = new Map()
+  const markdownPdfPrintReadyResolvers = new Map()
+
+  ipcMain.handle('GetMarkdownPdfPrintPayload', async (e, printId) => {
+    return markdownPdfPrintPayloadMap.get(printId) || null
+  })
+
+  ipcMain.handle('MarkdownPdfPrintReady', async (e, printId) => {
+    const resolve = markdownPdfPrintReadyResolvers.get(printId)
+    if (resolve) {
+      markdownPdfPrintReadyResolvers.delete(printId)
+      resolve()
+    }
+    return { ok: true }
+  })
+
+  const patchMarkdownPdfPrintLayout = async (printWin) => {
+    await printWin.webContents.insertCSS(`
+      @page { margin: 0; size: A4; }
+      html, body, #root {
+        margin: 0 !important;
+        padding: 0 !important;
+        width: 100% !important;
+        background: var(--Colors-Use-Neutral-Bg-Hover, #f0f1f3) !important;
+      }
+      [class*="markdown-pdf-print"] {
+        box-sizing: border-box !important;
+        padding: 20px !important;
+        background: var(--Colors-Use-Neutral-Bg-Hover, #f0f1f3) !important;
+      }
+      .stream-markdown .container,
+      .stream-markdown .\\!container {
+        width: 100% !important;
+        max-width: none !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+      }
+    `)
+  }
+
+  const waitMarkdownPrintPageResources = async (printWin) => {
+    await printWin.webContents.executeJavaScript(`
+      new Promise((resolve) => {
+        const done = () => {
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => resolve(true))
+          })
+        }
+        const waitFonts = (document.fonts && document.fonts.ready)
+          ? document.fonts.ready.catch(() => {})
+          : Promise.resolve()
+        const imgs = Array.from(document.images || [])
+        const waitImages = Promise.all(
+          imgs.map((img) => {
+            if (img.complete) return Promise.resolve()
+            return new Promise((r) => {
+              img.addEventListener('load', r, { once: true })
+              img.addEventListener('error', r, { once: true })
+            })
+          })
+        )
+        Promise.all([waitFonts, waitImages]).then(() => {
+          setTimeout(done, 500)
+        })
+      });
+    `)
+    await printWin.webContents.executeJavaScript(`
+      new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve(true))));
+    `)
+  }
+
+  /**
+   * Markdown 导出 PDF：隐藏窗口加载 StreamMarkdown 页面（与 YakRunner 预览一致）
+   */
+  const asyncPrintMarkdownPdfFromTemplate = async (params) => {
+    const { outputPath, code, theme = 'light' } = params || {}
+    if (!outputPath || typeof outputPath !== 'string') {
+      throw new Error('PrintMarkdownPdfFromTemplate: outputPath required')
+    }
+    if (code === undefined || code === null) {
+      throw new Error('PrintMarkdownPdfFromTemplate: code required')
+    }
+
+    const printId = `md-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    markdownPdfPrintPayloadMap.set(printId, { code: String(code), theme: theme || 'light' })
+
+    let printWin = null
+    try {
+      const readyPromise = new Promise((resolve, reject) => {
+        markdownPdfPrintReadyResolvers.set(printId, resolve)
+        setTimeout(() => {
+          if (markdownPdfPrintReadyResolvers.has(printId)) {
+            markdownPdfPrintReadyResolvers.delete(printId)
+            reject(new Error('PrintMarkdownPdfFromTemplate: render timeout'))
+          }
+        }, 120000)
+      })
+
+      // A4 可打印宽度约 794px（96dpi），与 PDF 页宽对齐，避免两侧白边
+      printWin = new BrowserWindow({
+        show: false,
+        width: 794,
+        height: 1800,
+        webPreferences: {
+          preload: path.join(__dirname, '../preload.js'),
+          nodeIntegration: true,
+          contextIsolation: false,
+          sandbox: true,
+        },
+      })
+
+      const search = `window=markdown-pdf-print&printId=${encodeURIComponent(printId)}`
+      if (isDev) {
+        await printWin.loadURL(`http://127.0.0.1:3000/?${search}`)
+      } else {
+        await printWin.loadFile(path.resolve(__dirname, '../../renderer/pages/main/index.html'), { search })
+      }
+
+      await readyPromise
+      await patchMarkdownPdfPrintLayout(printWin)
+      await waitMarkdownPrintPageResources(printWin)
+
+      const pdfBuffer = await printWin.webContents.printToPDF({
+        printBackground: true,
+        margins: {
+          marginType: 'none',
+        },
+        pageSize: 'A4',
+        preferCSSPageSize: true,
+        landscape: false,
+      })
+      fs.writeFileSync(outputPath, pdfBuffer)
+      return { ok: true }
+    } finally {
+      markdownPdfPrintPayloadMap.delete(printId)
+      markdownPdfPrintReadyResolvers.delete(printId)
+      if (printWin && !printWin.isDestroyed()) {
+        printWin.destroy()
+      }
+    }
+  }
+
+  ipcMain.handle('PrintMarkdownPdfFromTemplate', async (e, params) => {
+    return await asyncPrintMarkdownPdfFromTemplate(params)
   })
 }

--- a/app/renderer/src/main/public/locales/en/irifyAiCodeAudit.json
+++ b/app/renderer/src/main/public/locales/en/irifyAiCodeAudit.json
@@ -1,0 +1,7 @@
+{
+  "welcomeTitle": "IRify AI Code Audit",
+  "welcomeHint": "Use the panel on the right to work with AI on security review and code questions. Open a local folder to get started.",
+  "quickStart": "Get started",
+  "openLocalFolder": "Open local folder",
+  "recentlyOpened": "Recently opened"
+}

--- a/app/renderer/src/main/public/locales/en/yakitRoute.json
+++ b/app/renderer/src/main/public/locales/en/yakitRoute.json
@@ -51,6 +51,8 @@
     "domainAssets": "Domain Assets",
     "penTest": "PenTest",
     "codeAudit": "Code Audit",
+    "irifyAiCodeAudit": "AI Code Audit",
+    "irifyAiCodeAuditDescribe": "Open a local project and use ReAct AI for assisted code audit.",
     "auditRuleCodeAnalysis": "Analyze code behavior by writing audit rules to identify risky code fragments; supports multiple languages such as Java, PHP, Yaklang, and Go (Golang).",
     "database": "Database",
     "securityTools": "Security Tools",

--- a/app/renderer/src/main/public/locales/zh/irifyAiCodeAudit.json
+++ b/app/renderer/src/main/public/locales/zh/irifyAiCodeAudit.json
@@ -1,0 +1,7 @@
+{
+  "welcomeTitle": "IRify AI 代码审计",
+  "welcomeHint": "使用右侧与 AI 协作，进行安全审查与代码问答。打开本地文件夹即可开始。",
+  "quickStart": "快速开始",
+  "openLocalFolder": "打开本地文件夹",
+  "recentlyOpened": "最近打开"
+}

--- a/app/renderer/src/main/public/locales/zh/yakitRoute.json
+++ b/app/renderer/src/main/public/locales/zh/yakitRoute.json
@@ -51,6 +51,8 @@
     "domainAssets": "域名资产",
     "penTest": "渗透测试",
     "codeAudit": "代码审计",
+    "irifyAiCodeAudit": "AI代码审计",
+    "irifyAiCodeAuditDescribe": "本地目录打开项目，使用 ReAct AI 辅助代码审计",
     "auditRuleCodeAnalysis": "通过编写审计规则对代码行为进行分析，发现代码中的风险片段，支持Java、PHP、Yaklang、Golang等多种语言",
     "database": "数据库",
     "securityTools": "安全工具",

--- a/app/renderer/src/main/src/components/withHistoryAIReActChat.tsx
+++ b/app/renderer/src/main/src/components/withHistoryAIReActChat.tsx
@@ -48,6 +48,7 @@ export interface HistoryAIReActChatBridge {
   onStop: () => void
   onChatFromHistory: (session: string) => void
   setActiveChat: React.Dispatch<React.SetStateAction<AISession | undefined>>
+  aiReActChatRef: React.RefObject<AIReActChatRefProps>
 }
 
 export interface HistoryAIReActChatSlotOptions {
@@ -106,6 +107,8 @@ export interface HistoryAIReActChatProviderProps {
   focusModeLoop: HistoryAIReActFocusModeLoop
   children: React.ReactNode
   httpFuzzTabPageId?: string
+  /** 在 onStartRequest / onSendRequest 发往引擎前对 AIInputEvent 做附加处理 */
+  enrichAIInputEvent?: (event: AIInputEvent) => AIInputEvent
 }
 
 export const HistoryAIReActChatProvider = memo(function HistoryAIReActChatProviderInner({
@@ -113,6 +116,7 @@ export const HistoryAIReActChatProvider = memo(function HistoryAIReActChatProvid
   focusModeLoop,
   children,
   httpFuzzTabPageId,
+  enrichAIInputEvent,
 }: HistoryAIReActChatProviderProps) {
   const aiReActChatRef = useRef<AIReActChatRefProps>(null)
   const [showFreeChat, setShowFreeChat] = useSafeState(false)
@@ -212,6 +216,9 @@ export const HistoryAIReActChatProvider = memo(function HistoryAIReActChatProvid
           params = prependWebFuzzerHttpRequestToSendFields(params, raw)
         }
       }
+      if (enrichAIInputEvent) {
+        params = enrichAIInputEvent(params)
+      }
       resolve({
         params,
         extraParams: newChat,
@@ -241,6 +248,9 @@ export const HistoryAIReActChatProvider = memo(function HistoryAIReActChatProvid
       if (raw != null) {
         params = prependWebFuzzerHttpRequestToSendFields(params, raw)
       }
+    }
+    if (enrichAIInputEvent) {
+      params = enrichAIInputEvent(params)
     }
 
     return new Promise<AISendResProps>((resolve) => {
@@ -322,6 +332,7 @@ export const HistoryAIReActChatProvider = memo(function HistoryAIReActChatProvid
       onStop,
       onChatFromHistory,
       setActiveChat,
+      aiReActChatRef,
     }),
     [activeID, events, onStop, onChatFromHistory, setActiveChat],
   )

--- a/app/renderer/src/main/src/components/yakitSideTab/YakitSideTab.module.scss
+++ b/app/renderer/src/main/src/components/yakitSideTab/YakitSideTab.module.scss
@@ -167,7 +167,20 @@
 }
 
 .tab-wrap-vertical-right {
+  flex-direction: row;
+  align-items: stretch;
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  // 先渲染的子节点为侧栏内容，yakit-side-tab 在 DOM 后序，贴屏幕/面板最右侧
+  > :first-child {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
   .yakit-side-tab {
+    flex-shrink: 0;
     @include tab() {
       height: unset;
       padding-top: 12px;

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/YakitEditor.module.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/YakitEditor.module.scss
@@ -46,3 +46,9 @@
     font-size: 12px;
   }
 }
+.mark-down-wrapper {
+  padding: 8px 12px;
+  background-color: var(--Colors-Use-Neutral-Bg-Hover);
+  height: 100%;
+  overflow: auto;
+}

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/YakitEditor.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/YakitEditor.tsx
@@ -92,6 +92,8 @@ import type { IEvent } from 'monaco-editor'
 import { TFunction, useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { fontSizeOptions, useEditorFontSize } from '@/store/editorFontSize'
 import { JSONParseLog } from '@/utils/tool'
+import { isIRify } from '@/utils/envfile'
+import { StreamMarkdown } from '@/pages/assetViewer/reportRenders/markdownRender'
 
 export interface CodecTypeProps {
   key?: string
@@ -1950,92 +1952,98 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
         }}
       >
         <ShortcutKeyFocusHook style={{ height: '100%', width: '100%', overflow: 'hidden' }} focusId={focusIds}>
-          <MonacoEditor
-            // height={100}
-            theme={theme || 'kurior'}
-            value={value}
-            onChange={setValue || onChange}
-            language={language}
-            editorDidMount={(editor: YakitIMonacoEditor, monaco) => {
-              setEditor(editor)
-              if (keepSearchName) {
-                const keyword = keepSearchNameMap.get(keepSearchName)
-                if (keyword) {
-                  openFind(editor, keyword)
+          {isIRify() && language === 'markdown' ? (
+            <div className={styles['mark-down-wrapper']}>
+              <StreamMarkdown content={value} />
+            </div>
+          ) : (
+            <MonacoEditor
+              // height={100}
+              theme={theme || 'kurior'}
+              value={value}
+              onChange={setValue || onChange}
+              language={language}
+              editorDidMount={(editor: YakitIMonacoEditor, monaco) => {
+                setEditor(editor)
+                if (keepSearchName) {
+                  const keyword = keepSearchNameMap.get(keepSearchName)
+                  if (keyword) {
+                    openFind(editor, keyword)
+                  }
                 }
-              }
-              /** 编辑器关光标，设置坐标0的初始位置 */
-              editor.setSelection({
-                startColumn: 0,
-                startLineNumber: 0,
-                endColumn: 0,
-                endLineNumber: 0,
-              })
+                /** 编辑器关光标，设置坐标0的初始位置 */
+                editor.setSelection({
+                  startColumn: 0,
+                  startLineNumber: 0,
+                  endColumn: 0,
+                  endLineNumber: 0,
+                })
 
-              if (editor) {
-                /** Yak语言 代码错误检查 */
-                const model = editor.getModel()
-                if (model) {
-                  yakStaticAnalyze.run(editor, model)
-                  model.onDidChangeContent(() => {
+                if (editor) {
+                  /** Yak语言 代码错误检查 */
+                  const model = editor.getModel()
+                  if (model) {
                     yakStaticAnalyze.run(editor, model)
-                  })
+                    model.onDidChangeContent(() => {
+                      yakStaticAnalyze.run(editor, model)
+                    })
+                  }
                 }
-              }
 
-              editor.onKeyDown((e) => {
-                // 是否直接使用编辑器快捷键 不走自定义逻辑
-                const isUseDefaultShortcut = isYakEditorDefaultShortcut(e.browserEvent)
-                if (!isUseDefaultShortcut) {
-                  // 判断当前输入是否激活 编辑器内部快捷键
-                  const isActiveYakEditor = isYakEditorShortcut(e.browserEvent)
-                  if (isActiveYakEditor) {
-                    const keys = convertKeyEventToKeyCombination(e.browserEvent)
-                    if (keys) {
-                      let sortKeys = sortKeysCombination(keys)
-                      const keyToMenu = keyBindingRef.current[sortKeys.join('-')]
-                      if (!keyToMenu) return
-                      menuItemHandle(keyToMenu[0], keyToMenu)
+                editor.onKeyDown((e) => {
+                  // 是否直接使用编辑器快捷键 不走自定义逻辑
+                  const isUseDefaultShortcut = isYakEditorDefaultShortcut(e.browserEvent)
+                  if (!isUseDefaultShortcut) {
+                    // 判断当前输入是否激活 编辑器内部快捷键
+                    const isActiveYakEditor = isYakEditorShortcut(e.browserEvent)
+                    if (isActiveYakEditor) {
+                      const keys = convertKeyEventToKeyCombination(e.browserEvent)
+                      if (keys) {
+                        let sortKeys = sortKeysCombination(keys)
+                        const keyToMenu = keyBindingRef.current[sortKeys.join('-')]
+                        if (!keyToMenu) return
+                        menuItemHandle(keyToMenu[0], keyToMenu)
+                      }
+                      e.browserEvent.stopImmediatePropagation()
+                      return
                     }
-                    e.browserEvent.stopImmediatePropagation()
-                    return
+                    // 判断当前输入是否激活 页面级或全局快捷键
+                    const event = isPageOrGlobalShortcut(e.browserEvent)
+                    if (event) {
+                      // 未接入时特殊处理removePage,接入monaco快捷键后移除此项
+                      if (['removePage'].includes(event)) e.browserEvent.stopImmediatePropagation()
+                      // 由于目前 存在老版本键盘快捷键(line：1112) 暂时不做后续接入 等待第二版焦点与monaco绑定
+                      // e.browserEvent.stopImmediatePropagation()
+                      return
+                    }
                   }
-                  // 判断当前输入是否激活 页面级或全局快捷键
-                  const event = isPageOrGlobalShortcut(e.browserEvent)
-                  if (event) {
-                    // 未接入时特殊处理removePage,接入monaco快捷键后移除此项
-                    if (['removePage'].includes(event)) e.browserEvent.stopImmediatePropagation()
-                    // 由于目前 存在老版本键盘快捷键(line：1112) 暂时不做后续接入 等待第二版焦点与monaco绑定
-                    // e.browserEvent.stopImmediatePropagation()
-                    return
-                  }
-                }
-              })
+                })
 
-              if (editorDidMount) editorDidMount(editor, monaco)
-            }}
-            options={{
-              readOnly: readOnly,
-              scrollBeyondLastLine: false,
-              fontWeight: '500',
-              fontSize: nowFontsize || 12,
-              showFoldingControls: 'always',
-              showUnused: true,
-              wordWrap: noWordWrap ? 'off' : 'on',
-              renderLineHighlight,
-              lineNumbers: noLineNumber ? 'off' : 'on',
-              minimap: noMiniMap ? { enabled: false } : undefined,
-              lineNumbersMinChars: lineNumbersMinChars || 5,
-              contextmenu: false,
-              renderWhitespace: 'all',
-              bracketPairColorization: {
-                enabled: true,
-                independentColorPoolPerBracketType: true,
-              },
-              fixedOverflowWidgets: true,
-              renderValidationDecorations: renderValidationDecorations,
-            }}
-          />
+                if (editorDidMount) editorDidMount(editor, monaco)
+              }}
+              options={{
+                readOnly: readOnly,
+                scrollBeyondLastLine: false,
+                fontWeight: '500',
+                fontSize: nowFontsize || 12,
+                showFoldingControls: 'always',
+                showUnused: true,
+                wordWrap: noWordWrap ? 'off' : 'on',
+                renderLineHighlight,
+                lineNumbers: noLineNumber ? 'off' : 'on',
+                minimap: noMiniMap ? { enabled: false } : undefined,
+                lineNumbersMinChars: lineNumbersMinChars || 5,
+                contextmenu: false,
+                renderWhitespace: 'all',
+                bracketPairColorization: {
+                  enabled: true,
+                  independentColorPoolPerBracketType: true,
+                },
+                fixedOverflowWidgets: true,
+                renderValidationDecorations: renderValidationDecorations,
+              }}
+            />
+          )}
         </ShortcutKeyFocusHook>
       </div>
     </div>

--- a/app/renderer/src/main/src/constants/irifyFocusMode.ts
+++ b/app/renderer/src/main/src/constants/irifyFocusMode.ts
@@ -1,0 +1,2 @@
+/** Irify「AI 代码审计」与引擎约定的 focus / 场景标识（同 HTTP 历史的 `http_flow_analyze` 一类） */
+export const IRIFY_FOCUS_MODE_CODE_SECURITY_AUDIT = 'code_security_audit' as const

--- a/app/renderer/src/main/src/enums/yakitRoute.ts
+++ b/app/renderer/src/main/src/enums/yakitRoute.ts
@@ -85,6 +85,8 @@ export enum YakitRoute {
   YakRunner_Code_Scan = 'yakrunner-code-scan',
   // YakRunner代码审计
   YakRunner_Audit_Code = 'yakrunner-audit-code',
+  /** Irify：AI 代码审计 */
+  Irify_AI_Code_Audit = 'irify-ai-code-audit',
   // YakRunner项目管理
   YakRunner_Project_Manager = 'yakrunner-project-manager',
   // YakRunner扫描历史

--- a/app/renderer/src/main/src/index.tsx
+++ b/app/renderer/src/main/src/index.tsx
@@ -6,18 +6,19 @@ import NewApp from './NewApp'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import { DndProvider } from 'react-dnd'
 // import {createRoot} from "react-dom/client"
-import './yakitUI.scss'
-import './theme/yakit.scss'
-import './yakitLib.scss'
-import './assets/global.scss'
-import { Suspense, useEffect, useState } from 'react'
-import ChildNewApp from './ChildNewApp'
-import { getLocalValue } from './utils/kv'
-import { GetMainColor, getRemoteI18nGV } from './utils/envfile'
-import i18n from '@/i18n/i18n'
-import { useTheme } from './hook/useTheme'
-import { generateAllThemeColors } from './yakit-colors-generator'
-import { debugToPrintLogs } from './utils/logCollection'
+import "./yakitUI.scss"
+import "./theme/yakit.scss"
+import "./yakitLib.scss"
+import "./assets/global.scss"
+import {Suspense, useEffect, useState} from "react"
+import ChildNewApp from "./ChildNewApp"
+import MarkdownPdfPrintPage from "./pages/yakRunner/MarkdownPdfPrint/MarkdownPdfPrintPage"
+import {getLocalValue} from "./utils/kv"
+import {GetMainColor, getRemoteI18nGV} from "./utils/envfile"
+import i18n from "@/i18n/i18n"
+import {useTheme} from "./hook/useTheme"
+import {generateAllThemeColors} from "./yakit-colors-generator"
+import { debugToPrintLogs } from "./utils/logCollection"
 
 window.MonacoEnvironment = {
   getWorkerUrl: function (moduleId, label) {
@@ -108,15 +109,18 @@ const App = () => {
     applyThemeColors(theme, generateAllThemeColor)
   }, [theme])
 
-  return windowType === 'child' ? <ChildNewApp /> : <NewApp />
+    if (windowType === "markdown-pdf-print") {
+        return <MarkdownPdfPrintPage />
+    }
+    return windowType === "child" ? <ChildNewApp /> : <NewApp />
 }
 
 // 只在子窗口移除 loading
-if (window.location.search.includes('window=child')) {
-  const initialLoading = document.getElementById('initial-loading')
-  if (initialLoading) {
-    initialLoading.remove()
-  }
+if (window.location.search.includes("window=child") || window.location.search.includes("window=markdown-pdf-print")) {
+    const initialLoading = document.getElementById("initial-loading")
+    if (initialLoading) {
+        initialLoading.remove()
+    }
 }
 
 // const divRoot = document.getElementById("root")

--- a/app/renderer/src/main/src/index.tsx
+++ b/app/renderer/src/main/src/index.tsx
@@ -6,19 +6,19 @@ import NewApp from './NewApp'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import { DndProvider } from 'react-dnd'
 // import {createRoot} from "react-dom/client"
-import "./yakitUI.scss"
-import "./theme/yakit.scss"
-import "./yakitLib.scss"
-import "./assets/global.scss"
-import {Suspense, useEffect, useState} from "react"
-import ChildNewApp from "./ChildNewApp"
-import MarkdownPdfPrintPage from "./pages/yakRunner/MarkdownPdfPrint/MarkdownPdfPrintPage"
-import {getLocalValue} from "./utils/kv"
-import {GetMainColor, getRemoteI18nGV} from "./utils/envfile"
-import i18n from "@/i18n/i18n"
-import {useTheme} from "./hook/useTheme"
-import {generateAllThemeColors} from "./yakit-colors-generator"
-import { debugToPrintLogs } from "./utils/logCollection"
+import './yakitUI.scss'
+import './theme/yakit.scss'
+import './yakitLib.scss'
+import './assets/global.scss'
+import { Suspense, useEffect, useState } from 'react'
+import ChildNewApp from './ChildNewApp'
+import MarkdownPdfPrintPage from './pages/yakRunner/MarkdownPdfPrint/MarkdownPdfPrintPage'
+import { getLocalValue } from './utils/kv'
+import { GetMainColor, getRemoteI18nGV } from './utils/envfile'
+import i18n from '@/i18n/i18n'
+import { useTheme } from './hook/useTheme'
+import { generateAllThemeColors } from './yakit-colors-generator'
+import { debugToPrintLogs } from './utils/logCollection'
 
 window.MonacoEnvironment = {
   getWorkerUrl: function (moduleId, label) {
@@ -109,18 +109,18 @@ const App = () => {
     applyThemeColors(theme, generateAllThemeColor)
   }, [theme])
 
-    if (windowType === "markdown-pdf-print") {
-        return <MarkdownPdfPrintPage />
-    }
-    return windowType === "child" ? <ChildNewApp /> : <NewApp />
+  if (windowType === 'markdown-pdf-print') {
+    return <MarkdownPdfPrintPage />
+  }
+  return windowType === 'child' ? <ChildNewApp /> : <NewApp />
 }
 
 // 只在子窗口移除 loading
-if (window.location.search.includes("window=child") || window.location.search.includes("window=markdown-pdf-print")) {
-    const initialLoading = document.getElementById("initial-loading")
-    if (initialLoading) {
-        initialLoading.remove()
-    }
+if (window.location.search.includes('window=child') || window.location.search.includes('window=markdown-pdf-print')) {
+  const initialLoading = document.getElementById('initial-loading')
+  if (initialLoading) {
+    initialLoading.remove()
+  }
 }
 
 // const divRoot = document.getElementById("root")

--- a/app/renderer/src/main/src/pages/ai-agent/components/FileList.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/components/FileList.tsx
@@ -11,8 +11,9 @@ import { formatTimestamp } from '@/utils/timeUtil'
 import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
 import emiter from '@/utils/eventBus/eventBus'
 import { AITabsEnum } from '../defaultConstant'
-import { TabKey } from './aiFileSystemList/type'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import { useMemoizedFn } from 'ahooks'
+import { isIRify } from '@/utils/envfile'
 
 export interface FileListItem {
   name: string
@@ -51,6 +52,13 @@ const FileList: FC<FileListProps> = ({ title, fileList }) => {
   const switchAIActTab = () => {
     emiter.emit('switchAIActTab', JSON.stringify({ key: AITabsEnum.Operation_Log }))
   }
+  const onOpenFileByPath = useMemoizedFn((path: string, isDir: boolean) => {
+    if (!isDir && isIRify()) {
+      const name = getFileName(path, isDir)
+      emiter.emit('onOpenFileByPath', JSON.stringify({ params: { path, name }, isHistory: false }))
+    }
+  })
+
   return (
     <div className={styles['file-list']}>
       <div className={styles['file-list-title']}>
@@ -78,8 +86,18 @@ const FileList: FC<FileListProps> = ({ title, fileList }) => {
                   >
                     {action}
                   </YakitTag>
-                  <div className={styles['file-list-item-icon']}>{Icon}</div>
-                  <div className={styles['file-list-item-name']}>{dangerFile}</div>
+                  <div
+                    className={styles['file-list-item-icon']}
+                    onClick={() => onOpenFileByPath(data.path, data.is_dir)}
+                  >
+                    {Icon}
+                  </div>
+                  <div
+                    className={styles['file-list-item-name']}
+                    onClick={() => onOpenFileByPath(data.path, data.is_dir)}
+                  >
+                    {dangerFile}
+                  </div>
                   <div className={styles['file-list-item-desc']}>{message}</div>
                 </div>
                 <div className={styles['file-list-item-actions']}>

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiMarkdown/AIMarkdown.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiMarkdown/AIMarkdown.tsx
@@ -8,6 +8,7 @@ import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
 import {
   OutlineChevronsDownUpIcon,
   OutlineChevronsUpDownIcon,
+  OutlineDocumentIcon,
   OutlineDownloadIcon,
   OutlineNotebookIcon,
 } from '@/assets/icon/outline'
@@ -22,6 +23,9 @@ import { saveABSFileToOpen } from '@/utils/openWebsite'
 import { useGoEditNotepad } from '@/pages/notepadManage/hook/useGoEditNotepad'
 import { ModifyNotepadPageInfoProps } from '@/store/pageInfo'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import { isIRify } from '@/utils/envfile'
+import { FileSuffix } from '@/pages/yakRunner/FileTree/icon'
+import emiter from '@/utils/eventBus/eventBus'
 
 export const AIMarkdown: React.FC<AIMarkdownProps> = React.memo((props) => {
   const { content, nodeLabel, className, modalInfo, referenceNode } = props
@@ -79,12 +83,23 @@ export const AIMarkdown: React.FC<AIMarkdownProps> = React.memo((props) => {
     }
     goAddNotepad(params)
   })
+  const onOpenFile = useMemoizedFn(() => {
+    emiter.emit(
+      'onOpenTemporaryFile',
+      JSON.stringify({ name: '审计报告.md', code: item.content, icon: FileSuffix['md'], language: 'markdown' }),
+    )
+  })
   return (
     <ChatCard
       titleText={nodeLabel}
       titleExtra={<ModalInfo {...modalInfo} />}
       titleMore={
         <div className={styles['header-extra']}>
+          {isIRify() && (
+            <Tooltip title="AI代码审计中打开">
+              <YakitButton size="small" type="text" icon={<OutlineDocumentIcon />} onClick={onOpenFile} />
+            </Tooltip>
+          )}
           <Tooltip title={t('AIMarkdown.openFromNotepad')}>
             <YakitButton size="small" type="text" icon={<OutlineNotebookIcon />} onClick={onGoToNote} />
           </Tooltip>

--- a/app/renderer/src/main/src/pages/ai-agent/store/ChatDataStore.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/store/ChatDataStore.ts
@@ -196,6 +196,8 @@ export const aiChatDataStore = new ChatDataStore()
 export const knowledgeBaseDataStore = new ChatDataStore()
 export const histroyAiStore = new ChatDataStore()
 export const FlowAiStore = new ChatDataStore()
+/** Irify：独立「AI 代码审计」页 */
+export const irifyAiCodeAuditPageAiStore = new ChatDataStore()
 
 /** Web Fuzzer 每页 `new WebFuzzerAiStore(pageId)`；与上方单例区分需用 `instanceof` */
 export class WebFuzzerAiStore extends ChatDataStore {
@@ -211,5 +213,6 @@ export type ChatDataStoreKey =
   | 'knowledgeBaseDataStore'
   | 'histroyAiStore'
   | 'FlowAiStore'
+  | 'irifyAiCodeAuditPageAiStore'
   | 'WebFuzzerAiStore'
   | 'unknown'

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
@@ -149,6 +149,10 @@ export const AIReActChatContents: React.FC<AIReActChatContentsPProps> = React.me
   )
 
   const Footer = useCallback(() => {
+    const hasSessionContext = !!activeChat?.SessionID || chats.elements.length > 0
+    if (!hasSessionContext) {
+      return null
+    }
     return execute ? (
       <div style={{ height: '40px', maxWidth: '784px', margin: '0 auto' }}>
         {!!casualTitle ? (
@@ -169,7 +173,7 @@ export const AIReActChatContents: React.FC<AIReActChatContentsPProps> = React.me
     ) : (
       <div className={styles['end']}>当前会话已停止</div>
     )
-  }, [casualTitle, execute])
+  }, [activeChat?.SessionID, casualTitle, chats.elements.length, execute])
   const Header = useCallback(
     () =>
       casualLoadMoreLoading ? (

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcApi.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcApi.ts
@@ -29,6 +29,8 @@ export enum AISourceEnum {
   webFuzzer = 'webFuzzer',
   /** flow 来源 */
   flow = 'flow',
+  /** irify 来源 */
+  irify = 'irify',
   /** 兼容老数据 */
   other = '',
 }

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/useGetChatDataStoreKey.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/useGetChatDataStoreKey.ts
@@ -7,6 +7,7 @@ import {
   aiChatDataStore,
   knowledgeBaseDataStore,
   WebFuzzerAiStore,
+  irifyAiCodeAuditPageAiStore,
 } from '@/pages/ai-agent/store/ChatDataStore'
 import type { AISource } from './grpcApi'
 
@@ -23,6 +24,8 @@ function useGetChatDataStoreKey() {
         return 'aiChatDataStore'
       case knowledgeBaseDataStore:
         return 'knowledgeBaseDataStore'
+      case irifyAiCodeAuditPageAiStore:
+        return 'irifyAiCodeAuditPageAiStore'
       default:
         if (store instanceof WebFuzzerAiStore) return 'WebFuzzerAiStore'
         return 'unknown'

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/useGetChatDataStoreKey.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/useGetChatDataStoreKey.ts
@@ -46,6 +46,8 @@ export const getAISourceFromChatDataStoreKey = (key: ChatDataStoreKey): AISource
       return 'knowledgeBase'
     case 'WebFuzzerAiStore':
       return 'webFuzzer'
+    case 'irifyAiCodeAuditPageAiStore':
+      return 'irify'
     default:
       return undefined
   }

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditFileTree.tsx
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditFileTree.tsx
@@ -1,21 +1,25 @@
-import React, { memo, useEffect, useMemo, useState } from 'react'
-import { useMemoizedFn } from 'ahooks'
-import { OpenedFileProps, OpenFolderDraggerProps, RunnerFileTreeProps } from './RunnerFileTreeType'
+import React, { memo, useEffect, useMemo, useRef, useState } from 'react'
+import { useMemoizedFn, useSize, useUpdateEffect } from 'ahooks'
+import {
+  OpenedFileProps,
+  OpenFolderDraggerProps,
+  RunnerFileTreeProps,
+} from '@/pages/yakRunner/RunnerFileTree/RunnerFileTreeType'
 import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
-import { OutlinePluscircleIcon, OutlineRefreshIcon, OutlineXIcon } from '@/assets/icon/outline'
-import { CollapseList } from '../CollapseList/CollapseList'
-import { FileNodeMapProps, FileNodeProps, FileTreeListProps } from '../FileTree/FileTreeType'
-import { FileDefault, FileSuffix, KeyToIcon } from '../FileTree/icon'
-import useStore from '../hooks/useStore'
-import useDispatcher from '../hooks/useDispatcher'
-import useYakRunnerStoreRefs from '../hooks/useYakRunnerStoreRefs'
-import { FileTree } from '../FileTree/FileTree'
+import { OutlinCompileIcon, OutlinePluscircleIcon, OutlineRefreshIcon, OutlineXIcon } from '@/assets/icon/outline'
+import { CollapseList } from '@/pages/yakRunner/CollapseList/CollapseList'
+import { FileNodeMapProps, FileNodeProps, FileTreeListProps } from '@/pages/yakRunner/FileTree/FileTreeType'
+import { FileDefault, FileSuffix, KeyToIcon } from '@/pages/yakRunner/FileTree/icon'
+import useStore from '@/pages/yakRunner/hooks/useStore'
+import useDispatcher from '@/pages/yakRunner/hooks/useDispatcher'
+import useYakRunnerStoreRefs from '@/pages/yakRunner/hooks/useYakRunnerStoreRefs'
+import { FileTree } from '@/pages/yakRunner/FileTree/FileTree'
 
 import classNames from 'classnames'
-import styles from './RunnerFileTree.module.scss'
+import styles from '@/pages/yakRunner/RunnerFileTree/RunnerFileTree.module.scss'
 import { YakitDropdownMenu } from '@/components/yakitUI/YakitDropdownMenu/YakitDropdownMenu'
-import { YakitMenuItemType } from '@/components/yakitUI/YakitMenu/YakitMenu'
-import { FileDetailInfo } from '../RunnerTabs/RunnerTabsType'
+import { YakitMenuItemProps, YakitMenuItemType } from '@/components/yakitUI/YakitMenu/YakitMenu'
+import { FileDetailInfo } from '@/pages/yakRunner/RunnerTabs/RunnerTabsType'
 import {
   getDefaultActiveFile,
   getNameByPath,
@@ -30,10 +34,11 @@ import {
   removeYakRunnerAreaFileInfo,
   removeAreaFilesInfo,
   setAreaFileActive,
+  setYakRunnerHistory,
   updateAreaFileInfo,
   updateAreaFileInfoToDelete,
-} from '../utils'
-import { OpenFileByPathProps, YakRunnerHistoryProps } from '../YakRunnerType'
+} from '@/pages/yakRunner/utils'
+import { OpenFileByPathProps, YakRunnerHistoryProps } from '@/pages/yakRunner/YakRunnerType'
 import emiter from '@/utils/eventBus/eventBus'
 import {
   clearMapFileDetail,
@@ -41,7 +46,7 @@ import {
   getMapFileDetail,
   removeMapFileDetail,
   setMapFileDetail,
-} from '../FileTreeMap/FileMap'
+} from '@/pages/yakRunner/FileTreeMap/FileMap'
 import {
   clearMapFolderDetail,
   getMapAllFolderKey,
@@ -49,7 +54,7 @@ import {
   hasMapFolderDetail,
   removeMapFolderDetail,
   setMapFolderDetail,
-} from '../FileTreeMap/ChildMap'
+} from '@/pages/yakRunner/FileTreeMap/ChildMap'
 import { v4 as uuidv4 } from 'uuid'
 import cloneDeep from 'lodash/cloneDeep'
 import { failed, success, warn } from '@/utils/notification'
@@ -59,7 +64,7 @@ import { showYakitModal } from '@/components/yakitUI/YakitModal/YakitModalConfir
 import { YakitDragger } from '@/components/yakitUI/YakitForm/YakitForm'
 import { handleOpenFileSystemDialog } from '@/utils/fileSystemDialog'
 import { SystemInfo } from '@/constants/hardware'
-import { WatchFolderID } from '../FileTreeMap/watchFolderID'
+import { WatchFolderID } from '@/pages/yakRunner/FileTreeMap/watchFolderID'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import i18n from '@/i18n/i18n'
 
@@ -92,7 +97,7 @@ export const openFolder = () => {
   if (SystemInfo.mode === 'remote') {
     let absolutePath = ''
     const m = showYakitModal({
-      title: (modalT) => modalT('RunnerFileTree.enterFolderPath'),
+      title: tOriginal('RunnerFileTree.enterFolderPath'),
       width: 400,
       type: 'white',
       closable: false,
@@ -106,7 +111,7 @@ export const openFolder = () => {
           warn(tOriginal('RunnerFileTree.enterFolderPath'))
           return
         }
-        emiter.emit('onOpenFileTree', absolutePath)
+        emiter.emit('onIrifyAiCodeAuditOpenFileTree', absolutePath)
         m.destroy()
       },
     })
@@ -115,14 +120,14 @@ export const openFolder = () => {
       (data) => {
         if (data.filePaths.length) {
           let absolutePath: string = data.filePaths[0].replace(/\\/g, '\\')
-          emiter.emit('onOpenFileTree', absolutePath)
+          emiter.emit('onIrifyAiCodeAuditOpenFileTree', absolutePath)
         }
       },
     )
   }
 }
 
-export const RunnerFileTree: React.FC<RunnerFileTreeProps> = (props) => {
+export const IrifyAiCodeAuditFileTree: React.FC<RunnerFileTreeProps> = (props) => {
   const { addFileTab } = props
   const { t, i18n } = useI18nNamespaces(['yakRunner', 'yakitUi'])
   const { fileTree, areaInfo, activeFile } = useStore()
@@ -562,7 +567,7 @@ export const RunnerFileTree: React.FC<RunnerFileTreeProps> = (props) => {
     try {
       // 未打开文件夹时 创建临时文件
       if (fileTree.length === 0) {
-        addFileTab()
+        return
       } else {
         // 如若未选择则默认最顶层
         const newFoucsedKey = foucsedKey || fileTree[0].path
@@ -643,7 +648,7 @@ export const RunnerFileTree: React.FC<RunnerFileTreeProps> = (props) => {
       }
       // 打开文件夹
       else {
-        emiter.emit('onOpenFileTree', item.path)
+        emiter.emit('onIrifyAiCodeAuditOpenFileTree', item.path)
       }
     }
   })

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditPage.module.scss
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditPage.module.scss
@@ -1,0 +1,11 @@
+/* Irify「AI 代码审计」页根：与主工作区 + 侧栏 flex 链衔接，不放在 yakRunner 目录以免与 YAK Runner 功能混淆 */
+.pageRoot {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditPage.tsx
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditPage.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react'
+import { useMemoizedFn } from 'ahooks'
+import emiter from '@/utils/eventBus/eventBus'
+import { AuditCodePageInfoProps } from '@/store/pageInfo'
+import { irifyAiCodeAuditPageAiStore } from '@/pages/ai-agent/store/ChatDataStore'
+import { IRIFY_FOCUS_MODE_CODE_SECURITY_AUDIT } from '@/constants/irifyFocusMode'
+import { isIRify } from '@/utils/envfile'
+import { IrifyAiCodeAuditSidePanelLayout } from './IrifyAiCodeAuditSidePanelLayout'
+import { IrifyAiCodeAuditWorkbench } from './IrifyAiCodeAuditWorkbench'
+import { IrifyAiCodeAuditReActChatProvider } from './IrifyAiCodeAuditReActChatProvider'
+import { YakRunner } from '@/pages/yakRunner/YakRunner'
+import styles from './IrifyAiCodeAuditPage.module.scss'
+
+const IRIFY_COMPILE_AUDIT_CHAT_SEED = '开始代码审计'
+
+/** 从路由参数 / onAuditCodePageInfo 打开工程目录并预填侧栏输入（不自动发送） */
+const IrifyAiCodeAuditEntryBootstrap: React.FC<{ auditCodePageInfo?: AuditCodePageInfoProps }> = ({
+  auditCodePageInfo,
+}) => {
+  const applyEntry = useMemoizedFn((info?: AuditCodePageInfoProps) => {
+    const root = info?.Location?.trim()
+    if (!root) return
+    emiter.emit('onIrifyAiCodeAuditOpenFileTree', root)
+    window.setTimeout(() => {
+      emiter.emit('onIrifyAiCodeAuditSeedChatDraft', IRIFY_COMPILE_AUDIT_CHAT_SEED)
+    }, 0)
+  })
+
+  useEffect(() => {
+    applyEntry(auditCodePageInfo)
+  }, [auditCodePageInfo?.Location, applyEntry])
+
+  useEffect(() => {
+    const handler = (raw: string) => {
+      try {
+        const parsed: AuditCodePageInfoProps = JSON.parse(raw)
+        applyEntry(parsed)
+      } catch {
+        // ignore
+      }
+    }
+    emiter.on('onAuditCodePageInfo', handler)
+    return () => {
+      emiter.off('onAuditCodePageInfo', handler)
+    }
+  }, [applyEntry])
+
+  return null
+}
+
+export interface IrifyAiCodeAuditPageProps {
+  auditCodePageInfo?: AuditCodePageInfoProps
+}
+
+/** Irify「AI 代码审计」：主区为工作区；右侧为 Irify 专用 ReAct 侧栏。 */
+export const IrifyAiCodeAuditPage: React.FC<IrifyAiCodeAuditPageProps> = ({ auditCodePageInfo }) => {
+  if (!isIRify()) {
+    return <YakRunner />
+  }
+  return (
+    <IrifyAiCodeAuditReActChatProvider
+      cacheDataStore={irifyAiCodeAuditPageAiStore}
+      focusModeLoop={IRIFY_FOCUS_MODE_CODE_SECURITY_AUDIT}
+    >
+      <IrifyAiCodeAuditEntryBootstrap auditCodePageInfo={auditCodePageInfo} />
+      <IrifyAiCodeAuditSidePanelLayout placement="right" rootClassName={styles.pageRoot}>
+        <IrifyAiCodeAuditWorkbench />
+      </IrifyAiCodeAuditSidePanelLayout>
+    </IrifyAiCodeAuditReActChatProvider>
+  )
+}

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditReActChatProvider.tsx
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditReActChatProvider.tsx
@@ -1,0 +1,320 @@
+import React, {
+  createContext,
+  memo,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
+import { useCreation, useInViewport, useMemoizedFn, useSafeState } from 'ahooks'
+import { cloneDeep } from 'lodash'
+
+import { HistroryAIReActChat } from '@/components/AIReActChat'
+import AIAgentContext, {
+  AIAgentContextDispatcher,
+  AIAgentContextStore,
+} from '@/pages/ai-agent/useContext/AIAgentContext'
+import ChatIPCContent, {
+  AIChatIPCSendParams,
+  AISendConfigHotpatchParams,
+  AISendSyncMessageParams,
+  ChatIPCContextDispatcher,
+  ChatIPCContextStore,
+  defaultDispatcherOfChatIPC,
+} from '@/pages/ai-agent/useContext/ChatIPCContent/ChatIPCContent'
+import { AIAgentSetting } from '@/pages/ai-agent/aiAgentType'
+import { AIAgentSettingDefault } from '@/pages/ai-agent/defaultConstant'
+import { ChatDataStore } from '@/pages/ai-agent/store/ChatDataStore'
+import { AISession } from '@/pages/ai-agent/type/aiChat'
+import {
+  AIHandleStartExtraProps,
+  AIHandleStartParams,
+  AIHandleStartResProps,
+  AIReActChatProps,
+  AIReActChatRefProps,
+  AISendParams,
+  AISendResProps,
+} from '@/pages/ai-re-act/aiReActChat/AIReActChatType'
+import { AIInputEvent } from '@/pages/ai-re-act/hooks/grpcApi'
+import { ChatIPCSendType, UseChatIPCEvents } from '@/pages/ai-re-act/hooks/type'
+import useChatIPC from '@/pages/ai-re-act/hooks/useChatIPC'
+import useGetSetState from '@/pages/pluginHub/hooks/useGetSetState'
+import emiter from '@/utils/eventBus/eventBus'
+import { appendCodeAuditTargetAttachmentToEvent } from './codeAuditAttachment'
+import { IrifyWorkbenchAiAttachProvider, IrifyWorkbenchAiAttachRef } from './IrifyWorkbenchAiAttachContext'
+
+export type IrifyAiCodeAuditReActChatExternalParameters = NonNullable<AIReActChatProps['externalParameters']>
+
+export interface IrifyAiCodeAuditReActChatBridge {
+  activeID?: string
+  events: UseChatIPCEvents
+  onStop: () => void
+  onChatFromHistory: (session: string) => void
+  setActiveChat: React.Dispatch<React.SetStateAction<AISession | undefined>>
+}
+
+export interface IrifyAiCodeAuditReActChatSlotOptions {
+  externalParameters: IrifyAiCodeAuditReActChatExternalParameters
+  className?: string
+}
+
+export type IrifyAiCodeAuditReActChatSlotRender = (options: IrifyAiCodeAuditReActChatSlotOptions) => React.ReactNode
+
+export type IrifyAiCodeAuditFocusModeLoop = NonNullable<AIInputEvent['FocusModeLoop']>
+
+export interface IrifyAiCodeAuditReActChatContextValue {
+  renderIrifyAiReActChat: IrifyAiCodeAuditReActChatSlotRender
+  setShowFreeChat: React.Dispatch<React.SetStateAction<boolean>>
+  irifyAiReActChatBridge: IrifyAiCodeAuditReActChatBridge
+  focusModeLoop: IrifyAiCodeAuditFocusModeLoop
+}
+
+const IrifyAiCodeAuditReActChatContext = createContext<IrifyAiCodeAuditReActChatContextValue | null>(null)
+
+export function useIrifyAiCodeAuditReActChat(): IrifyAiCodeAuditReActChatContextValue {
+  const ctx = useContext(IrifyAiCodeAuditReActChatContext)
+  if (!ctx) {
+    throw new Error('useIrifyAiCodeAuditReActChat 必须在 IrifyAiCodeAuditReActChatProvider 内使用')
+  }
+  return ctx
+}
+
+export interface IrifyAiCodeAuditReActChatProviderProps {
+  cacheDataStore: ChatDataStore
+  focusModeLoop: IrifyAiCodeAuditFocusModeLoop
+}
+
+type InnerProps = PropsWithChildren<IrifyAiCodeAuditReActChatProviderProps> & {
+  attachRef: React.MutableRefObject<IrifyWorkbenchAiAttachRef>
+}
+
+const IrifyAiCodeAuditReActChatProviderInner = memo(function IrifyAiCodeAuditReActChatProviderInner({
+  cacheDataStore,
+  focusModeLoop,
+  children,
+  attachRef,
+}: InnerProps) {
+  const aiReActChatRef = useRef<AIReActChatRefProps>(null)
+  const [showFreeChat, setShowFreeChat] = useSafeState(false)
+  const refRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const onSeed = (text: string) => {
+      const apply = () => aiReActChatRef.current?.setValue(text)
+      apply()
+      window.setTimeout(apply, 50)
+      window.setTimeout(apply, 200)
+    }
+    emiter.on('onIrifyAiCodeAuditSeedChatDraft', onSeed)
+    return () => {
+      emiter.off('onIrifyAiCodeAuditSeedChatDraft', onSeed)
+    }
+  }, [])
+
+  const [inViewport = true] = useInViewport(refRef)
+
+  const [setting, setSetting, getSetting] = useGetSetState<AIAgentSetting>(cloneDeep(AIAgentSettingDefault))
+  const [chats, setChats, getChats] = useGetSetState<AISession[]>([])
+  const [activeChat, setActiveChat] = useSafeState<AISession>()
+
+  const [chatIPCData, events] = useChatIPC({
+    cacheDataStore,
+  })
+
+  const { execute } = chatIPCData
+
+  const activeID = useCreation(() => {
+    return activeChat?.SessionID
+  }, [activeChat])
+
+  const handleSendInteractiveMessage = useMemoizedFn((params: AIChatIPCSendParams, type: ChatIPCSendType) => {
+    const { value, id, optionValue } = params
+    if (!activeID) return
+    if (!id) return
+
+    const info: AIInputEvent = {
+      IsInteractiveMessage: true,
+      InteractiveId: id,
+      InteractiveJSONInput: value,
+    }
+    events.onSend({ token: activeID, type, params: info, optionValue })
+  })
+
+  const handleSendCasual = useMemoizedFn((params: AIChatIPCSendParams) => {
+    const targetParams = { ...params, FocusModeLoop: focusModeLoop }
+    handleSendInteractiveMessage(targetParams, 'casual')
+  })
+
+  const onStartRequest = useMemoizedFn((data: AIHandleStartParams) => {
+    const newChat: AIHandleStartExtraProps = {
+      chatId: activeChat?.SessionID,
+    }
+
+    return new Promise<AIHandleStartResProps>((resolve) => {
+      let params: AIInputEvent = { ...data.params, FocusModeLoop: focusModeLoop }
+      params = appendCodeAuditTargetAttachmentToEvent(params, attachRef.current.projectRootAbsPath)
+      resolve({
+        params,
+        extraParams: newChat,
+      })
+    })
+  })
+
+  const onChatFromHistory = useMemoizedFn((session: string) => {
+    events.onDelChats([session])
+  })
+
+  const onStop = useMemoizedFn(() => {
+    if (execute && activeID) {
+      events.onClose(activeID)
+    }
+  })
+
+  const handleSend = useMemoizedFn((params: AIChatIPCSendParams) => {
+    const targetParams = { ...params, FocusModeLoop: focusModeLoop }
+    handleSendInteractiveMessage(targetParams, '')
+  })
+
+  const onSendRequest = useMemoizedFn((data: AISendParams) => {
+    let params: AIInputEvent = { ...data.params, FocusModeLoop: focusModeLoop }
+    params = appendCodeAuditTargetAttachmentToEvent(params, attachRef.current.projectRootAbsPath)
+
+    return new Promise<AISendResProps>((resolve) => {
+      resolve({
+        params,
+      })
+    })
+  })
+
+  const handleSendSyncMessage = useMemoizedFn((data: AISendSyncMessageParams) => {
+    if (!activeID) return
+    const { syncType, SyncJsonInput } = data
+    const params = { ...data.params, FocusModeLoop: focusModeLoop }
+    const info: AIInputEvent = {
+      IsSyncMessage: true,
+      SyncType: syncType,
+      SyncJsonInput,
+      Params: params,
+    }
+    events.onSend({ token: activeID, type: '', params: info })
+  })
+
+  const handleSendConfigHotpatch = useMemoizedFn((data: AISendConfigHotpatchParams) => {
+    if (!activeID) return
+    const { hotpatchType } = data
+
+    const params = { ...data.params, FocusModeLoop: focusModeLoop }
+    const info: AIInputEvent = {
+      IsConfigHotpatch: true,
+      HotpatchType: hotpatchType,
+      Params: params,
+    }
+    events.onSend({ token: activeID, type: '', params: info })
+  })
+
+  const store: ChatIPCContextStore = useCreation(() => {
+    return {
+      chatIPCData,
+      planReviewTreeKeywordsMap: new Map(),
+      reviewExpand: false,
+    }
+  }, [chatIPCData])
+
+  const dispatcher: ChatIPCContextDispatcher = useCreation(() => {
+    return {
+      ...defaultDispatcherOfChatIPC,
+      chatIPCEvents: events,
+      handleSendCasual,
+      handleStop: onStop,
+      handleSend,
+      handleSendSyncMessage,
+      handleSendConfigHotpatch,
+    }
+  }, [events])
+
+  const stores: AIAgentContextStore = useMemo(() => {
+    return {
+      setting: setting,
+      chats: chats,
+      activeChat: activeChat,
+    }
+  }, [setting, chats, activeChat])
+
+  const dispatchers: AIAgentContextDispatcher = useMemo(() => {
+    return {
+      getSetting: getSetting,
+      setSetting: setSetting,
+      setChats: setChats,
+      getChats: getChats,
+      setActiveChat: setActiveChat,
+      getChatData: cacheDataStore.get,
+    }
+  }, [])
+
+  const irifyAiReActChatBridge: IrifyAiCodeAuditReActChatBridge = useMemo(
+    () => ({
+      activeID,
+      events,
+      onStop,
+      onChatFromHistory,
+      setActiveChat,
+    }),
+    [activeID, events, onStop, onChatFromHistory, setActiveChat],
+  )
+
+  const renderIrifyAiReActChat = useCallback(
+    ({ className, externalParameters }: IrifyAiCodeAuditReActChatSlotOptions) => (
+      <HistroryAIReActChat
+        className={className}
+        refRef={refRef}
+        showFreeChat={showFreeChat}
+        setShowFreeChat={setShowFreeChat}
+        aiReActChatRef={aiReActChatRef}
+        onStartRequest={onStartRequest}
+        onSendRequest={onSendRequest}
+        inViewport={inViewport}
+        setSetting={setSetting}
+        externalParameters={externalParameters}
+      />
+    ),
+    [inViewport, onSendRequest, onStartRequest, showFreeChat],
+  )
+
+  const contextValue = useMemo(
+    (): IrifyAiCodeAuditReActChatContextValue => ({
+      renderIrifyAiReActChat,
+      setShowFreeChat,
+      irifyAiReActChatBridge,
+      focusModeLoop,
+    }),
+    [renderIrifyAiReActChat, setShowFreeChat, irifyAiReActChatBridge, focusModeLoop],
+  )
+
+  return (
+    <AIAgentContext.Provider value={{ store: stores, dispatcher: dispatchers }}>
+      <ChatIPCContent.Provider value={{ store, dispatcher }}>
+        <IrifyAiCodeAuditReActChatContext.Provider value={contextValue}>
+          {children}
+        </IrifyAiCodeAuditReActChatContext.Provider>
+      </ChatIPCContent.Provider>
+    </AIAgentContext.Provider>
+  )
+})
+
+IrifyAiCodeAuditReActChatProviderInner.displayName = 'IrifyAiCodeAuditReActChatProviderInner'
+
+export const IrifyAiCodeAuditReActChatProvider: React.FC<PropsWithChildren<IrifyAiCodeAuditReActChatProviderProps>> = ({
+  children,
+  ...props
+}) => {
+  const attachRef = useRef<IrifyWorkbenchAiAttachRef>({})
+  return (
+    <IrifyWorkbenchAiAttachProvider attachRef={attachRef}>
+      <IrifyAiCodeAuditReActChatProviderInner {...props} attachRef={attachRef}>
+        {children}
+      </IrifyAiCodeAuditReActChatProviderInner>
+    </IrifyWorkbenchAiAttachProvider>
+  )
+}

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditReActChatProvider.tsx
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditReActChatProvider.tsx
@@ -11,7 +11,7 @@ import React, {
 import { useCreation, useInViewport, useMemoizedFn, useSafeState } from 'ahooks'
 import { cloneDeep } from 'lodash'
 
-import { HistroryAIReActChat } from '@/components/AIReActChat'
+import { HistroryAIReActChat } from '@/components/historyAIReActChat'
 import AIAgentContext, {
   AIAgentContextDispatcher,
   AIAgentContextStore,

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditSidePanelLayout.module.scss
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditSidePanelLayout.module.scss
@@ -1,0 +1,60 @@
+/* 与 HTTPHistory AI 分栏同构，独立在 irify 页内，避免动公共 chat 改造 */
+.layoutRoot {
+  height: 100%;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.railLeft {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+.railRight {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.tabWrap {
+  flex: 1 1 0 !important;
+  min-width: 0 !important;
+  min-height: 0 !important;
+  overflow: hidden !important;
+  align-items: stretch !important;
+}
+
+.tabContent {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+
+.aiChatWrap {
+  flex: 1 1 0;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-self: stretch;
+  width: 100%;
+}

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditSidePanelLayout.tsx
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditSidePanelLayout.tsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useState } from 'react'
+import { useCreation, useMemoizedFn } from 'ahooks'
+import { Tooltip } from 'antd'
+import { OutlineBotIcon, OutlinePlusIcon, OutlineXIcon } from '@/assets/icon/outline'
+import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
+import { YakitResizeBox } from '@/components/yakitUI/YakitResizeBox/YakitResizeBox'
+import { YakitSideTab } from '@/components/yakitSideTab/YakitSideTab'
+import { YakitTabsProps } from '@/components/yakitSideTab/YakitSideTabType'
+import { useIrifyAiCodeAuditReActChat } from './IrifyAiCodeAuditReActChatProvider'
+import { AIInputInnerFeatureEnum } from '@/pages/ai-agent/template/type'
+import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import classNames from 'classnames'
+import styles from './IrifyAiCodeAuditSidePanelLayout.module.scss'
+
+const defaultAiTabs: YakitTabsProps[] = [
+  {
+    icon: <OutlineBotIcon />,
+    label: 'HTTPHistory.AI',
+    value: 'ai',
+  },
+]
+
+type Placement = 'left' | 'right'
+
+export interface IrifyAiCodeAuditSidePanelLayoutProps {
+  children: React.ReactNode
+  placement?: Placement
+  rootClassName?: string
+  sideTabs?: YakitTabsProps[]
+}
+
+const IrifyAiCodeAuditSidePanelLayoutInner: React.FC<{
+  placement: Placement
+  rootClassName?: string
+  children: React.ReactNode
+  sideTabs: YakitTabsProps[]
+}> = ({ placement, children, rootClassName, sideTabs }) => {
+  const { t, i18n } = useI18nNamespaces(['history'])
+  const { renderIrifyAiReActChat, setShowFreeChat, irifyAiReActChatBridge, focusModeLoop } =
+    useIrifyAiCodeAuditReActChat()
+
+  const [activeKey, setActiveKey] = useState<string>('ai')
+  const [openTabsFlag, setOpenTabsFlag] = useState<boolean>(true)
+
+  useEffect(() => {
+    setShowFreeChat(true)
+  }, [setShowFreeChat])
+
+  const onActiveKey = useMemoizedFn((key: string) => {
+    if (key === 'ai') {
+      setShowFreeChat(true)
+    }
+    setActiveKey(key)
+  })
+
+  const resizeBoxProps = useCreation(() => {
+    if (placement === 'left') {
+      return openTabsFlag
+        ? { firstRatio: '20%', secondRatio: '80%' }
+        : { firstRatio: '24px', secondRatio: 'calc(100% - 24px)' }
+    }
+    return openTabsFlag
+      ? { firstRatio: '80%', secondRatio: '20%' }
+      : { firstRatio: 'calc(100% - 24px)', secondRatio: '24px' }
+  }, [openTabsFlag, placement])
+
+  const aiChat =
+    activeKey === 'ai' &&
+    renderIrifyAiReActChat({
+      className: styles.aiChatWrap,
+      externalParameters: {
+        isOpen: false,
+        rightIcon: (
+          <>
+            <Tooltip title="新建对话">
+              <YakitButton
+                type="text2"
+                icon={<OutlinePlusIcon />}
+                onClick={() => {
+                  const { activeID, events, onStop, onChatFromHistory, setActiveChat } = irifyAiReActChatBridge
+                  if (activeID) {
+                    onStop()
+                    events.onReset()
+                    onChatFromHistory(activeID)
+                    setActiveChat(undefined)
+                  }
+                }}
+              />
+            </Tooltip>
+            <YakitButton type="text2" icon={<OutlineXIcon />} onClick={() => setOpenTabsFlag(false)} />
+          </>
+        ),
+        footerLeftTypes: [
+          AIInputInnerFeatureEnum.AIReviewRuleSelect,
+          AIInputInnerFeatureEnum.AIModelSelect,
+          {
+            type: AIInputInnerFeatureEnum.AIFocusMode,
+            props: {
+              value: focusModeLoop,
+              onChange: () => {},
+              disabled: true,
+            },
+          },
+        ],
+        filterMentionType: ['focusMode'],
+      },
+    })
+
+  const rail = (
+    <div className={placement === 'left' ? styles.railLeft : styles.railRight}>
+      <YakitSideTab
+        key={i18n.language}
+        t={t}
+        type={placement === 'right' ? 'vertical-right' : undefined}
+        yakitTabs={sideTabs}
+        activeKey={activeKey}
+        onActiveKey={onActiveKey}
+        show={openTabsFlag}
+        setShow={setOpenTabsFlag}
+        className={styles.tabWrap}
+      >
+        <div className={styles.tabContent}>{aiChat}</div>
+      </YakitSideTab>
+    </div>
+  )
+
+  if (placement === 'left') {
+    return (
+      <div className={classNames(styles.layoutRoot, rootClassName)}>
+        <YakitResizeBox
+          isVer={false}
+          freeze={openTabsFlag}
+          isRecalculateWH={openTabsFlag}
+          firstNode={() => rail}
+          lineStyle={{ display: '' }}
+          firstNodeStyle={{ minWidth: 0, flexShrink: 0 }}
+          firstMinSize={openTabsFlag ? '325px' : '24px'}
+          secondMinSize={720}
+          secondNode={children}
+          secondNodeStyle={{
+            padding: undefined,
+            display: '',
+            minWidth: 0,
+            overflow: 'hidden',
+          }}
+          {...resizeBoxProps}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className={classNames(styles.layoutRoot, rootClassName)}>
+      <YakitResizeBox
+        isVer={false}
+        freeze={openTabsFlag}
+        isRecalculateWH={openTabsFlag}
+        firstNode={children}
+        lineStyle={{ display: '' }}
+        firstNodeStyle={{ minWidth: 0, overflow: 'hidden' }}
+        firstMinSize={openTabsFlag ? '480px' : '200px'}
+        secondMinSize={openTabsFlag ? '340px' : '28px'}
+        secondNode={() => rail}
+        secondNodeStyle={{
+          padding: undefined,
+          display: '',
+          minWidth: 0,
+          overflow: 'hidden',
+        }}
+        {...resizeBoxProps}
+      />
+    </div>
+  )
+}
+
+export const IrifyAiCodeAuditSidePanelLayout: React.FC<IrifyAiCodeAuditSidePanelLayoutProps> = ({
+  children,
+  placement = 'right',
+  rootClassName,
+  sideTabs = defaultAiTabs,
+}) => {
+  return (
+    <IrifyAiCodeAuditSidePanelLayoutInner placement={placement} rootClassName={rootClassName} sideTabs={sideTabs}>
+      {children}
+    </IrifyAiCodeAuditSidePanelLayoutInner>
+  )
+}

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditWelcomePage.module.scss
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditWelcomePage.module.scss
@@ -1,0 +1,150 @@
+/* Irify AI 代码审计欢迎区（自包含样式，避免改动 Yak Runner） */
+.yak-runner-welcome-page {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
+  overflow: auto;
+
+  .title {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    .icon-style {
+      display: flex;
+      justify-content: center;
+      svg {
+        width: 72px;
+        height: 72px;
+      }
+    }
+    .header-style {
+      color: var(--Colors-Use-Neutral-Text-1-Title);
+      font-size: 32px;
+      font-weight: 600;
+      line-height: 40px;
+      text-align: center;
+    }
+    .welcome-subtitle {
+      max-width: 520px;
+      color: var(--Colors-Use-Neutral-Text-3-Secondary);
+      font-size: 14px;
+      font-weight: 400;
+      line-height: 22px;
+      text-align: center;
+    }
+  }
+  .operate-box {
+    width: 100%;
+    max-width: 1200px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    padding: 0px 145px;
+    .operate {
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      border-radius: 8px;
+      background: var(--Colors-Use-Neutral-Bg);
+      .title-style {
+        color: var(--Colors-Use-Neutral-Text-1-Title);
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 20px;
+        text-align: center;
+      }
+      .operate-btn-group {
+        display: flex;
+        align-items: flex-start;
+        flex-wrap: wrap;
+        gap: 16px;
+        &-irify {
+          justify-content: center;
+        }
+        .btn-style {
+          flex: 1 0 0;
+          padding: 16px 16px 16px 12px;
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          border-radius: 4px;
+          cursor: pointer;
+          user-select: none;
+          .btn-title {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            color: var(--Colors-Use-Neutral-Text-1-Title);
+            font-size: 14px;
+            font-weight: 400;
+            line-height: 20px;
+            white-space: nowrap;
+            svg {
+              width: 32px;
+              height: 32px;
+            }
+          }
+
+          .icon-style {
+            svg {
+              width: 20px;
+              height: 20px;
+              color: var(--Colors-Use-Neutral-Text-3-Secondary);
+            }
+          }
+        }
+        .btn-open-folder {
+          background: rgba(53, 216, 238, 0.1);
+          &:hover {
+            background: rgba(53, 216, 238, 0.2);
+          }
+        }
+      }
+    }
+
+    .recent-open {
+      max-width: 100%;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      .title-style {
+        color: var(--Colors-Use-Neutral-Text-1-Title);
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 20px;
+      }
+      .recent-list {
+        display: flex;
+        flex-direction: column;
+        .list-opt {
+          cursor: pointer;
+          padding: 4px 0px;
+          display: flex;
+          align-items: flex-start;
+          gap: 8px;
+          font-size: 14px;
+          font-weight: 400;
+          line-height: 20px;
+          white-space: nowrap;
+          .file-name {
+            color: var(--Colors-Use-Main-Primary);
+          }
+          .file-path {
+            color: var(--Colors-Use-Neutral-Disable);
+          }
+          &:hover {
+            .file-path {
+              color: var(--Colors-Use-Main-Hover);
+              text-decoration: underline;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditWelcomePage.tsx
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditWelcomePage.tsx
@@ -1,0 +1,123 @@
+import React, { memo, useEffect, useRef, useState } from 'react'
+import { useMemoizedFn, useSize } from 'ahooks'
+import classNames from 'classnames'
+import { OutlineImportIcon } from '@/assets/icon/outline'
+import { SolidIrifyMiniLogoIcon } from '@/assets/icon/colors'
+import { YakRunnerOpenFolderIcon } from '@/pages/yakRunner/icon'
+import emiter from '@/utils/eventBus/eventBus'
+import { getYakRunnerHistory } from '@/pages/yakRunner/utils'
+import { YakRunnerHistoryProps } from '@/pages/yakRunner/YakRunnerType'
+import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import { handleOpenFileSystemDialog } from '@/utils/fileSystemDialog'
+import { SystemInfo } from '@/constants/hardware'
+import { showYakitModal } from '@/components/yakitUI/YakitModal/YakitModalConfirm'
+import { OpenFolderDragger } from '@/pages/yakRunner/RunnerFileTree/RunnerFileTree'
+import { warn } from '@/utils/notification'
+import i18n from '@/i18n/i18n'
+import styles from './IrifyAiCodeAuditWelcomePage.module.scss'
+
+const tYak = i18n.getFixedT(null, 'yakRunner')
+
+export const IrifyAiCodeAuditWelcomePage: React.FC = memo(() => {
+  const { t } = useI18nNamespaces(['irifyAiCodeAudit'])
+  const ref = useRef<HTMLDivElement>(null)
+  const size = useSize(ref)
+  const [historyList, setHistoryList] = useState<YakRunnerHistoryProps[]>([])
+
+  const getHistoryList = useMemoizedFn(async () => {
+    try {
+      const list = await getYakRunnerHistory()
+      setHistoryList(list)
+    } catch (error) {}
+  })
+  useEffect(() => {
+    getHistoryList()
+  }, [])
+
+  const openFolder = useMemoizedFn(() => {
+    if (SystemInfo.mode === 'remote') {
+      let absolutePath = ''
+      const m = showYakitModal({
+        title: tYak('RunnerFileTree.enterFolderPath'),
+        width: 400,
+        type: 'white',
+        closable: false,
+        centered: true,
+        content: <OpenFolderDragger setAbsolutePath={(v) => (absolutePath = v)} />,
+        onCancel: () => {
+          m.destroy()
+        },
+        onOk: async () => {
+          if (absolutePath.length === 0) {
+            warn(tYak('RunnerFileTree.enterFolderPath'))
+            return
+          }
+          emiter.emit('onIrifyAiCodeAuditOpenFileTree', absolutePath)
+          m.destroy()
+        },
+      })
+    } else {
+      handleOpenFileSystemDialog({ title: tYak('RunnerFileTree.selectFolder'), properties: ['openDirectory'] }).then(
+        (data) => {
+          if (data.filePaths.length) {
+            const absolutePath: string = data.filePaths[0].replace(/\\/g, '\\')
+            emiter.emit('onIrifyAiCodeAuditOpenFileTree', absolutePath)
+          }
+        },
+      )
+    }
+  })
+
+  return (
+    <div className={styles['yak-runner-welcome-page']} ref={ref}>
+      <div className={styles['title']}>
+        <div className={styles['icon-style']}>
+          <SolidIrifyMiniLogoIcon />
+        </div>
+        <div className={styles['header-style']}>{t('welcomeTitle')}</div>
+        <div className={styles['welcome-subtitle']}>{t('welcomeHint')}</div>
+      </div>
+      <div className={styles['operate-box']} style={size && size.width < 600 ? { padding: '0px 20px' } : {}}>
+        <div className={styles['operate']}>
+          <div className={styles['title-style']}>{t('quickStart')}</div>
+          <div
+            className={classNames(styles['operate-btn-group'], {
+              [styles['operate-btn-group-irify']]: true,
+            })}
+          >
+            <div className={classNames(styles['btn-style'], styles['btn-open-folder'])} onClick={openFolder}>
+              <div className={styles['btn-title']}>
+                <YakRunnerOpenFolderIcon />
+                {t('openLocalFolder')}
+              </div>
+              <OutlineImportIcon className={styles['icon-style']} />
+            </div>
+          </div>
+        </div>
+
+        <div className={styles['recent-open']}>
+          <div className={styles['title-style']}>{t('recentlyOpened')}</div>
+          <div className={styles['recent-list']}>
+            {historyList
+              .filter((h) => !h.isFile)
+              .slice(0, 3)
+              .map((item) => {
+                return (
+                  <div
+                    key={item.path}
+                    className={styles['list-opt']}
+                    onClick={() => {
+                      emiter.emit('onIrifyAiCodeAuditOpenFileTree', item.path)
+                    }}
+                  >
+                    <div className={styles['file-name']}>{item.name}</div>
+                    <div className={classNames(styles['file-path'], 'yakit-single-line-ellipsis')}>{item.path}</div>
+                  </div>
+                )
+              })}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+})

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditWorkbench.tsx
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyAiCodeAuditWorkbench.tsx
@@ -1,0 +1,1089 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCreation,
+  useDebounceEffect,
+  useGetState,
+  useInViewport,
+  useMemoizedFn,
+  useThrottleFn,
+  useUpdateEffect,
+} from 'ahooks'
+import { IrifyLeftSideBar } from './IrifyLeftSideBar'
+import { BottomSideBar } from '@/pages/yakRunner/BottomSideBar/BottomSideBar'
+import { FileNodeMapProps, FileTreeListProps } from '@/pages/yakRunner/FileTree/FileTreeType'
+import {
+  addAreaFileInfo,
+  excludeAreaInfoCode,
+  getCodeByPath,
+  getCodeSizeByPath,
+  getNameByPath,
+  getPathParent,
+  grpcFetchCreateFile,
+  grpcFetchFileTree,
+  judgeAreaExistFilePath,
+  judgeAreaExistFileUnSave,
+  MAX_FILE_SIZE_BYTES,
+  monacaLanguageType,
+  removeYakRunnerAreaFileInfo,
+  setAreaFileActive,
+  setYakRunnerHistory,
+  updateAreaFileInfo,
+} from '@/pages/yakRunner/utils'
+import {
+  getIrifyAiCodeAuditLastAreaFile,
+  getIrifyAiCodeAuditLastFolderExpanded,
+  setIrifyAiCodeAuditLastAreaFile,
+  setIrifyAiCodeAuditLastFolderExpanded,
+} from './irifyAiCodeAuditStorage'
+import { AreaInfoProps, OpenFileByPathProps, YakRunnerHistoryProps } from '@/pages/yakRunner/YakRunnerType'
+import { failed, success, yakitNotify } from '@/utils/notification'
+import YakRunnerContext, {
+  YakRunnerContextDispatcher,
+  YakRunnerContextStore,
+} from '@/pages/yakRunner/hooks/YakRunnerContext'
+import { FileDefault, FileSuffix, FolderDefault } from '@/pages/yakRunner/FileTree/icon'
+import { RunnerTabs } from '@/pages/yakRunner/RunnerTabs/RunnerTabs'
+import { IrifyAiCodeAuditWelcomePage } from './IrifyAiCodeAuditWelcomePage'
+
+import { DragDropContext, ResponderProvided, DropResult } from '@hello-pangea/dnd'
+
+import classNames from 'classnames'
+import styles from '@/pages/yakRunner/YakRunner.module.scss'
+import { SplitView } from '@/pages/yakRunner/SplitView/SplitView'
+import { BottomEditorDetails } from '@/pages/yakRunner/BottomEditorDetails/BottomEditorDetails'
+import { ShowItemType } from '@/pages/yakRunner/BottomEditorDetails/BottomEditorDetailsType'
+import { FileDetailInfo } from '@/pages/yakRunner/RunnerTabs/RunnerTabsType'
+import cloneDeep from 'lodash/cloneDeep'
+import { v4 as uuidv4 } from 'uuid'
+import moment from 'moment'
+import emiter from '@/utils/eventBus/eventBus'
+import {
+  clearMapFileDetail,
+  getMapAllFileKey,
+  getMapFileDetail,
+  setMapFileDetail,
+} from '@/pages/yakRunner/FileTreeMap/FileMap'
+import {
+  clearMapFolderDetail,
+  getMapFolderDetail,
+  hasMapFolderDetail,
+  setMapFolderDetail,
+} from '@/pages/yakRunner/FileTreeMap/ChildMap'
+import { sendDuplexConn } from '@/utils/duplex/duplex'
+import { StringToUint8Array } from '@/utils/str'
+import { YakitResizeBox } from '@/components/yakitUI/YakitResizeBox/YakitResizeBox'
+import { YakitHint } from '@/components/yakitUI/YakitHint/YakitHint'
+import { LeftSideType } from '@/pages/yakRunner/LeftSideBar/LeftSideBarType'
+import { YakitRoute } from '@/enums/yakitRoute'
+import { ShortcutKeyPage } from '@/utils/globalShortcutKey/events/pageMaps'
+import { registerShortcutKeyHandle, unregisterShortcutKeyHandle } from '@/utils/globalShortcutKey/utils'
+import { getStorageYakRunnerShortcutKeyEvents } from '@/utils/globalShortcutKey/events/page/yakRunner'
+import useShortcutKeyTrigger from '@/utils/globalShortcutKey/events/useShortcutKeyTrigger'
+import { WatchFolderID } from '@/pages/yakRunner/FileTreeMap/watchFolderID'
+import { randomString } from '@/utils/randomUtil'
+import { YakitTabsProps } from '@/components/yakitSideTab/YakitSideTabType'
+import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import { useIrifyWorkbenchAiAttachRef } from './IrifyWorkbenchAiAttachContext'
+const { ipcRenderer } = window.require('electron')
+
+// 模拟tabs分块及对应文件
+// 设想方法1：区域4等分，减少其结构嵌套层数，分别用1、2、3、4标注其展示所处区域 例如全屏展示则为[1、2、3、4]
+/**
+ * 设想方法2（数组每一项对应着垂直项,其中elements中代表横着的项）：[
+//
+ * {
+        elements:[{...},{...}]
+ * },
+ * {
+ *
+ * }
+ * ]
+*/
+
+export const YakRunnerTab: YakitTabsProps[] = [
+  {
+    label: 'YakRunner.resourceExplorer',
+    value: 'file-tree',
+  },
+  {
+    label: 'YakRunner.helpDocumentation',
+    value: 'help-doc',
+  },
+]
+
+/** 仅资源管理器（无帮助文档侧栏） */
+export const YakRunnerTabFileTreeOnly: YakitTabsProps[] = [
+  {
+    label: 'YakRunner.resourceExplorer',
+    value: 'file-tree',
+  },
+]
+
+export const IrifyAiCodeAuditWorkbench: React.FC = () => {
+  const { t, i18n } = useI18nNamespaces(['yakRunner', 'yakitUi'])
+
+  /** ---------- 文件树 ---------- */
+  const [fileTree, setFileTree] = useState<FileTreeListProps[]>([])
+  const [areaInfo, setAreaInfo] = useState<AreaInfoProps[]>([])
+  const [activeFile, setActiveFile] = useState<FileDetailInfo>()
+  const [runnerTabsId, setRunnerTabsId] = useState<string>()
+  const [isShowFileHint, setShowFileHint] = useState<boolean>(false)
+
+  const irifyWorkbenchAttachRef = useIrifyWorkbenchAiAttachRef()
+  useEffect(() => {
+    if (!irifyWorkbenchAttachRef) return
+    if (fileTree.length > 0 && fileTree[0].path?.trim()) {
+      irifyWorkbenchAttachRef.current.projectRootAbsPath = fileTree[0].path.trim()
+    } else {
+      irifyWorkbenchAttachRef.current.projectRootAbsPath = undefined
+    }
+  }, [fileTree, irifyWorkbenchAttachRef])
+
+  const handleFetchFileList = useMemoizedFn((path: string, callback?: (value: FileNodeMapProps[]) => any) => {
+    if (getMapFileDetail(path).isCreate) {
+      if (callback) callback([])
+      return
+    }
+    grpcFetchFileTree(path)
+      .then((res) => {
+        // console.log("文件树", res)
+        if (callback) callback(res)
+      })
+      .catch((error) => {
+        yakitNotify('error', t('YakRunner.fetchFileTreeFailed', { error: error + '' }))
+        if (callback) callback([])
+      })
+  })
+
+  // 轮询下标
+  const loadIndexRef = useRef<number>(0)
+  // 接口是否运行中
+  const isFetchRef = useRef<boolean>(false)
+
+  // 提前注入Map
+  const insertFileMap = useMemoizedFn((path) => {
+    isFetchRef.current = true
+    loadIndexRef.current += 1
+    handleFetchFileList(path, (value) => {
+      isFetchRef.current = false
+      if (value.length > 0) {
+        // 此处还需缓存结构Map用于结构信息
+        /* 示例 [
+                    {
+                        key:path,
+                        child:[path1,path2,...]
+                    },
+                    {
+                        key:path1,
+                        child:[path11,path12,...]
+                    }]
+                */
+        let childArr: string[] = []
+        // 文件Map
+        value.forEach((item) => {
+          // 注入文件结构Map
+          childArr.push(item.path)
+          // 文件Map
+          setMapFileDetail(item.path, item)
+        })
+        setMapFolderDetail(path, childArr)
+      }
+    })
+  })
+
+  // 轮询提前加载未打开文件
+  const loadFileMap = useMemoizedFn(() => {
+    // 接口运行中 暂时拦截下一个接口请求
+    if (isFetchRef.current) return
+    if (fileTree.length === 0) return
+    const keys = getMapAllFileKey()
+    const index = loadIndexRef.current
+    if (!keys[index]) return
+    // 如果为文件时无需加载 加载下一个
+    if (!getMapFileDetail(keys[index]).isFolder) {
+      loadIndexRef.current += 1
+      return
+    }
+    // 校验其子项是否存在 存在则无需加载
+    const isLoadChild = hasMapFolderDetail(keys[index])
+    if (isLoadChild) {
+      loadIndexRef.current += 1
+      return
+    }
+    insertFileMap(keys[index])
+  })
+
+  const clearMap = useMemoizedFn(() => {
+    clearMapFileDetail()
+    clearMapFolderDetail()
+  })
+
+  useEffect(() => {
+    loadIndexRef.current = 0
+    clearMap()
+    let id = setInterval(() => {
+      loadFileMap()
+    }, 100)
+    return () => clearInterval(id)
+  }, [])
+
+  // 重置Map与轮询
+  const resetMap = useMemoizedFn((isFirst) => {
+    loadIndexRef.current = 0
+    clearMap()
+    // FileTree缓存清除
+    isFirst && emiter.emit('onResetFileTree', JSON.stringify({ reset: false }))
+  })
+
+  const startMonitorFolder = useMemoizedFn((absolutePath) => {
+    if (WatchFolderID.Id) {
+      // 先停止 再启用
+      const stopData = StringToUint8Array(
+        JSON.stringify({
+          operate: 'stop',
+          id: WatchFolderID.Id,
+        }),
+      )
+      sendDuplexConn({
+        Data: stopData,
+        MessageType: 'file_monitor',
+        Timestamp: new Date().getTime(),
+      })
+    }
+
+    WatchFolderID.Id = randomString(16)
+    const startData = StringToUint8Array(
+      JSON.stringify({
+        operate: 'new',
+        path: absolutePath,
+        id: WatchFolderID.Id,
+      }),
+    )
+    sendDuplexConn({
+      Data: startData,
+      MessageType: 'file_monitor',
+      Timestamp: new Date().getTime(),
+    })
+  })
+
+  const onInitTreeFun = useMemoizedFn(async (rootPath: string, isFirst: boolean = true) => {
+    try {
+      // 开启文件夹监听
+      startMonitorFolder(rootPath)
+      // console.log("onOpenFileTreeFun", rootPath)
+      const lastFolder = await getNameByPath(rootPath)
+
+      if (rootPath.length > 0 && lastFolder.length > 0) {
+        resetMap(isFirst)
+        const node: FileNodeMapProps = {
+          parent: null,
+          name: lastFolder,
+          path: rootPath,
+          isFolder: true,
+          icon: FolderDefault,
+        }
+
+        handleFetchFileList(rootPath, (list) => {
+          // 如若打开空文件夹 则不可展开
+          if (list.length === 0) {
+            node.isLeaf = true
+          }
+          setMapFileDetail(rootPath, node)
+          const children: FileTreeListProps[] = []
+
+          let childArr: string[] = []
+          list.forEach((item) => {
+            // 注入文件结构Map
+            childArr.push(item.path)
+            // 文件Map
+            setMapFileDetail(item.path, item)
+            // 注入tree结构
+            children.push({ path: item.path })
+          })
+          // 文件结构Map
+          setMapFolderDetail(rootPath, childArr)
+
+          if (list) setFileTree([{ path: rootPath }])
+        })
+
+        // 打开文件夹时接入历史记录
+        const history: YakRunnerHistoryProps = {
+          isFile: false,
+          name: lastFolder,
+          path: rootPath,
+        }
+        setYakRunnerHistory(history)
+      }
+    } catch (error) {}
+  })
+
+  // 加载文件树(初次加载)
+  const onOpenFileTreeFun = useMemoizedFn(async (absolutePath: string) => {
+    // console.log("文件树---", absolutePath)
+    onInitTreeFun(absolutePath)
+  })
+
+  // 刷新文件/审计树
+  const onRefreshTreeFun = useMemoizedFn(() => {
+    if (fileTree.length > 0) {
+      const ProjectPath = fileTree[0].path
+      onInitTreeFun(ProjectPath, false)
+    }
+  })
+
+  // 是否正在读取中
+  const isReadingRef = useRef<boolean>(false)
+  const onOpenFileByPathFun = useMemoizedFn(async (data) => {
+    try {
+      const { params, isHistory } = JSON.parse(data) as OpenFileByPathProps
+      const { path, name, parent, highLightRange } = params
+
+      // 校验是否已存在 如若存在则不创建只定位
+      const file = await judgeAreaExistFilePath(areaInfo, path)
+      if (file) {
+        let cacheAreaInfo = areaInfo
+        // 如若存在高亮显示 则注入
+        if (highLightRange) {
+          cacheAreaInfo = updateAreaFileInfo(areaInfo, { ...file, highLightRange }, file.path)
+        }
+        const newAreaInfo = setAreaFileActive(cacheAreaInfo, path)
+        setAreaInfo && setAreaInfo(newAreaInfo)
+        setActiveFile && setActiveFile({ ...file, highLightRange })
+      } else {
+        const { size, isPlainText } = await getCodeSizeByPath(path)
+        if (size > MAX_FILE_SIZE_BYTES) {
+          setShowFileHint(true)
+          return
+        }
+        // 取消上一次请求
+        if (isReadingRef.current) {
+          ipcRenderer.invoke('cancel-ReadFile')
+        }
+        isReadingRef.current = true
+        const code = await getCodeByPath(path)
+        isReadingRef.current = false
+        const suffix = name.indexOf('.') > -1 ? name.split('.').pop() : ''
+        const scratchFile: FileDetailInfo = {
+          name,
+          code,
+          icon: suffix ? FileSuffix[suffix] || FileDefault : FileDefault,
+          isActive: true,
+          openTimestamp: moment().unix(),
+          isPlainText,
+          // 此处赋值 path 用于拖拽 分割布局等UI标识符操作
+          path,
+          parent: parent || null,
+          language: monacaLanguageType(suffix),
+          highLightRange,
+        }
+        // (性能优化 为了快速打开文件 在文件打开时不注入语法检测 再文件打开后再注入语法检测)
+        // const syntaxActiveFile = {...(await getDefaultActiveFile(scratchFile))}
+        const { newAreaInfo, newActiveFile } = addAreaFileInfo(areaInfo, scratchFile, activeFile)
+        setAreaInfo(newAreaInfo)
+        setActiveFile(newActiveFile)
+
+        if (isHistory) {
+          // 创建文件时接入历史记录
+          const history: YakRunnerHistoryProps = {
+            isFile: true,
+            name,
+            path,
+          }
+          setYakRunnerHistory(history)
+        }
+      }
+    } catch (error) {
+      failed(`error: ${error}`)
+    }
+  })
+
+  const onGetCodeByPathCacheFun = useMemoizedFn(async (data) => {
+    try {
+      const { params } = JSON.parse(data) as OpenFileByPathProps
+      const { path, name } = params
+      // 校验是否已存在 如若存在则赋予其code
+      const file = await judgeAreaExistFilePath(areaInfo, path)
+      if (file) {
+        const { size, isPlainText } = await getCodeSizeByPath(path)
+        if (size > MAX_FILE_SIZE_BYTES) {
+          !isShowFileHint && setShowFileHint(true)
+          // 如若历史文件过大 则移除展示的文件
+          if (activeFile) {
+            const { newAreaInfo, newActiveFile } = removeYakRunnerAreaFileInfo(areaInfo, activeFile)
+            setAreaInfo && setAreaInfo(newAreaInfo)
+            setActiveFile && setActiveFile(newActiveFile)
+          }
+          return
+        }
+        // 取消上一次请求
+        if (isReadingRef.current) {
+          ipcRenderer.invoke('cancel-ReadFile')
+        }
+        isReadingRef.current = true
+        const code = await getCodeByPath(path)
+        isReadingRef.current = false
+        const suffix = name.indexOf('.') > -1 ? name.split('.').pop() : ''
+        const newAreaInfo = updateAreaFileInfo(
+          areaInfo,
+          {
+            code,
+            icon: suffix ? FileSuffix[suffix] || FileDefault : FileDefault,
+            openTimestamp: moment().unix(),
+            isPlainText,
+            language: monacaLanguageType(suffix),
+          },
+          path,
+        )
+        setAreaInfo(newAreaInfo)
+        setActiveFile(
+          activeFile
+            ? {
+                ...activeFile,
+                icon: suffix ? FileSuffix[suffix] || FileDefault : FileDefault,
+                openTimestamp: moment().unix(),
+                isPlainText,
+                language: monacaLanguageType(suffix),
+              }
+            : activeFile,
+        )
+      }
+    } catch (error) {
+      failed(`error: ${error}`)
+    }
+  })
+
+  const onCloseYakRunnerFun = useMemoizedFn(async () => {
+    try {
+      if (areaInfo.length === 0) {
+        emiter.emit('closePage', JSON.stringify({ route: YakitRoute.YakScript }))
+        return
+      }
+      if (activeFile?.isUnSave) {
+        emiter.emit('onCloseFile', activeFile.path)
+        return
+      }
+      const unSaveArr = await judgeAreaExistFileUnSave(areaInfo)
+      if (unSaveArr.length > 0) {
+        emiter.emit('onCloseFile', unSaveArr[0])
+      } else {
+        emiter.emit('closePage', JSON.stringify({ route: YakitRoute.YakScript }))
+      }
+    } catch (error) {
+      emiter.emit('closePage', JSON.stringify({ route: YakitRoute.YakScript }))
+    }
+  })
+
+  const onOpenTemporaryFileFun = useMemoizedFn((data: any) => {
+    try {
+      const { name, code, icon, language } = JSON.parse(data)
+      addFileTab({ name, code, icon, language })
+    } catch (error) {
+      failed(`error: ${error}`)
+    }
+  })
+
+  useEffect(() => {
+    // 监听文件树打开
+    emiter.on('onIrifyAiCodeAuditOpenFileTree', onOpenFileTreeFun)
+    // 刷新树
+    emiter.on('onRefreshTree', onRefreshTreeFun)
+    // 通过路径打开文件
+    emiter.on('onOpenFileByPath', onOpenFileByPathFun)
+    // 通过缓存文件路径读取文件内容
+    emiter.on('onGetCodeByPathCache', onGetCodeByPathCacheFun)
+    // 监听一级页面关闭事件
+    emiter.on('onCloseYakRunner', onCloseYakRunnerFun)
+    // 打开临时文件
+    emiter.on('onOpenTemporaryFile', onOpenTemporaryFileFun)
+    return () => {
+      emiter.off('onIrifyAiCodeAuditOpenFileTree', onOpenFileTreeFun)
+      emiter.off('onRefreshTree', onRefreshTreeFun)
+      emiter.off('onOpenFileByPath', onOpenFileByPathFun)
+      emiter.off('onGetCodeByPathCache', onGetCodeByPathCacheFun)
+      emiter.off('onCloseYakRunner', onCloseYakRunnerFun)
+      emiter.off('onOpenTemporaryFile', onOpenTemporaryFileFun)
+    }
+  }, [])
+
+  // 加载下一层
+  const handleFileLoadData = useMemoizedFn((path: string) => {
+    return new Promise((resolve, reject) => {
+      // 校验其子项是否存在
+      const childArr = getMapFolderDetail(path)
+      if (childArr.length > 0) {
+        emiter.emit('onRefreshFileTree')
+        resolve('')
+      } else {
+        handleFetchFileList(path, (value) => {
+          if (value.length > 0) {
+            let childArr: string[] = []
+            value.forEach((item) => {
+              // 注入文件结构Map
+              childArr.push(item.path)
+              // 文件Map
+              setMapFileDetail(item.path, item)
+            })
+            setMapFolderDetail(path, childArr)
+            setTimeout(() => {
+              emiter.emit('onRefreshFileTree')
+              resolve('')
+            }, 300)
+          } else {
+            reject()
+          }
+        })
+      }
+    })
+  })
+
+  const [active, setActive, getActive] = useGetState<LeftSideType>('file-tree')
+  const [isUnShow, setIsUnShow] = useState<boolean>(true)
+  const onActiveKey = useMemoizedFn((key) => {
+    setActive(key)
+  })
+
+  // 根据历史读取上次打开的文件夹
+  const onGetYakRunnerLastFolderExpanded = useMemoizedFn(async () => {
+    try {
+      const historyData = await getIrifyAiCodeAuditLastFolderExpanded()
+      if (historyData?.folderPath) {
+        onOpenFileTreeFun(historyData.folderPath)
+        setIsUnShow(false)
+      }
+      emiter.emit('onDefaultExpanded', JSON.stringify(historyData?.expandedKeys || []))
+    } catch (error) {}
+  })
+
+  // 获取上次打开的展示分布及文件历史
+  const onGetYakRunnerLastAreaFile = useMemoizedFn(async () => {
+    try {
+      const historyData = await getIrifyAiCodeAuditLastAreaFile()
+      if (historyData?.activeFile && historyData.areaInfo) {
+        setActiveFile(historyData.activeFile)
+        setAreaInfo(historyData.areaInfo)
+        setIsUnShow(false)
+      }
+    } catch (error) {}
+  })
+
+  useEffect(() => {
+    onGetYakRunnerLastFolderExpanded()
+    onGetYakRunnerLastAreaFile()
+  }, [])
+
+  const onSaveYakRunnerLastFolder = useMemoizedFn(async (newPath) => {
+    try {
+      const historyData = await getIrifyAiCodeAuditLastFolderExpanded()
+      const folderPath = historyData?.folderPath || ''
+      if (folderPath.length === 0) {
+        setIrifyAiCodeAuditLastFolderExpanded({
+          folderPath: newPath,
+          expandedKeys: [],
+        })
+      }
+
+      if (folderPath.length > 0 && folderPath !== newPath) {
+        setIrifyAiCodeAuditLastFolderExpanded({
+          folderPath: newPath,
+          expandedKeys: [],
+        })
+        // FileTree缓存清除
+        emiter.emit('onResetFileTree', JSON.stringify({ reset: true }))
+      }
+    } catch (error) {}
+  })
+
+  useUpdateEffect(() => {
+    if (fileTree.length > 0) {
+      onSaveYakRunnerLastFolder(fileTree[0].path)
+      setIsUnShow(false)
+    } else {
+      setIrifyAiCodeAuditLastFolderExpanded({
+        folderPath: '',
+        expandedKeys: [],
+      })
+    }
+  }, [fileTree])
+
+  // 计算areaInfo区域是否变化
+  const areaKey = useMemo(() => {
+    let areaKey: string = ''
+    areaInfo.forEach((item, index) => {
+      item.elements.forEach((_, indexIn) => {
+        areaKey += `${index}-${indexIn},`
+      })
+    })
+    return areaKey
+  }, [areaInfo])
+
+  useDebounceEffect(
+    () => {
+      // 由于更改分布信息时activeFile也会改变 因此两者埋点合并
+      let newAreaInfo = excludeAreaInfoCode(areaInfo)
+      let newActiveFile: FileDetailInfo | undefined = undefined
+      if (activeFile) {
+        newActiveFile = cloneDeep(activeFile)
+        if (!newActiveFile.isUnSave) {
+          delete newActiveFile.code
+        }
+      }
+      setIrifyAiCodeAuditLastAreaFile(newAreaInfo, newActiveFile)
+    },
+    [activeFile?.path, areaKey],
+    { wait: 300 },
+  )
+
+  const store: YakRunnerContextStore = useMemo(() => {
+    return {
+      fileTree: fileTree,
+      areaInfo: areaInfo,
+      activeFile: activeFile,
+      runnerTabsId: runnerTabsId,
+    }
+  }, [fileTree, areaInfo, activeFile, runnerTabsId])
+
+  const dispatcher: YakRunnerContextDispatcher = useMemo(() => {
+    return {
+      setFileTree: setFileTree,
+      handleFileLoadData: handleFileLoadData,
+      setAreaInfo: setAreaInfo,
+      setActiveFile: setActiveFile,
+      setRunnerTabsId: setRunnerTabsId,
+    }
+  }, [])
+
+  const shortcutRef = useRef<HTMLDivElement>(null)
+  const [inViewport] = useInViewport(shortcutRef)
+  const unTitleCountRef = useRef<number>(1)
+
+  const addFileTab = useThrottleFn(
+    (params?: { name?: string; code?: string; icon?: string; language?: string }) => {
+      // 新建临时文件
+      const scratchFile: FileDetailInfo = {
+        name: params?.name || `Untitle-${unTitleCountRef.current}.yak`,
+        code: params?.code || '# input your yak code\nprintln(`Hello Yak World!`)',
+        icon: params?.icon || '_f_yak',
+        isActive: true,
+        openTimestamp: moment().unix(),
+        isPlainText: true,
+        // 此处赋值 path 用于拖拽 分割布局等UI标识符操作
+        path: `${uuidv4()}-${params?.name || `Untitle-${unTitleCountRef.current}`}.${params?.language || 'yak'}`,
+        parent: null,
+        language: params?.language || 'yak',
+        isUnSave: true,
+      }
+      unTitleCountRef.current += 1
+      const { newAreaInfo, newActiveFile } = addAreaFileInfo(areaInfo, scratchFile, activeFile)
+
+      setAreaInfo(newAreaInfo)
+      setActiveFile(newActiveFile)
+    },
+    { wait: 300 },
+  ).run
+
+  const [codePath, setCodePath] = useState<string>('')
+  // 默认保存路径
+  useEffect(() => {
+    ipcRenderer.invoke('fetch-code-path').then((path: string) => {
+      ipcRenderer
+        .invoke('is-exists-file', path)
+        .then(() => {
+          setCodePath('')
+        })
+        .catch(() => {
+          setCodePath(path)
+        })
+    })
+  }, [])
+
+  // 存储文件
+  const ctrl_s = useMemoizedFn(() => {
+    try {
+      // 如若未保存 则
+      if (activeFile && activeFile.isUnSave && activeFile.code && activeFile.code.length > 0) {
+        ipcRenderer
+          .invoke('show-save-dialog', `${codePath}${codePath ? '/' : ''}${activeFile.name}`)
+          .then(async (res) => {
+            const path = res.filePath
+            const name = res.name
+            if (path.length > 0) {
+              const suffix = name.split('.').pop()
+
+              const file: FileDetailInfo = {
+                ...activeFile,
+                path,
+                isUnSave: false,
+                language: monacaLanguageType(suffix || ''),
+              }
+              const parentPath = await getPathParent(file.path)
+              const parentDetail = getMapFileDetail(parentPath)
+              const result = await grpcFetchCreateFile(file.path, file.code, parentDetail.isReadFail ? '' : parentPath)
+              // 如若保存路径为文件列表中则需要更新文件树
+              if (fileTree.length > 0 && file.path.startsWith(fileTree[0].path)) {
+                let arr: FileNodeMapProps[] = []
+                arr = await grpcFetchFileTree(parentPath)
+                if (arr.length > 0) {
+                  let childArr: string[] = []
+                  // 文件Map
+                  arr.forEach((item) => {
+                    // 注入文件结构Map
+                    childArr.push(item.path)
+                    // 文件Map
+                    setMapFileDetail(item.path, item)
+                  })
+                  setMapFolderDetail(parentPath, childArr)
+                }
+                emiter.emit('onRefreshFileTree', parentPath)
+              }
+              if (result.length > 0) {
+                file.name = result[0].name
+                file.isDelete = false
+                success(t('YakRunner.saveSuccess', { name: result[0].name }))
+                const removeAreaInfo = removeYakRunnerAreaFileInfo(areaInfo, file).newAreaInfo
+                const newAreaInfo = updateAreaFileInfo(removeAreaInfo, file, activeFile.path)
+                setAreaInfo && setAreaInfo(newAreaInfo)
+                setActiveFile && setActiveFile(file)
+
+                // 创建文件时接入历史记录
+                const history: YakRunnerHistoryProps = {
+                  isFile: true,
+                  name,
+                  path,
+                }
+                setYakRunnerHistory(history)
+              }
+            }
+          })
+      }
+    } catch (error) {
+      failed(t('YakRunner.saveFailed', { name: activeFile?.name || '' }))
+    }
+  })
+
+  // 关闭文件
+  const ctrl_w = useMemoizedFn(() => {
+    if (activeFile && areaInfo.length > 0) {
+      emiter.emit('onCloseFile', activeFile.path)
+    } else {
+      emiter.emit('closePage', JSON.stringify({ route: YakitRoute.YakScript }))
+    }
+  })
+
+  // 终端
+  const onOpenTermina = useMemoizedFn(() => {
+    emiter.emit('onOpenTerminaDetail')
+  })
+
+  // 文件树重命名（快捷键）
+  const onTreeRename = useMemoizedFn(() => {
+    emiter.emit('onOperationFileTree', 'rename')
+  })
+
+  // 文件树删除（快捷键）
+  const onTreeDelete = useMemoizedFn(() => {
+    emiter.emit('onOperationFileTree', 'delete')
+  })
+
+  // 文件树复制（快捷键）
+  const onTreeCopy = useMemoizedFn(() => {
+    emiter.emit('onOperationFileTree', 'copy')
+  })
+
+  // 文件树粘贴（快捷键）
+  const onTreePaste = useMemoizedFn(() => {
+    emiter.emit('onOperationFileTree', 'paste')
+  })
+
+  useEffect(() => {
+    if (inViewport) {
+      registerShortcutKeyHandle(ShortcutKeyPage.YakRunner)
+      getStorageYakRunnerShortcutKeyEvents()
+      return () => {
+        unregisterShortcutKeyHandle(ShortcutKeyPage.YakRunner)
+      }
+    }
+  }, [inViewport])
+
+  useShortcutKeyTrigger('create*yakRunner', () => {
+    return
+  })
+
+  useShortcutKeyTrigger('save*yakRunner', () => {
+    // 保存
+    ctrl_s()
+  })
+
+  useShortcutKeyTrigger('close*yakRunner', () => {
+    // 关闭
+    ctrl_w()
+  })
+
+  useShortcutKeyTrigger('openTermina*yakRunner', () => {
+    // 打开终端
+    onOpenTermina()
+  })
+
+  useShortcutKeyTrigger('rename*yakRunner', () => {
+    // 文件树相关快捷键只在文件树控件展示时生效
+    if (getActive() !== 'file-tree') return
+    // 文件树重命名
+    onTreeRename()
+  })
+
+  useShortcutKeyTrigger('delete*yakRunner', () => {
+    // 文件树相关快捷键只在文件树控件展示时生效
+    if (getActive() !== 'file-tree') return
+    // 文件树删除
+    onTreeDelete()
+  })
+
+  useShortcutKeyTrigger('copy*yakRunner', () => {
+    // 文件树相关快捷键只在文件树控件展示时生效
+    if (getActive() !== 'file-tree') return
+    // 文件树复制
+    onTreeCopy()
+  })
+
+  useShortcutKeyTrigger('paste*yakRunner', () => {
+    // 文件树相关快捷键只在文件树控件展示时生效
+    if (getActive() !== 'file-tree') return
+    // 文件树粘贴
+    onTreePaste()
+  })
+
+  const [isShowEditorDetails, setEditorDetails] = useState<boolean>(false)
+  // 当前展示项
+  const [showItem, setShowItem] = useState<ShowItemType>('output')
+  // 最后焦点聚集编辑器输出
+  const onFixedEditorDetails = useMemoizedFn((element: React.ReactNode): React.ReactNode => {
+    // 后续此处还需要传入焦点代码/路径等信息
+    return (
+      <SplitView
+        isVertical={true}
+        isLastHidden={!isShowEditorDetails}
+        elements={[
+          { element: element },
+          {
+            element: (
+              <BottomEditorDetails
+                showItem={showItem}
+                setShowItem={setShowItem}
+                isShowEditorDetails={isShowEditorDetails}
+                setEditorDetails={setEditorDetails}
+              />
+            ),
+          },
+        ]}
+      />
+    )
+  })
+  // 打开底部编辑器输出
+  const onOpenEditorDetails = useMemoizedFn((v: ShowItemType) => {
+    setShowItem(v)
+    setEditorDetails(true)
+  })
+
+  const onDragStart = useMemoizedFn(() => {
+    // 切换时应移除编辑器焦点(原因：拖拽会导致monaca焦点无法主动失焦)
+    if (document.activeElement !== null) {
+      // @ts-ignore
+      document.activeElement.blur()
+    }
+  })
+
+  // 根据数组下标进行位置互换
+  const moveArrayElement = useMemoizedFn((arr, fromIndex, toIndex) => {
+    // 检查下标是否有效
+    if (fromIndex < 0 || fromIndex >= arr.length || toIndex < 0 || toIndex >= arr.length) {
+      console.error('Invalid indices')
+      return arr // 返回原始数组
+    }
+    // 从数组中移除元素并插入到目标位置
+    const [element] = arr.splice(fromIndex, 1)
+    arr.splice(toIndex, 0, element)
+    return arr // 返回移动后的数组
+  })
+
+  // 拖放结束时的回调函数
+  const onDragEnd = useMemoizedFn((result: DropResult, provided: ResponderProvided) => {
+    try {
+      const { source, destination, draggableId, type, combine } = result
+      if (!destination) {
+        return
+      }
+      const newAreaInfo: AreaInfoProps[] = cloneDeep(areaInfo)
+      // 同层内拖拽
+      if (source.droppableId === destination.droppableId) {
+        newAreaInfo.forEach((item, index) => {
+          item.elements.forEach((itemIn, indexIn) => {
+            if (itemIn.id === source.droppableId) {
+              moveArrayElement(newAreaInfo[index].elements[indexIn].files, source.index, destination.index)
+            }
+          })
+        })
+      }
+      // 拖拽到另一层
+      else if (source.droppableId !== destination.droppableId) {
+        let element: FileDetailInfo | null = null
+        let indexArr: number[] = []
+        newAreaInfo.forEach((item, index) => {
+          item.elements.forEach((itemIn, indexIn) => {
+            // 需要移除项
+            if (itemIn.id === source.droppableId) {
+              // 从数组中移除元素并获取拖拽元素
+              const [ele] = newAreaInfo[index].elements[indexIn].files.splice(source.index, 1)
+              element = ele
+
+              let filesLength = newAreaInfo[index].elements[indexIn].files.length
+              // 校验是否仅有一项 移除后是否为空 为空则删除此大项
+              if (filesLength === 0) {
+                if (item.elements.length > 1) {
+                  newAreaInfo[index].elements = newAreaInfo[index].elements.filter(
+                    (item) => item.id !== source.droppableId,
+                  )
+                } else if (item.elements.length <= 1) {
+                  newAreaInfo.splice(index, 1)
+                }
+              }
+              // 由于移走激活文件 重新赋予激活文件
+              else if (filesLength !== 0 && ele.isActive) {
+                newAreaInfo[index].elements[indexIn].files[source.index - 1 < 0 ? 0 : source.index - 1].isActive = true
+              }
+            }
+            // 需要新增项
+            if (itemIn.id === destination.droppableId) {
+              indexArr = [index, indexIn]
+            }
+          })
+        })
+        // 新增
+        if (element && indexArr.length > 0) {
+          // 如若拖拽项是已激活文件 则将拖拽后的原本激活文件变为未激活
+          if ((element as FileDetailInfo)?.isActive) {
+            newAreaInfo[indexArr[0]].elements[indexArr[1]].files = newAreaInfo[indexArr[0]].elements[
+              indexArr[1]
+            ].files.map((item) => ({ ...item, isActive: false }))
+            setActiveFile(element)
+          }
+          // 新增拖拽项
+          newAreaInfo[indexArr[0]].elements[indexArr[1]].files.splice(destination.index, 0, element)
+        }
+      }
+      setAreaInfo(newAreaInfo)
+    } catch (error) {}
+  })
+
+  const getTabsId = useMemoizedFn((row, col) => {
+    try {
+      return areaInfo[row].elements[col].id
+    } catch (error) {
+      return `${row}*${col}`
+    }
+  })
+
+  // 布局处理
+  const onChangeArea = useMemoizedFn(() => {
+    if (areaInfo.length === 0) {
+      return <IrifyAiCodeAuditWelcomePage />
+    }
+    return (
+      <DragDropContext onDragEnd={onDragEnd} onDragStart={onDragStart}>
+        <SplitView
+          isVertical={true}
+          isLastHidden={areaInfo.length === 1}
+          elements={[
+            {
+              element: (
+                <SplitView
+                  isLastHidden={areaInfo.length > 0 && areaInfo[0].elements.length === 1}
+                  elements={[
+                    { element: <RunnerTabs tabsId={getTabsId(0, 0)} /> },
+                    { element: <RunnerTabs tabsId={getTabsId(0, 1)} /> },
+                  ]}
+                />
+              ),
+            },
+            {
+              element: (
+                <SplitView
+                  isLastHidden={areaInfo.length > 1 && areaInfo[1].elements.length === 1}
+                  elements={[
+                    {
+                      element: <RunnerTabs wrapperClassName={styles['runner-tabs-top']} tabsId={getTabsId(1, 0)} />,
+                    },
+                    {
+                      element: <RunnerTabs wrapperClassName={styles['runner-tabs-top']} tabsId={getTabsId(1, 1)} />,
+                    },
+                  ]}
+                />
+              ),
+            },
+          ]}
+        />
+      </DragDropContext>
+    )
+  })
+
+  useEffect(() => {
+    // 执行结束
+    ipcRenderer.on('client-yak-end', () => {
+      setRunnerTabsId(undefined)
+    })
+    return () => {
+      ipcRenderer.removeAllListeners('client-yak-end')
+    }
+  }, [])
+
+  return (
+    <YakRunnerContext.Provider value={{ store, dispatcher }}>
+      <div className={styles['yak-runner']} ref={shortcutRef} tabIndex={0} id="yakit-runnner-main-box-id">
+        <div className={styles['yak-runner-body']}>
+          <YakitResizeBox
+            freeze={!isUnShow}
+            firstRatio={isUnShow ? '25px' : '300px'}
+            firstNodeStyle={isUnShow ? { padding: 0, maxWidth: 25 } : { padding: 0 }}
+            lineDirection="right"
+            firstMinSize={isUnShow ? 25 : 200}
+            lineStyle={{ width: 4 }}
+            secondMinSize={480}
+            firstNode={
+              <IrifyLeftSideBar
+                addFileTab={addFileTab}
+                isUnShow={isUnShow}
+                setIsUnShow={setIsUnShow}
+                active={active}
+                setActive={onActiveKey}
+                fileTreeOnlyTabs={YakRunnerTabFileTreeOnly}
+              />
+            }
+            secondNodeStyle={
+              isUnShow ? { padding: 0, minWidth: 'calc(100% - 25px)' } : { overflow: 'unset', padding: 0 }
+            }
+            secondNode={
+              <div
+                className={classNames(styles['yak-runner-code'], {
+                  [styles['yak-runner-code-offset']]: !isUnShow,
+                })}
+              >
+                <div className={styles['code-container']}>{onFixedEditorDetails(onChangeArea())}</div>
+              </div>
+            }
+          />
+        </div>
+
+        <BottomSideBar onOpenEditorDetails={onOpenEditorDetails} />
+      </div>
+      {/* 文件过大提示框 */}
+      <YakitHint
+        visible={isShowFileHint}
+        title={t('YakRunner.fileTooLargeWarning')}
+        content={t('YakRunner.fileTooLargeContent')}
+        cancelButtonProps={{ style: { display: 'none' } }}
+        onOk={() => {
+          setShowFileHint(false)
+        }}
+        okButtonText={t('YakitButton.iKnow')}
+      />
+    </YakRunnerContext.Provider>
+  )
+}

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyLeftSideBar.tsx
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyLeftSideBar.tsx
@@ -1,0 +1,63 @@
+import React, { useRef } from 'react'
+import { useMemoizedFn } from 'ahooks'
+import { LeftSideBarProps, LeftSideType } from '@/pages/yakRunner/LeftSideBar/LeftSideBarType'
+import { IrifyAiCodeAuditFileTree } from './IrifyAiCodeAuditFileTree'
+import { YakHelpDoc } from '@/pages/yakRunner/YakHelpDoc/YakHelpDoc'
+import classNames from 'classnames'
+import styles from '@/pages/yakRunner/LeftSideBar/LeftSideBar.module.scss'
+import { YakitSideTab } from '@/components/yakitSideTab/YakitSideTab'
+import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import { YakitTabsProps } from '@/components/yakitSideTab/YakitSideTabType'
+
+export const IrifyLeftSideBar: React.FC<LeftSideBarProps & { fileTreeOnlyTabs: YakitTabsProps[] }> = (props) => {
+  const { addFileTab, isUnShow, active, setActive, setIsUnShow, fileTreeOnlyTabs } = props
+  const { t, i18n } = useI18nNamespaces(['yakRunner'])
+
+  const rendered = useRef<Set<string>>(new Set(['file-tree']))
+
+  const onSetActive = useMemoizedFn((type: string) => {
+    if (!rendered.current.has(type as string)) {
+      rendered.current.add(type as string)
+    }
+    setActive(type as LeftSideType)
+  })
+
+  return (
+    <div
+      className={classNames(styles['left-side-bar'], {
+        [styles['folded']]: !active,
+      })}
+    >
+      <YakitSideTab
+        key={i18n.language}
+        yakitTabs={fileTreeOnlyTabs}
+        activeKey={active}
+        onActiveKey={onSetActive}
+        show={!isUnShow}
+        setShow={(v) => setIsUnShow(!v)}
+        t={t}
+      />
+
+      <div className={styles['left-side-bar-content']}>
+        {rendered.current.has('file-tree') && (
+          <div
+            className={classNames(styles['content-wrapper'], {
+              [styles['hidden-content']]: active !== 'file-tree' || isUnShow,
+            })}
+          >
+            <IrifyAiCodeAuditFileTree addFileTab={addFileTab} />
+          </div>
+        )}
+        {rendered.current.has('help-doc') && (
+          <div
+            className={classNames(styles['content-wrapper'], {
+              [styles['hidden-content']]: active !== 'help-doc' || isUnShow,
+            })}
+          >
+            <YakHelpDoc />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyWorkbenchAiAttachContext.tsx
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/IrifyWorkbenchAiAttachContext.tsx
@@ -1,0 +1,20 @@
+import React, { createContext, useContext, MutableRefObject } from 'react'
+
+/** 与左侧 Irify 工作区同步，供右侧 AI 请求读取（发送时读 `.current`） */
+export interface IrifyWorkbenchAiAttachRef {
+  /** 用户选择的项目根目录绝对路径（代码审计 AttachedResourceInfo） */
+  projectRootAbsPath?: string
+}
+
+export const IrifyWorkbenchAiAttachContext = createContext<MutableRefObject<IrifyWorkbenchAiAttachRef> | null>(null)
+
+export const IrifyWorkbenchAiAttachProvider: React.FC<{
+  children: React.ReactNode
+  attachRef: MutableRefObject<IrifyWorkbenchAiAttachRef>
+}> = ({ children, attachRef }) => (
+  <IrifyWorkbenchAiAttachContext.Provider value={attachRef}>{children}</IrifyWorkbenchAiAttachContext.Provider>
+)
+
+export function useIrifyWorkbenchAiAttachRef() {
+  return useContext(IrifyWorkbenchAiAttachContext)
+}

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/codeAuditAttachment.ts
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/codeAuditAttachment.ts
@@ -1,0 +1,30 @@
+import type { AIInputEvent, AttachedResourceInfo } from '@/pages/ai-re-act/hooks/grpcApi'
+
+/** 与 yaklang loop_code_security_audit / AttachedResourceTypeFile 一致 */
+export const CODE_AUDIT_ATTACHED_TYPE_FILE = 'file' as const
+
+/** 与 AttachedResourceKeyCodeAuditTargetPath 一致 */
+export const CODE_AUDIT_ATTACHED_KEY_TARGET_PATH = 'code_audit_target_path' as const
+
+/** @name 构造一条代码审计目标目录附件（须为已规范的项目根目录绝对路径） */
+export function buildCodeAuditTargetAttachment(projectRootAbsPath: string): AttachedResourceInfo {
+  return {
+    Key: CODE_AUDIT_ATTACHED_KEY_TARGET_PATH as AttachedResourceInfo['Key'],
+    Type: CODE_AUDIT_ATTACHED_TYPE_FILE as AttachedResourceInfo['Type'],
+    Value: projectRootAbsPath,
+  }
+}
+
+/** @name 向 AIInputEvent.AttachedResourceInfo 追加代码审计目标（不修改 FreeInput） */
+export function appendCodeAuditTargetAttachmentToEvent(
+  event: AIInputEvent,
+  projectRootAbsPath: string | undefined | null,
+): AIInputEvent {
+  const path = (projectRootAbsPath || '').trim()
+  if (!path) return event
+  const item = buildCodeAuditTargetAttachment(path)
+  const existing = event.AttachedResourceInfo || []
+  const dup = existing.some((e) => e.Type === item.Type && e.Key === item.Key && e.Value === item.Value)
+  if (dup) return event
+  return { ...event, AttachedResourceInfo: [...existing, item] }
+}

--- a/app/renderer/src/main/src/pages/irifyAiCodeAudit/irifyAiCodeAuditStorage.ts
+++ b/app/renderer/src/main/src/pages/irifyAiCodeAudit/irifyAiCodeAuditStorage.ts
@@ -1,0 +1,54 @@
+import { getRemoteValue, setRemoteValue } from '@/utils/kv'
+import { AreaInfoProps } from '@/pages/yakRunner/YakRunnerType'
+import { FileDetailInfo } from '@/pages/yakRunner/RunnerTabs/RunnerTabsType'
+
+const IrifyAiCodeAuditLastFolderExpanded = 'IrifyAiCodeAuditLastFolderExpanded'
+const IrifyAiCodeAuditLastAreaFile = 'IrifyAiCodeAuditLastAreaFile'
+
+export interface IrifyAiCodeAuditLastFolderExpandedProps {
+  folderPath: string
+  expandedKeys: string[]
+}
+
+export const setIrifyAiCodeAuditLastFolderExpanded = (cache: IrifyAiCodeAuditLastFolderExpandedProps) => {
+  setRemoteValue(IrifyAiCodeAuditLastFolderExpanded, JSON.stringify(cache))
+}
+
+export const getIrifyAiCodeAuditLastFolderExpanded = (): Promise<IrifyAiCodeAuditLastFolderExpandedProps | null> => {
+  return new Promise((resolve) => {
+    getRemoteValue(IrifyAiCodeAuditLastFolderExpanded).then((data) => {
+      try {
+        if (!data) {
+          resolve(null)
+          return
+        }
+        resolve(JSON.parse(data as string))
+      } catch {
+        resolve(null)
+      }
+    })
+  })
+}
+
+export const setIrifyAiCodeAuditLastAreaFile = (areaInfo: AreaInfoProps[], activeFile?: FileDetailInfo) => {
+  setRemoteValue(IrifyAiCodeAuditLastAreaFile, JSON.stringify({ areaInfo, activeFile }))
+}
+
+export const getIrifyAiCodeAuditLastAreaFile = (): Promise<{
+  activeFile: FileDetailInfo
+  areaInfo: AreaInfoProps[]
+} | null> => {
+  return new Promise((resolve) => {
+    getRemoteValue(IrifyAiCodeAuditLastAreaFile).then((data) => {
+      try {
+        if (!data) {
+          resolve(null)
+          return
+        }
+        resolve(JSON.parse(data as string))
+      } catch {
+        resolve(null)
+      }
+    })
+  })
+}

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -895,6 +895,9 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
       case YakitRoute.YakRunner_Audit_Code:
         addYakRunnerAuditCodePage(params)
         break
+      case YakitRoute.Irify_AI_Code_Audit:
+        addIrifyAiCodeAuditPage(params)
+        break
       case YakitRoute.YakRunner_Code_Scan:
         addYakRunnerCodeScanPage(params)
         break
@@ -1062,6 +1065,44 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
     setPagesData(YakitRoute.YakRunner_Audit_Code, pageNodeInfo)
     openMenuPage(
       { route: YakitRoute.YakRunner_Audit_Code },
+      {
+        pageParams: {
+          auditCodePageInfo: data
+            ? {
+                ...data,
+              }
+            : undefined,
+        },
+      },
+    )
+  })
+
+  const addIrifyAiCodeAuditPage = useMemoizedFn((data?: AuditCodePageInfoProps) => {
+    const isExist = pageCache.filter((item) => item.route === YakitRoute.Irify_AI_Code_Audit).length
+    if (isExist && data) {
+      emiter.emit('onAuditCodePageInfo', JSON.stringify(data))
+    }
+    const pageNodeInfo: PageProps = {
+      ...cloneDeep(defPage),
+      pageList: [
+        {
+          id: randomString(8),
+          routeKey: YakitRoute.Irify_AI_Code_Audit,
+          pageGroupId: '0',
+          pageId: YakitRoute.Irify_AI_Code_Audit,
+          pageName: YakitRouteToPageInfo[YakitRoute.Irify_AI_Code_Audit]?.label || '',
+          pageParamsInfo: {
+            auditCodePageInfo: data,
+          },
+          sortFieId: 0,
+        },
+      ],
+      routeKey: YakitRoute.Irify_AI_Code_Audit,
+      singleNode: true,
+    }
+    setPagesData(YakitRoute.Irify_AI_Code_Audit, pageNodeInfo)
+    openMenuPage(
+      { route: YakitRoute.Irify_AI_Code_Audit },
       {
         pageParams: {
           auditCodePageInfo: data
@@ -1506,6 +1547,9 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
       }
       if (type === YakitRoute.YakRunner_Audit_Code) {
         openMenuPage({ route: YakitRoute.YakRunner_Audit_Code })
+      }
+      if (type === YakitRoute.Irify_AI_Code_Audit) {
+        openMenuPage({ route: YakitRoute.Irify_AI_Code_Audit })
       }
       if (type === YakitRoute.YakRunner_Audit_Hole) {
         openMenuPage({ route: YakitRoute.YakRunner_Audit_Hole })

--- a/app/renderer/src/main/src/pages/layout/publicMenu/MenuMode.tsx
+++ b/app/renderer/src/main/src/pages/layout/publicMenu/MenuMode.tsx
@@ -367,6 +367,15 @@ export const MenuMode: React.FC<MenuModeProps> = React.memo((props) => {
             <div className={styles['title-style']}>{t('YakitRoute.codeAudit')}</div>
           </div>
           <div className={styles['divider-style']}></div>
+          <div className={styles['vertical-menu-wrapper']} onClick={() => onMenu(YakitRoute.Irify_AI_Code_Audit)}>
+            <div className={styles['menu-icon-wrapper']}>
+              <div className={styles['icon-wrapper']}>
+                <PublicAIAgentIcon />
+              </div>
+            </div>
+            <div className={styles['title-style']}>{t('YakitRoute.irifyAiCodeAudit')}</div>
+          </div>
+          <div className={styles['divider-style']}></div>
           <div className={styles['vertical-menu-wrapper']} onClick={() => onMenu(YakitRoute.YakRunner_Code_Scan)}>
             <div className={styles['menu-icon-wrapper']}>
               <div className={styles['icon-wrapper']}>

--- a/app/renderer/src/main/src/pages/yakRunner/FileTree/FileTree.tsx
+++ b/app/renderer/src/main/src/pages/yakRunner/FileTree/FileTree.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useMemo, useRef, useState } from 'react'
+import React, { memo, useEffect, useMemo, useRef, useState, startTransition } from 'react'
 import { useInViewport, useMemoizedFn, useSize, useUpdateEffect } from 'ahooks'
 import { FileTreeNodeProps, FileTreeProps, FileNodeProps, FileNodeMapProps } from './FileTreeType'
 import { SystemInfo } from '@/constants/hardware'
@@ -33,8 +33,6 @@ import {
   updateAreaFileInfo,
   updateAreaFilesPathInfo,
 } from '../utils'
-import useStore from '../hooks/useStore'
-import useDispatcher from '../hooks/useDispatcher'
 import {
   getMapAllFolderKey,
   getMapFolderDetail,
@@ -49,8 +47,6 @@ import { OpenFileByPathProps } from '../YakRunnerType'
 import { setClipboardText } from '@/utils/clipboard'
 import { TFunction, useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 
-const { ipcRenderer } = window.require('electron')
-
 const FolderMenu: (t: TFunction) => YakitMenuItemProps[] = (t) => {
   return [
     { label: t('YakitButton.newFile'), key: 'newFile' },
@@ -61,8 +57,18 @@ const FolderMenu: (t: TFunction) => YakitMenuItemProps[] = (t) => {
 }
 
 export const FileTree: React.FC<FileTreeProps> = memo((props) => {
-  const { folderPath, data, onLoadData, onSelect, onExpand, foucsedKey, setFoucsedKey, expandedKeys, setExpandedKeys } =
-    props
+  const {
+    folderPath,
+    data,
+    onLoadData,
+    onSelect,
+    onExpand,
+    storeRefs,
+    foucsedKey,
+    setFoucsedKey,
+    expandedKeys,
+    setExpandedKeys,
+  } = props
   const treeRef = useRef<any>(null)
   const wrapper = useRef<HTMLDivElement>(null)
   const size = useSize(wrapper)
@@ -85,6 +91,9 @@ export const FileTree: React.FC<FileTreeProps> = memo((props) => {
   const selectedKeys = useMemo(() => {
     return selectedNodes.map((node) => node.path)
   }, [selectedNodes])
+
+  const expandedKeySet = useMemo(() => new Set(expandedKeys), [expandedKeys])
+  const selectedKeySet = useMemo(() => new Set(selectedKeys), [selectedKeys])
 
   const scrollExpandedKeys = useRef<string[]>([])
   const scrollExpandedKeysFun = useMemoizedFn((path) => {
@@ -207,27 +216,43 @@ export const FileTree: React.FC<FileTreeProps> = memo((props) => {
   })
 
   const handleExpand = useMemoizedFn((expanded: boolean, node: FileNodeProps) => {
-    let arr = [...expandedKeys]
-    if (expanded) {
-      arr = arr.filter((item) => item !== node.path)
-    } else {
-      arr = [...arr, node.path]
-    }
+    const arr = expanded ? expandedKeys.filter((item) => item !== node.path) : [...expandedKeys, node.path]
     if (selectedNodes.length > 0) setSelectedNodes([selectedNodes[selectedNodes.length - 1]])
     setFoucsedKey(node.path)
-    onSaveYakRunnerLastExpanded([...arr])
-    setExpandedKeys([...arr])
+    onSaveYakRunnerLastExpanded(arr)
+    startTransition(() => {
+      setExpandedKeys(arr)
+    })
     if (onExpand) {
       onExpand(arr, { expanded: !expanded, node })
     }
   })
 
+  const titleRender = useMemoizedFn((nodeData: FileNodeProps) => {
+    return (
+      <FileTreeNode
+        isDownCtrlCmd={isDownCtrlCmd}
+        info={nodeData}
+        folderPath={folderPath}
+        storeRefs={storeRefs}
+        isFoucsed={foucsedKey === nodeData.path}
+        isSelected={selectedKeySet.has(nodeData.path)}
+        isExpanded={expandedKeySet.has(nodeData.path)}
+        onSelected={handleSelect}
+        onExpanded={handleExpand}
+        copyPath={copyPath}
+        setCopyPath={setCopyPath}
+        setFoucsedKey={setFoucsedKey}
+      />
+    )
+  })
+
   return (
     <div ref={wrapper} className={styles['file-tree']}>
       <Tree
-        // virtual={false}
         ref={treeRef}
         height={size?.height}
+        itemHeight={22}
         fieldNames={{ title: 'name', key: 'path', children: 'children' }}
         treeData={data}
         blockNode={true}
@@ -237,34 +262,21 @@ export const FileTree: React.FC<FileTreeProps> = memo((props) => {
         loadData={onLoadData}
         // 解决重复打开同一个项目时 能加载
         loadedKeys={[]}
-        titleRender={(nodeData) => {
-          return (
-            <FileTreeNode
-              isDownCtrlCmd={isDownCtrlCmd}
-              info={nodeData}
-              foucsedKey={foucsedKey}
-              selectedKeys={selectedKeys}
-              expandedKeys={expandedKeys}
-              onSelected={handleSelect}
-              onExpanded={handleExpand}
-              copyPath={copyPath}
-              setCopyPath={setCopyPath}
-              setFoucsedKey={setFoucsedKey}
-            />
-          )
-        }}
+        titleRender={titleRender}
       />
     </div>
   )
 })
 
-const FileTreeNode: React.FC<FileTreeNodeProps> = (props) => {
+const FileTreeNode: React.FC<FileTreeNodeProps> = memo((props) => {
   const {
     isDownCtrlCmd,
     info,
-    foucsedKey,
-    selectedKeys,
-    expandedKeys,
+    folderPath,
+    storeRefs,
+    isFoucsed,
+    isSelected,
+    isExpanded,
     onSelected,
     onExpanded,
     copyPath,
@@ -272,8 +284,6 @@ const FileTreeNode: React.FC<FileTreeNodeProps> = (props) => {
     setFoucsedKey,
   } = props
   const { t, i18n } = useI18nNamespaces(['yakRunner', 'yakitUi'])
-  const { areaInfo, activeFile, fileTree } = useStore()
-  const { setAreaInfo, setActiveFile, setFileTree } = useDispatcher()
   // 是否为输入模式
   const [isInput, setInput] = useState<boolean>(false)
   // 是否为编辑（用于默认选中文件名）
@@ -282,18 +292,6 @@ const FileTreeNode: React.FC<FileTreeNodeProps> = (props) => {
   const inputRef = useRef<any>(null)
 
   const [removeCheckVisible, setRemoveCheckVisible] = useState<boolean>(false)
-
-  const isFoucsed = useMemo(() => {
-    return foucsedKey === info.path
-  }, [foucsedKey, info.path])
-
-  const isSelected = useMemo(() => {
-    return selectedKeys.includes(info.path)
-  }, [selectedKeys, info.path])
-
-  const isExpanded = useMemo(() => {
-    return expandedKeys.includes(info.path)
-  }, [expandedKeys, info.path])
 
   const handleSelect = useMemoizedFn(() => {
     onSelected(isSelected, info)
@@ -335,13 +333,12 @@ const FileTreeNode: React.FC<FileTreeNodeProps> = (props) => {
 
   // 复制相对路径
   const onCopyRelativePath = useMemoizedFn(async () => {
-    if (fileTree.length === 0) {
+    if (!folderPath) {
       failed(t('FileTree.copyRelativePathFailed'))
       return
     }
     try {
-      const basePath = fileTree[0].path
-      const relativePath = await getRelativePath(basePath, info.path)
+      const relativePath = await getRelativePath(folderPath, info.path)
       setClipboardText(relativePath)
     } catch (error) {}
   })
@@ -422,10 +419,7 @@ const FileTreeNode: React.FC<FileTreeNodeProps> = (props) => {
         setRemoveCheckVisible(true)
         break
       case 'copy':
-        if (!!foucsedKey) {
-          setCopyPath(foucsedKey)
-          // success(`已获取路径 ${foucsedKey}`)
-        }
+        setCopyPath(info.path)
         break
       case 'paste':
         onPaste()
@@ -442,6 +436,8 @@ const FileTreeNode: React.FC<FileTreeNodeProps> = (props) => {
   }, [])
 
   const onRenameFun = useMemoizedFn(async () => {
+    const { areaInfo, activeFile } = storeRefs.current
+    const { setAreaInfo, setActiveFile } = storeRefs.current
     try {
       if (value.length !== 0 && value !== info.name) {
         // 重命名 调用接口成功后更新tree
@@ -675,7 +671,7 @@ const FileTreeNode: React.FC<FileTreeNodeProps> = (props) => {
       },
     ]
     const CloseFolder: YakitMenuItemType[] = []
-    if (fileTree.length > 0 && info.path === fileTree[0].path) {
+    if (folderPath && info.path === folderPath) {
       CloseFolder.push({
         label: t('FileTree.closeFolder'),
         key: 'closeFolder',
@@ -706,11 +702,11 @@ const FileTreeNode: React.FC<FileTreeNodeProps> = (props) => {
         ...base,
       ]
     }
-  }, [info, copyPath, i18n.language])
+  }, [info, copyPath, folderPath, i18n.language])
 
   // 此处关闭文件夹由于审计树没有树右键 因此只有文件树存在
   const closeFolder = useMemoizedFn(() => {
-    setFileTree && setFileTree([])
+    storeRefs.current.setFileTree?.([])
   })
 
   const handleContextMenu = useMemoizedFn(() => {
@@ -845,4 +841,23 @@ const FileTreeNode: React.FC<FileTreeNodeProps> = (props) => {
       />
     </>
   )
+}, fileTreeNodePropsAreEqual)
+
+function fileTreeNodePropsAreEqual(prev: FileTreeNodeProps, next: FileTreeNodeProps) {
+  if (prev.storeRefs !== next.storeRefs) return false
+  if (prev.isDownCtrlCmd !== next.isDownCtrlCmd) return false
+  if (prev.isFoucsed !== next.isFoucsed) return false
+  if (prev.isSelected !== next.isSelected) return false
+  if (prev.isExpanded !== next.isExpanded) return false
+  if (prev.copyPath !== next.copyPath) return false
+  if (prev.folderPath !== next.folderPath) return false
+  if (prev.info.path !== next.info.path) return false
+  if (prev.info.name !== next.info.name) return false
+  if (prev.info.isLeaf !== next.info.isLeaf) return false
+  if (prev.info.isFolder !== next.info.isFolder) return false
+  if (prev.info.isBottom !== next.info.isBottom) return false
+  if (prev.info.isCreate !== next.info.isCreate) return false
+  if (prev.info.depth !== next.info.depth) return false
+  if (prev.info.icon !== next.info.icon) return false
+  return true
 }

--- a/app/renderer/src/main/src/pages/yakRunner/FileTree/FileTreeType.d.ts
+++ b/app/renderer/src/main/src/pages/yakRunner/FileTree/FileTreeType.d.ts
@@ -1,5 +1,5 @@
-import {ReactNode} from "react"
-import {YakRunnerStoreRefs} from "../hooks/useYakRunnerStoreRefs"
+import { ReactNode } from 'react'
+import { YakRunnerStoreRefs } from '../hooks/useYakRunnerStoreRefs'
 
 // 文件树的结构只需要path 其详细内容则被存入Map中
 export interface FileTreeListProps {
@@ -55,32 +55,32 @@ export interface FileNodeProps {
 }
 
 export interface FileTreeProps {
-    // 根文件夹路径
-    folderPath: string
-    data: FileNodeProps[]
-    onLoadData: (node: FileNodeProps) => Promise<any>
-    /** 由父级 useYakRunnerStoreRefs 提供，避免树节点订阅全局 store */
-    storeRefs: YakRunnerStoreRefs
-    foucsedKey: string
-    setFoucsedKey: (v:string) => void
-    expandedKeys: string[]
-    setExpandedKeys: (v:string[]) => void
-    onSelect?: (
-        selectedKeys: string[],
-        e: {selected: boolean; selectedNodes: FileNodeProps[]; node: FileNodeProps}
-    ) => any
-    onExpand?: (expandedKeys: string[], e: {expanded: boolean; node: FileNodeProps}) => any
+  // 根文件夹路径
+  folderPath: string
+  data: FileNodeProps[]
+  onLoadData: (node: FileNodeProps) => Promise<any>
+  /** 由父级 useYakRunnerStoreRefs 提供，避免树节点订阅全局 store */
+  storeRefs: YakRunnerStoreRefs
+  foucsedKey: string
+  setFoucsedKey: (v: string) => void
+  expandedKeys: string[]
+  setExpandedKeys: (v: string[]) => void
+  onSelect?: (
+    selectedKeys: string[],
+    e: { selected: boolean; selectedNodes: FileNodeProps[]; node: FileNodeProps },
+  ) => any
+  onExpand?: (expandedKeys: string[], e: { expanded: boolean; node: FileNodeProps }) => any
 }
 
 export interface FileTreeNodeProps {
-    isDownCtrlCmd: boolean
-    info: FileNodeProps
-    folderPath: string
-    storeRefs: YakRunnerStoreRefs
+  isDownCtrlCmd: boolean
+  info: FileNodeProps
+  folderPath: string
+  storeRefs: YakRunnerStoreRefs
 
-    isFoucsed: boolean
-    isSelected: boolean
-    isExpanded: boolean
+  isFoucsed: boolean
+  isSelected: boolean
+  isExpanded: boolean
 
   onSelected: (selected: boolean, node: FileNodeProps) => any
   onExpanded: (expanded: boolean, node: FileNodeProps) => void

--- a/app/renderer/src/main/src/pages/yakRunner/FileTree/FileTreeType.d.ts
+++ b/app/renderer/src/main/src/pages/yakRunner/FileTree/FileTreeType.d.ts
@@ -1,4 +1,5 @@
-import { ReactNode } from 'react'
+import {ReactNode} from "react"
+import {YakRunnerStoreRefs} from "../hooks/useYakRunnerStoreRefs"
 
 // 文件树的结构只需要path 其详细内容则被存入Map中
 export interface FileTreeListProps {
@@ -54,28 +55,32 @@ export interface FileNodeProps {
 }
 
 export interface FileTreeProps {
-  // 根文件夹路径
-  folderPath: string
-  data: FileNodeProps[]
-  onLoadData: (node: FileNodeProps) => Promise<any>
-  foucsedKey: string
-  setFoucsedKey: (v: string) => void
-  expandedKeys: string[]
-  setExpandedKeys: (v: string[]) => void
-  onSelect?: (
-    selectedKeys: string[],
-    e: { selected: boolean; selectedNodes: FileNodeProps[]; node: FileNodeProps },
-  ) => any
-  onExpand?: (expandedKeys: string[], e: { expanded: boolean; node: FileNodeProps }) => any
+    // 根文件夹路径
+    folderPath: string
+    data: FileNodeProps[]
+    onLoadData: (node: FileNodeProps) => Promise<any>
+    /** 由父级 useYakRunnerStoreRefs 提供，避免树节点订阅全局 store */
+    storeRefs: YakRunnerStoreRefs
+    foucsedKey: string
+    setFoucsedKey: (v:string) => void
+    expandedKeys: string[]
+    setExpandedKeys: (v:string[]) => void
+    onSelect?: (
+        selectedKeys: string[],
+        e: {selected: boolean; selectedNodes: FileNodeProps[]; node: FileNodeProps}
+    ) => any
+    onExpand?: (expandedKeys: string[], e: {expanded: boolean; node: FileNodeProps}) => any
 }
 
 export interface FileTreeNodeProps {
-  isDownCtrlCmd: boolean
-  info: FileNodeProps
+    isDownCtrlCmd: boolean
+    info: FileNodeProps
+    folderPath: string
+    storeRefs: YakRunnerStoreRefs
 
-  foucsedKey: string
-  selectedKeys: string[]
-  expandedKeys: string[]
+    isFoucsed: boolean
+    isSelected: boolean
+    isExpanded: boolean
 
   onSelected: (selected: boolean, node: FileNodeProps) => any
   onExpanded: (expanded: boolean, node: FileNodeProps) => void

--- a/app/renderer/src/main/src/pages/yakRunner/MarkdownPdfPrint/MarkdownPdfPrintPage.module.scss
+++ b/app/renderer/src/main/src/pages/yakRunner/MarkdownPdfPrint/MarkdownPdfPrintPage.module.scss
@@ -1,0 +1,51 @@
+:global(html),
+:global(body),
+:global(#root) {
+  margin: 0 !important;
+  padding: 0 !important;
+  width: 100% !important;
+  min-height: 100vh;
+  background-color: var(--Colors-Use-Neutral-Bg-Hover) !important;
+}
+
+.markdown-pdf-print {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 100vh;
+  margin: 0;
+  padding: 8px 12px;
+  background-color: var(--Colors-Use-Neutral-Bg-Hover);
+  color: var(--Colors-Use-Neutral-Text-1-Title);
+  overflow: visible;
+
+  :global(.stream-markdown) {
+    width: 100%;
+    max-width: none !important;
+
+    :global(.container),
+    :global(.\!container) {
+      width: 100% !important;
+      max-width: none !important;
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+    }
+  }
+}
+
+@media print {
+  :global(html),
+  :global(body),
+  :global(#root),
+  .markdown-pdf-print {
+    margin: 0 !important;
+    padding: 8px 12px;
+    background-color: var(--Colors-Use-Neutral-Bg-Hover) !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+
+  @page {
+    margin: 0;
+    size: A4;
+  }
+}

--- a/app/renderer/src/main/src/pages/yakRunner/MarkdownPdfPrint/MarkdownPdfPrintPage.tsx
+++ b/app/renderer/src/main/src/pages/yakRunner/MarkdownPdfPrint/MarkdownPdfPrintPage.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { StreamMarkdown } from '@/pages/assetViewer/reportRenders/markdownRender'
+import { useTheme } from '@/hook/useTheme'
+import styles from './MarkdownPdfPrintPage.module.scss'
+
+const { ipcRenderer } = window.require('electron')
+
+const getPrintId = () => new URLSearchParams(window.location.search).get('printId') || ''
+
+/** 隐藏打印窗口：用 StreamMarkdown 渲染，与 YakRunner 预览一�?*/
+const MarkdownPdfPrintPage: React.FC = () => {
+  const { theme } = useTheme()
+  const [content, setContent] = useState<string | null>(null)
+  const signaledRef = useRef(false)
+
+  useEffect(() => {
+    const printId = getPrintId()
+    if (!printId) return
+    ipcRenderer
+      .invoke('GetMarkdownPdfPrintPayload', printId)
+      .then((payload: { code?: string; theme?: string } | null) => {
+        if (payload?.theme) {
+          document.documentElement.setAttribute('data-theme', payload.theme)
+        }
+        setContent(payload?.code ?? '')
+      })
+  }, [])
+
+  useEffect(() => {
+    if (content === null) return
+    const printId = getPrintId()
+    if (!printId) return
+
+    const signalReady = () => {
+      if (signaledRef.current) return
+      signaledRef.current = true
+      ipcRenderer.invoke('MarkdownPdfPrintReady', printId).catch(() => {})
+    }
+
+    let cancelled = false
+    const run = async () => {
+      try {
+        if (document.fonts?.ready) {
+          await document.fonts.ready.catch(() => {})
+        }
+        await new Promise((r) => setTimeout(r, 300))
+        const imgs = Array.from(document.images || [])
+        await Promise.all(
+          imgs.map(
+            (img) =>
+              new Promise<void>((resolve) => {
+                if (img.complete) resolve()
+                else {
+                  img.addEventListener('load', () => resolve(), { once: true })
+                  img.addEventListener('error', () => resolve(), { once: true })
+                }
+              }),
+          ),
+        )
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)))
+        await new Promise((r) => setTimeout(r, 800))
+      } finally {
+        if (!cancelled) signalReady()
+      }
+    }
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [content, theme])
+
+  return (
+    <div className={styles['markdown-pdf-print']}>
+      <StreamMarkdown
+        content={content ?? ''}
+        controls={{
+          mermaid: {
+            fullscreen: false,
+            download: false,
+            copy: false,
+            panZoom: false,
+          },
+          table: false,
+          code: false,
+        }}
+      />
+    </div>
+  )
+}
+
+export default MarkdownPdfPrintPage

--- a/app/renderer/src/main/src/pages/yakRunner/RunnerTabs/RunnerTabs.tsx
+++ b/app/renderer/src/main/src/pages/yakRunner/RunnerTabs/RunnerTabs.tsx
@@ -21,6 +21,7 @@ import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
 import {
   OutlineChevrondoubleleftIcon,
   OutlineChevrondoublerightIcon,
+  OutlineDownloadIcon,
   OutlineImportIcon,
   OutlinePauseIcon,
   OutlinePlayIcon,
@@ -37,6 +38,7 @@ import useDispatcher from '../hooks/useDispatcher'
 import { AreaInfoProps, OpenFileByPathProps, TabFileProps, YakRunnerHistoryProps } from '../YakRunnerType'
 import { IMonacoEditor } from '@/utils/editors'
 import {
+  getCodeByPath,
   getDefaultActiveFile,
   getOpenFileInfo,
   getPathParent,
@@ -53,7 +55,8 @@ import {
   updateAreaFileInfo,
 } from '../utils'
 import cloneDeep from 'lodash/cloneDeep'
-import { failed, warn, success } from '@/utils/notification'
+import { failed, warn, success, yakitNotify } from '@/utils/notification'
+import { yakitDialog } from '@/services/electronBridge'
 import emiter from '@/utils/eventBus/eventBus'
 import { Divider, Result } from 'antd'
 import { YakitDropdownMenu } from '@/components/yakitUI/YakitDropdownMenu/YakitDropdownMenu'
@@ -72,19 +75,21 @@ import { openFolder } from '../RunnerFileTree/RunnerFileTree'
 import { JumpToEditorProps } from '../BottomEditorDetails/BottomEditorDetailsType'
 import { YakitRoute } from '@/enums/yakitRoute'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import { isIRify } from '@/utils/envfile'
 
 const { ipcRenderer } = window.require('electron')
 
 export const RunnerTabs: React.FC<RunnerTabsProps> = memo((props) => {
   const { tabsId, wrapperClassName } = props
   const { t, i18n } = useI18nNamespaces(['yakRunner', 'yakitUi'])
-  const { areaInfo, activeFile, runnerTabsId, fileTree } = useStore()
+  const { areaInfo, activeFile, runnerTabsId } = useStore()
   const { setActiveFile, setAreaInfo, setRunnerTabsId } = useDispatcher()
   const [tabsList, setTabsList] = useState<FileDetailInfo[]>([])
   const [splitDirection, setSplitDirection] = useState<SplitDirectionProps[]>([])
 
   const [modalInfo, setModalInfo] = useState<FileDetailInfo>()
   const [isShowModal, setShowModal] = useState<boolean>(false)
+  const [downloadLoading, setDownloadLoading] = useState(false)
 
   useEffect(() => {
     let direction: SplitDirectionProps[] = []
@@ -116,6 +121,9 @@ export const RunnerTabs: React.FC<RunnerTabsProps> = memo((props) => {
     let val: boolean = false
     tabsList.some((item) => {
       if (item.isActive && item.language === 'yak') {
+        val = true
+      }
+      if (isIRify() && item.isActive && item.language === 'markdown') {
         val = true
       }
       return item.isActive
@@ -620,6 +628,36 @@ export const RunnerTabs: React.FC<RunnerTabsProps> = memo((props) => {
     })
   })
 
+  const onDownloadReport = useMemoizedFn(async () => {
+    let code = activeFile?.code
+    if (!code && activeFile?.path) {
+      code = await getCodeByPath(activeFile?.path)
+    }
+    if (!code?.trim()) {
+      yakitNotify('error', '报告内容为空，无法导出')
+      return
+    }
+    const baseName = (activeFile?.name || 'report').replace(/\.(md|markdown)$/i, '') || 'report'
+    setDownloadLoading(true)
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      const saveRes = await yakitDialog.showSaveDialog(`${baseName}.pdf`)
+      if (saveRes.canceled || !saveRes.filePath) return
+      const theme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light'
+      await ipcRenderer.invoke('PrintMarkdownPdfFromTemplate', {
+        outputPath: saveRes.filePath,
+        code,
+        name: activeFile?.name,
+        theme,
+      })
+      success('PDF 导出成功')
+    } catch (e) {
+      failed(`PDF 导出失败: ${e}`)
+    } finally {
+      setDownloadLoading(false)
+    }
+  })
+
   const extraDom = useMemoizedFn(() => {
     return (
       <div className={styles['extra-box']}>
@@ -627,24 +665,34 @@ export const RunnerTabs: React.FC<RunnerTabsProps> = memo((props) => {
         <>
           {splitDirection.length > 0 && isShowExtra && <Divider type={'vertical'} style={{ margin: '4px 0px 0px' }} />}
         </>
-        {isShowExtra && (
-          <>
-            {runnerTabsId === tabsId ? (
-              <YakitButton colors="danger" icon={<OutlinePauseIcon />} onClick={onStopYak}>
-                {t('YakitButton.stop')}
-              </YakitButton>
-            ) : (
-              <YakitButton
-                icon={<OutlinePlayIcon />}
-                loading={runnerTabsId === tabsId}
-                disabled={!!runnerTabsId && runnerTabsId !== tabsId}
-                onClick={onRunYak}
-              >
-                {t('YakitButton.execute')}
-              </YakitButton>
-            )}
-          </>
-        )}
+        {isShowExtra &&
+          (activeFile?.language === 'markdown' ? (
+            <YakitButton
+              onClick={onDownloadReport}
+              loading={downloadLoading}
+              disabled={downloadLoading}
+              icon={<OutlineDownloadIcon />}
+            >
+              下载报告
+            </YakitButton>
+          ) : (
+            <>
+              {runnerTabsId === tabsId ? (
+                <YakitButton colors="danger" icon={<OutlinePauseIcon />} onClick={onStopYak}>
+                  {t('YakitButton.stop')}
+                </YakitButton>
+              ) : (
+                <YakitButton
+                  icon={<OutlinePlayIcon />}
+                  loading={runnerTabsId === tabsId}
+                  disabled={!!runnerTabsId && runnerTabsId !== tabsId}
+                  onClick={onRunYak}
+                >
+                  {t('YakitButton.execute')}
+                </YakitButton>
+              )}
+            </>
+          ))}
       </div>
     )
   })

--- a/app/renderer/src/main/src/pages/yakRunner/hooks/useYakRunnerStoreRefs.ts
+++ b/app/renderer/src/main/src/pages/yakRunner/hooks/useYakRunnerStoreRefs.ts
@@ -1,0 +1,40 @@
+import { useRef } from 'react'
+import useStore from './useStore'
+import useDispatcher from './useDispatcher'
+import { YakRunnerContextDispatcher, YakRunnerContextStore } from './YakRunnerContext'
+
+export type YakRunnerStoreRefsCurrent = YakRunnerContextStore & YakRunnerContextDispatcher
+
+export interface YakRunnerStoreRefs {
+  current: YakRunnerStoreRefsCurrent
+}
+
+/** 在父级订阅 store，通过稳定 ref 向子树提供最新数据，避免每个树节点因 store 变更而重渲染 */
+export default function useYakRunnerStoreRefs(): YakRunnerStoreRefs {
+  const { fileTree, areaInfo, activeFile, runnerTabsId } = useStore()
+  const { setFileTree, handleFileLoadData, setAreaInfo, setActiveFile, setRunnerTabsId } = useDispatcher()
+  const container = useRef<YakRunnerStoreRefs>({
+    current: {
+      fileTree: [],
+      areaInfo: [],
+      activeFile: undefined,
+      runnerTabsId: undefined,
+      setFileTree: undefined,
+      handleFileLoadData: undefined,
+      setAreaInfo: undefined,
+      setActiveFile: undefined,
+      setRunnerTabsId: undefined,
+    },
+  })
+  const current = container.current.current
+  current.fileTree = fileTree
+  current.areaInfo = areaInfo
+  current.activeFile = activeFile
+  current.runnerTabsId = runnerTabsId
+  current.setFileTree = setFileTree
+  current.handleFileLoadData = handleFileLoadData
+  current.setAreaInfo = setAreaInfo
+  current.setActiveFile = setActiveFile
+  current.setRunnerTabsId = setRunnerTabsId
+  return container.current
+}

--- a/app/renderer/src/main/src/pages/yakRunnerAuditCode/YakRunnerAuditCode.tsx
+++ b/app/renderer/src/main/src/pages/yakRunnerAuditCode/YakRunnerAuditCode.tsx
@@ -61,6 +61,8 @@ import { getStorageAuditCodeShortcutKeyEvents } from '@/utils/globalShortcutKey/
 import useShortcutKeyTrigger from '@/utils/globalShortcutKey/events/useShortcutKeyTrigger'
 import { getCodeByPath, getCodeSizeByPath, getNameByPath, monacaLanguageType } from '../yakRunner/utils'
 import { openAIForge } from '../yakRunnerAuditHole/YakitAuditHoleTable/utils'
+import { isIRify } from '@/utils/envfile'
+import { YakitRoute } from '@/enums/yakitRoute'
 const { ipcRenderer } = window.require('electron')
 export const YakRunnerAuditCode: React.FC<YakRunnerAuditCodeProps> = (props) => {
   const { auditCodePageInfo } = props
@@ -846,6 +848,21 @@ export const AuditCodeStatusInfo: React.FC<AuditCodeStatusInfoProps> = (props) =
     e.stopPropagation()
     if (!path) {
       yakitNotify('error', '未找到项目路径，无法进行AI审计')
+      return
+    }
+    if (isIRify()) {
+      const auditParams: AuditCodePageInfoProps = {
+        Schema: 'syntaxflow',
+        Location: path,
+        Path: '/',
+      }
+      emiter.emit(
+        'openPage',
+        JSON.stringify({
+          route: YakitRoute.Irify_AI_Code_Audit,
+          params: auditParams,
+        }),
+      )
       return
     }
     const params = {

--- a/app/renderer/src/main/src/routes/newRoute.tsx
+++ b/app/renderer/src/main/src/routes/newRoute.tsx
@@ -25,6 +25,7 @@ import { CVEViewer } from '@/pages/cve/CVEViewer'
 import { YakJavaDecompiler } from '@/pages/yakJavaDecompiler/YakJavaDecompiler'
 import { PageLoading } from './PageLoading'
 import {
+  PrivateOutlineAIAgentIcon,
   PrivateOutlineAuditCodeIcon,
   PrivateOutlineAuditHoleIcon,
   PrivateOutlineBasicCrawlerIcon,
@@ -91,6 +92,7 @@ import {
   PrivateSolidTCPPortLogIcon,
   PrivateSolidWebFuzzerIcon,
   PrivateSolidWebsocketFuzzerIcon,
+  PrivateSolidAIAgentIcon,
 } from './privateIcon'
 import { ControlAdminPage } from '@/pages/dynamicControl/DynamicControl'
 import { DebugMonacoEditorPage } from '@/pages/debugMonaco/DebugMonacoEditorPage'
@@ -160,6 +162,7 @@ import {
 import { SimpleDetect } from '@/pages/simpleDetect/SimpleDetect'
 import { YakitRoute } from '../enums/yakitRoute'
 import { YakRunner } from '@/pages/yakRunner/YakRunner'
+import { IrifyAiCodeAuditPage } from '@/pages/irifyAiCodeAudit/IrifyAiCodeAuditPage'
 import { YakRunnerCodeScan } from '@/pages/yakRunnerCodeScan/YakRunnerCodeScan'
 import { YakRunnerAuditCode } from '@/pages/yakRunnerAuditCode/YakRunnerAuditCode'
 import { AddYakitPlugin } from '@/pages/pluginEditor/addYakitPlugin/AddYakitPlugin'
@@ -368,6 +371,11 @@ export const YakitRouteToPageInfo: Record<
     labelUi: 'YakitRoute.codeAudit',
     describeUi: 'YakitRoute.auditRuleCodeAnalysis',
   },
+  'irify-ai-code-audit': {
+    label: 'AI代码审计',
+    labelUi: 'YakitRoute.irifyAiCodeAudit',
+    describeUi: 'YakitRoute.irifyAiCodeAuditDescribe',
+  },
   'yakrunner-project-manager': { label: '项目管理', labelUi: 'YakitRoute.projectManagement' },
   yakrunner_scanHistory: { label: '项目历史', labelUi: 'YakitRoute.projectHistory' },
   'rule-management': {
@@ -440,6 +448,7 @@ export const SingletonPageRoute: YakitRoute[] = [
   YakitRoute.Beta_WebShellManager,
   YakitRoute.Data_Statistics,
   YakitRoute.YakRunner_Audit_Code,
+  YakitRoute.Irify_AI_Code_Audit,
   YakitRoute.YakRunner_Project_Manager,
   YakitRoute.YakRunner_ScanHistory,
   YakitRoute.Rule_Management,
@@ -496,6 +505,7 @@ export const NoPaddingRoute: YakitRoute[] = [
   YakitRoute.ShellReceiver,
   YakitRoute.YakRunner_Code_Scan,
   YakitRoute.YakRunner_Audit_Code,
+  YakitRoute.Irify_AI_Code_Audit,
   YakitRoute.YakRunner_Project_Manager,
   YakitRoute.YakRunner_ScanHistory,
   YakitRoute.Rule_Management,
@@ -904,6 +914,8 @@ export const RouteToPage: (props: PageItemProps) => ReactNode = (props) => {
       return <YakRunnerCodeScan pageId={params?.id || ''} />
     case YakitRoute.YakRunner_Audit_Code:
       return <YakRunnerAuditCode auditCodePageInfo={params?.auditCodePageInfo} />
+    case YakitRoute.Irify_AI_Code_Audit:
+      return <IrifyAiCodeAuditPage auditCodePageInfo={params?.auditCodePageInfo} />
     case YakitRoute.YakRunner_Project_Manager:
       return <YakRunnerProjectManager />
     case YakitRoute.YakRunner_ScanHistory:
@@ -1080,6 +1092,10 @@ export const getPublicRouteMenu = (softMode: SoftMode) => {
           {
             page: YakitRoute.YakRunner_Audit_Code,
             ...YakitRouteToPageInfo[YakitRoute.YakRunner_Audit_Code],
+          },
+          {
+            page: YakitRoute.Irify_AI_Code_Audit,
+            ...YakitRouteToPageInfo[YakitRoute.Irify_AI_Code_Audit],
           },
           {
             page: YakitRoute.YakRunner_Code_Scan,
@@ -1956,6 +1972,12 @@ export const PrivateAllMenus: Record<string, PrivateRouteMenuProps> = {
     hoverIcon: <PrivateSolidAuditCodeIcon />,
     ...YakitRouteToPageInfo[YakitRoute.YakRunner_Audit_Code],
   },
+  [YakitRoute.Irify_AI_Code_Audit]: {
+    page: YakitRoute.Irify_AI_Code_Audit,
+    icon: <PrivateOutlineAIAgentIcon />,
+    hoverIcon: <PrivateSolidAIAgentIcon />,
+    ...YakitRouteToPageInfo[YakitRoute.Irify_AI_Code_Audit],
+  },
   [YakitRoute.YakRunner_Audit_Hole]: {
     page: YakitRoute.YakRunner_Audit_Hole,
     icon: <PrivateOutlineAuditHoleIcon />,
@@ -2078,6 +2100,7 @@ export const PrivateExpertRouteMenu: PrivateRouteMenuProps[] = isIRify()
         children: [
           PrivateAllMenus[YakitRoute.YakRunner_Project_Manager],
           PrivateAllMenus[YakitRoute.YakRunner_Audit_Code],
+          PrivateAllMenus[YakitRoute.Irify_AI_Code_Audit],
           PrivateAllMenus[YakitRoute.YakRunner_Code_Scan],
           PrivateAllMenus[YakitRoute.Rule_Management],
           PrivateAllMenus[YakitRoute.YakRunner_Audit_Hole],

--- a/app/renderer/src/main/src/utils/eventBus/eventBus.ts
+++ b/app/renderer/src/main/src/utils/eventBus/eventBus.ts
@@ -27,6 +27,7 @@ import { ReportPageEventProps } from './events/reportPage'
 import { YakKnowledgeRepositoryEventProps } from './events/aiRepository'
 import { MainWinOperatorEventProps } from './events/mainWin'
 import { RuleManagementEventProps } from './events/ruleManagement'
+import { IrifyAiCodeAuditEventProps } from './events/irifyAiCodeAudit'
 
 type Contrast<T extends object, E extends object> = [keyof T & keyof E] extends [never] ? never : string
 type OneToArr<T extends object, E extends object[]> = E extends [infer X extends object, ...infer Y extends object[]]
@@ -81,6 +82,7 @@ type Events = [
   YakKnowledgeRepositoryEventProps,
   MainWinOperatorEventProps,
   RuleManagementEventProps,
+  IrifyAiCodeAuditEventProps,
 ]
 
 type CheckVal = Exchange<ArrContrast<Events>>

--- a/app/renderer/src/main/src/utils/eventBus/events/irifyAiCodeAudit.ts
+++ b/app/renderer/src/main/src/utils/eventBus/events/irifyAiCodeAudit.ts
@@ -1,0 +1,5 @@
+export type IrifyAiCodeAuditEventProps = {
+  onIrifyAiCodeAuditOpenFileTree: string
+  /** 预填侧栏 AI 输入框文案（不自动发送） */
+  onIrifyAiCodeAuditSeedChatDraft: string
+}

--- a/app/renderer/src/main/src/utils/eventBus/events/yakRunner.ts
+++ b/app/renderer/src/main/src/utils/eventBus/events/yakRunner.ts
@@ -33,6 +33,8 @@ export type YakRunnerEventProps = {
   onOperationFileTree: string
   // 通过路径打开文件
   onOpenFileByPath: string
+  // 打开临时文件
+  onOpenTemporaryFile: string
   // 通过缓存文件路径读取文件内容
   onGetCodeByPathCache: string
   // 打开编译文件Modal


### PR DESCRIPTION
- New irifyAiCodeAudit workbench + HistoryAIReAct side panel (no pageReAct/HTTPHistory migration)
- Route, menu, ChatDataStore singleton, event bus, i18n
- Previous PageReAct refactor remains on branch backup/irify-pageReAct-chat-migration

Made-with: Cursor

feat(irify): isolate AI ReAct sidebar, code audit attachment, vertical-right rail

- Add IrifyAiCodeAuditReActChatProvider mirroring History flow without touching historyAIReActChat.
- Attach project root via AttachedResourceInfo (Type file, Key code_audit_target_path) using codeAuditAttachment helpers.
- Sync opened folder root from workbench fileTree into IrifyWorkbenchAiAttachContext.
- Fix YakitSideTab vertical-right layout so the AI rail sits on the outer edge (row flex).

Made-with: Cursor

fix(irify): use AISession instead of removed AIChatInfo for tsc

Made-with: Cursor

feat(irify): compile dialog opens AI code audit with project path and seed input

- YakRunner audit compile modal: Irify opens Irify_AI_Code_Audit via openPage with AuditCodePageInfo
- Irify page: bootstrap file tree from auditCodePageInfo and prefill chat with 开始代码审计 (no auto-send)
- Route passes auditCodePageInfo; ReAct provider listens for seed draft event; reuse onAuditCodePageInfo for singleton refresh

Made-with: Cursor

feat: 增加跳转

wait: 等待ai md总结使用临时文件打开，且支持PDF导出
fix: 修复文件树性能
fix: -


feat: 文件树性能优化


feat: 新增临时文件打开


feat: irify md报告导出