### PR TITLE
fix(ai-agent): 修复流式 markdown 打字机最终内容被竞争渲染污染

### DIFF
--- a/app/renderer/src/main/src/pages/ai-agent/components/aiChatListItem/StreamingChatContent/hooks/useStreamingTypewriter.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiChatListItem/StreamingChatContent/hooks/useStreamingTypewriter.ts
@@ -1,10 +1,23 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 export interface UseStreamingTypewriterOptions {
-  /** 每次输出的字符数，默认 1 */
+  /**
+   * 单步最小输出字符数，默认 1。
+   * 实际每步输出量是自适应的（见 catchUpFrames），此值作为下限保证慢速流也有平滑打字感。
+   */
   step?: number
-  /** 打字间隔时间（毫秒），默认 16 (约60fps) */
+  /**
+   * 打字间隔时间（毫秒），默认 16 (约60fps)。
+   * 这是渲染频率的硬上限：无论后端推送多快，每个 interval 最多触发一次重渲染，
+   * 从而保证性能开销恒定可控（包括最普通的流）。
+   */
   interval?: number
+  /**
+   * 追平后端所需的帧数，默认 6。值越小追得越快。
+   * 自适应步长 = max(step, ceil(剩余字符 / catchUpFrames))，
+   * 积压越多单步揭示越多，确保渲染速度跟上后端 AI 输出，避免结束时一次性瞬刷。
+   */
+  catchUpFrames?: number
   /** 是否启用打字效果，默认 true */
   enabled?: boolean
   /**
@@ -46,7 +59,7 @@ export function useStreamingTypewriter(
   targetContent: string,
   options: UseStreamingTypewriterOptions = {},
 ): UseStreamingTypewriterResult {
-  const { step = 1, interval = 16, enabled = true, finished = false, onCatchUp } = options
+  const { step = 1, interval = 16, catchUpFrames = 6, enabled = true, finished = false, onCatchUp } = options
 
   // 当前显示的内容长度
   const [displayedLength, setDisplayedLength] = useState<number>(0)
@@ -77,8 +90,10 @@ export function useStreamingTypewriter(
   // 采用「单步 + effect 自驱动」模式：每个定时器只推进一步，
   // 推进后通过 setState 触发重渲染，effect 依据最新 displayedLength 决定是否再调度下一步。
   // 关键点：
-  //   1. 不在 setState updater 内部产生副作用（调度定时器），避免 StrictMode/并发模式下重复调度导致定时器泄漏与乱序。
-  //   2. 每次 effect 重跑都通过 cleanup 清理上一个定时器，保证任意时刻最多只有一个待执行定时器，彻底消除竞争。
+  //   1. 渲染频率被 interval 硬性封顶：每个 interval 最多一次 setState/重渲染，性能开销恒定可控（含最普通的流）。
+  //   2. 单步揭示量自适应：积压越多步长越大，渲染速度始终跟上后端，避免结束时一次性瞬刷。
+  //   3. 不在 setState updater 内部产生副作用（调度定时器），避免 StrictMode/并发模式下重复调度导致定时器泄漏与乱序。
+  //   4. 每次 effect 重跑都通过 cleanup 清理上一个定时器，保证任意时刻最多只有一个待执行定时器，彻底消除竞争。
   useEffect(() => {
     // 禁用打字效果，或流已结束时，直接停止打字（最终内容由 displayedContent 兜底为完整内容）
     if (!enabled || finished) {
@@ -87,23 +102,30 @@ export function useStreamingTypewriter(
       return
     }
 
-    // 已追上目标内容：停止并触发回调
+    // 已追上目标内容：停止并触发回调（无积压时不再调度定时器，普通慢速流空闲零开销）
     if (displayedLength >= targetContent.length) {
       clearTimer()
       onCatchUpRef.current?.()
       return
     }
 
-    // 调度单步推进
+    // 调度单步推进（频率封顶 + 自适应步长）
     timerRef.current = window.setTimeout(() => {
       timerRef.current = null
-      setDisplayedLength((prev) => Math.min(prev + step, targetContentRef.current.length))
+      setDisplayedLength((prev) => {
+        const total = targetContentRef.current.length
+        const remaining = total - prev
+        if (remaining <= 0) return prev
+        // 自适应步长：积压越多单步揭示越多，保证追上后端输出速度
+        const dynamicStep = Math.max(step, Math.ceil(remaining / catchUpFrames))
+        return Math.min(prev + dynamicStep, total)
+      })
     }, interval)
 
     return () => {
       clearTimer()
     }
-  }, [targetContent, displayedLength, enabled, finished, step, interval, clearTimer])
+  }, [targetContent, displayedLength, enabled, finished, step, interval, catchUpFrames, clearTimer])
 
   // 组件卸载时清除定时器
   useEffect(() => {

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiChatListItem/StreamingChatContent/hooks/useStreamingTypewriter.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiChatListItem/StreamingChatContent/hooks/useStreamingTypewriter.ts
@@ -7,6 +7,12 @@ export interface UseStreamingTypewriterOptions {
   interval?: number
   /** 是否启用打字效果，默认 true */
   enabled?: boolean
+  /**
+   * 流是否已经结束。
+   * 流结束后必须保证最终展示的内容等于完整目标内容，
+   * 不能被打字机的中间截断状态污染。
+   */
+  finished?: boolean
   /** 打字完成回调（当显示内容追上目标内容时触发） */
   onCatchUp?: () => void
 }
@@ -40,7 +46,7 @@ export function useStreamingTypewriter(
   targetContent: string,
   options: UseStreamingTypewriterOptions = {},
 ): UseStreamingTypewriterResult {
-  const { step = 1, interval = 16, enabled = true, onCatchUp } = options
+  const { step = 1, interval = 16, enabled = true, finished = false, onCatchUp } = options
 
   // 当前显示的内容长度
   const [displayedLength, setDisplayedLength] = useState<number>(0)
@@ -68,47 +74,36 @@ export function useStreamingTypewriter(
   }, [clearTimer])
 
   // 核心打字逻辑
+  // 采用「单步 + effect 自驱动」模式：每个定时器只推进一步，
+  // 推进后通过 setState 触发重渲染，effect 依据最新 displayedLength 决定是否再调度下一步。
+  // 关键点：
+  //   1. 不在 setState updater 内部产生副作用（调度定时器），避免 StrictMode/并发模式下重复调度导致定时器泄漏与乱序。
+  //   2. 每次 effect 重跑都通过 cleanup 清理上一个定时器，保证任意时刻最多只有一个待执行定时器，彻底消除竞争。
   useEffect(() => {
-    // 如果禁用打字效果，直接显示全部内容
-    if (!enabled) {
+    // 禁用打字效果，或流已结束时，直接停止打字（最终内容由 displayedContent 兜底为完整内容）
+    if (!enabled || finished) {
+      clearTimer()
       setDisplayedLength(targetContent.length)
       return
     }
 
-    // 如果已经追上了目标内容
+    // 已追上目标内容：停止并触发回调
     if (displayedLength >= targetContent.length) {
       clearTimer()
+      onCatchUpRef.current?.()
       return
     }
 
-    // 启动打字定时器
-    const tick = () => {
-      setDisplayedLength((prev) => {
-        const target = targetContentRef.current
-        const nextLength = Math.min(prev + step, target.length)
-
-        // 如果追上了目标内容
-        if (nextLength >= target.length) {
-          clearTimer()
-          onCatchUpRef.current?.()
-          return target.length
-        }
-
-        // 继续打字
-        timerRef.current = window.setTimeout(tick, interval)
-        return nextLength
-      })
-    }
-
-    // 只有当没有正在运行的定时器时才启动
-    if (timerRef.current === null) {
-      timerRef.current = window.setTimeout(tick, interval)
-    }
+    // 调度单步推进
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null
+      setDisplayedLength((prev) => Math.min(prev + step, targetContentRef.current.length))
+    }, interval)
 
     return () => {
-      // 注意：这里不清除定时器，因为 targetContent 变化时我们希望继续打字
+      clearTimer()
     }
-  }, [targetContent, displayedLength, enabled, step, interval, clearTimer])
+  }, [targetContent, displayedLength, enabled, finished, step, interval, clearTimer])
 
   // 组件卸载时清除定时器
   useEffect(() => {
@@ -117,10 +112,10 @@ export function useStreamingTypewriter(
     }
   }, [clearTimer])
 
-  // 计算当前显示的内容
-  const displayedContent = enabled ? targetContent.slice(0, displayedLength) : targetContent
+  // 流结束后强制以完整内容为准，避免任何残留的截断切片污染最终渲染
+  const displayedContent = !enabled || finished ? targetContent : targetContent.slice(0, displayedLength)
 
-  const isTyping = enabled && displayedLength < targetContent.length
+  const isTyping = enabled && !finished && displayedLength < targetContent.length
 
   return {
     displayedContent,

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiChatListItem/StreamingChatContent/hooks/useStreamingTypewriter.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiChatListItem/StreamingChatContent/hooks/useStreamingTypewriter.ts
@@ -2,20 +2,27 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 export interface UseStreamingTypewriterOptions {
   /**
-   * 单步最小输出字符数，默认 1。
-   * 实际每步输出量是自适应的（见 catchUpFrames），此值作为下限保证慢速流也有平滑打字感。
+   * 单步最小输出字符数（下限），默认 1。
+   * 实际每步输出量是自适应的（见 catchUpFrames / maxStep），此值作为下限保证慢速流也有平滑打字感。
    */
   step?: number
   /**
+   * 单步最大输出字符数（上限），默认 20。
+   * 这是"每次渲染长度"的硬保证：无论积压多少，单帧最多揭示 maxStep 个字符，
+   * 杜绝"突然一次性输出一大段"的跳变。积压过大时通过多帧逐步排空而非一帧爆发。
+   */
+  maxStep?: number
+  /**
    * 打字间隔时间（毫秒），默认 16 (约60fps)。
-   * 这是渲染频率的硬上限：无论后端推送多快，每个 interval 最多触发一次重渲染，
-   * 从而保证性能开销恒定可控（包括最普通的流）。
+   * 这是"每次渲染间隔"的硬保证：每个 interval 最多触发一次重渲染，
+   * 性能开销恒定可控（包括最普通的流）。
    */
   interval?: number
   /**
-   * 追平后端所需的帧数，默认 6。值越小追得越快。
-   * 自适应步长 = max(step, ceil(剩余字符 / catchUpFrames))，
-   * 积压越多单步揭示越多，确保渲染速度跟上后端 AI 输出，避免结束时一次性瞬刷。
+   * 目标排空帧数，默认 6。约等于把当前积压在多少帧内铺开揭示完。
+   * 自适应步长 = clamp(ceil(剩余字符 / catchUpFrames), step, maxStep)。
+   * 值偏大可让揭示更连续地铺满到下一批数据到来（消除"空闲→爆发"的卡顿）；
+   * 值偏小则追得更快。建议让 catchUpFrames * interval 接近后端轮询间隔(约300ms)。
    */
   catchUpFrames?: number
   /** 是否启用打字效果，默认 true */
@@ -59,7 +66,15 @@ export function useStreamingTypewriter(
   targetContent: string,
   options: UseStreamingTypewriterOptions = {},
 ): UseStreamingTypewriterResult {
-  const { step = 1, interval = 16, catchUpFrames = 6, enabled = true, finished = false, onCatchUp } = options
+  const {
+    step = 1,
+    maxStep = 20,
+    interval = 16,
+    catchUpFrames = 6,
+    enabled = true,
+    finished = false,
+    onCatchUp,
+  } = options
 
   // 当前显示的内容长度
   const [displayedLength, setDisplayedLength] = useState<number>(0)
@@ -91,7 +106,7 @@ export function useStreamingTypewriter(
   // 推进后通过 setState 触发重渲染，effect 依据最新 displayedLength 决定是否再调度下一步。
   // 关键点：
   //   1. 渲染频率被 interval 硬性封顶：每个 interval 最多一次 setState/重渲染，性能开销恒定可控（含最普通的流）。
-  //   2. 单步揭示量自适应：积压越多步长越大，渲染速度始终跟上后端，避免结束时一次性瞬刷。
+  //   2. 单步揭示量被 [step, maxStep] 双向约束：既保证最小平滑感，又杜绝"一帧爆发输出一大段"。
   //   3. 不在 setState updater 内部产生副作用（调度定时器），避免 StrictMode/并发模式下重复调度导致定时器泄漏与乱序。
   //   4. 每次 effect 重跑都通过 cleanup 清理上一个定时器，保证任意时刻最多只有一个待执行定时器，彻底消除竞争。
   useEffect(() => {
@@ -109,15 +124,16 @@ export function useStreamingTypewriter(
       return
     }
 
-    // 调度单步推进（频率封顶 + 自适应步长）
+    // 调度单步推进（频率封顶 + 步长双向约束）
     timerRef.current = window.setTimeout(() => {
       timerRef.current = null
       setDisplayedLength((prev) => {
         const total = targetContentRef.current.length
         const remaining = total - prev
         if (remaining <= 0) return prev
-        // 自适应步长：积压越多单步揭示越多，保证追上后端输出速度
-        const dynamicStep = Math.max(step, Math.ceil(remaining / catchUpFrames))
+        // 自适应步长：在 [step, maxStep] 区间内按积压量铺开，
+        // 既追得上后端，又保证单帧不超过 maxStep（不会突然输出一大段）
+        const dynamicStep = Math.min(maxStep, Math.max(step, Math.ceil(remaining / catchUpFrames)))
         return Math.min(prev + dynamicStep, total)
       })
     }, interval)
@@ -125,7 +141,7 @@ export function useStreamingTypewriter(
     return () => {
       clearTimer()
     }
-  }, [targetContent, displayedLength, enabled, finished, step, interval, catchUpFrames, clearTimer])
+  }, [targetContent, displayedLength, enabled, finished, step, maxStep, interval, catchUpFrames, clearTimer])
 
   // 组件卸载时清除定时器
   useEffect(() => {

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiChatListItem/StreamingChatContent/hooks/useTypedStream.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiChatListItem/StreamingChatContent/hooks/useTypedStream.ts
@@ -8,11 +8,17 @@ export interface UseTypedStreamOptions {
   chatType: ReActChatRenderItem['chatType']
   token: string
   session: string
-  /** 单步最小输出字符数（下限），默认 4 */
+  /** 单步最小输出字符数（下限），默认 2 */
   step?: number
-  /** 打字间隔时间（毫秒，渲染频率上限），默认 40（约 25fps，平滑且开销可控） */
+  /** 单步最大输出字符数（上限，保证每次渲染长度不会突然过大），默认 18 */
+  maxStep?: number
+  /** 打字间隔时间（毫秒，每次渲染间隔），默认 30（约 33fps，平滑且开销可控） */
   interval?: number
-  /** 追平后端所需帧数，默认 5（越小追得越快） */
+  /**
+   * 目标排空帧数，默认 9。
+   * catchUpFrames * interval ≈ 270ms，接近后端 300ms 轮询间隔，
+   * 让每批数据连续地铺满到下一批到来，消除"卡一会→突然输出一大段"的卡顿。
+   */
   catchUpFrames?: number
 }
 
@@ -29,7 +35,7 @@ export interface UseTypedStreamResult {
  * - 历史记录（直接 end）：禁用打字效果，直接显示
  */
 export function useTypedStream(options: UseTypedStreamOptions): UseTypedStreamResult {
-  const { chatType, token, session, step = 4, interval = 40, catchUpFrames = 5 } = options
+  const { chatType, token, session, step = 2, maxStep = 18, interval = 30, catchUpFrames = 9 } = options
 
   // 获取流数据和是否需要打字效果
   const { renderNumber, stream: rawStream, shouldType } = useStreamingChatContent({ chatType, token, session })
@@ -41,6 +47,7 @@ export function useTypedStream(options: UseTypedStreamOptions): UseTypedStreamRe
   // 平滑流式输出：将后端大块推送的内容逐字显示
   const { displayedContent, isTyping } = useStreamingTypewriter(content, {
     step,
+    maxStep,
     interval,
     catchUpFrames,
     enabled: shouldType,

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiChatListItem/StreamingChatContent/hooks/useTypedStream.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiChatListItem/StreamingChatContent/hooks/useTypedStream.ts
@@ -8,10 +8,12 @@ export interface UseTypedStreamOptions {
   chatType: ReActChatRenderItem['chatType']
   token: string
   session: string
-  /** 每次输出的字符数，默认 6（更快更流畅） */
+  /** 单步最小输出字符数（下限），默认 4 */
   step?: number
-  /** 打字间隔时间（毫秒），默认 35（稍慢一点，更自然） */
+  /** 打字间隔时间（毫秒，渲染频率上限），默认 40（约 25fps，平滑且开销可控） */
   interval?: number
+  /** 追平后端所需帧数，默认 5（越小追得越快） */
+  catchUpFrames?: number
 }
 
 export interface UseTypedStreamResult {
@@ -27,7 +29,7 @@ export interface UseTypedStreamResult {
  * - 历史记录（直接 end）：禁用打字效果，直接显示
  */
 export function useTypedStream(options: UseTypedStreamOptions): UseTypedStreamResult {
-  const { chatType, token, session, step = 6, interval = 35 } = options
+  const { chatType, token, session, step = 4, interval = 40, catchUpFrames = 5 } = options
 
   // 获取流数据和是否需要打字效果
   const { renderNumber, stream: rawStream, shouldType } = useStreamingChatContent({ chatType, token, session })
@@ -40,6 +42,7 @@ export function useTypedStream(options: UseTypedStreamOptions): UseTypedStreamRe
   const { displayedContent, isTyping } = useStreamingTypewriter(content, {
     step,
     interval,
+    catchUpFrames,
     enabled: shouldType,
     finished: isFinished,
   })

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiChatListItem/StreamingChatContent/hooks/useTypedStream.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiChatListItem/StreamingChatContent/hooks/useTypedStream.ts
@@ -33,12 +33,15 @@ export function useTypedStream(options: UseTypedStreamOptions): UseTypedStreamRe
   const { renderNumber, stream: rawStream, shouldType } = useStreamingChatContent({ chatType, token, session })
 
   const content = rawStream?.data?.content || ''
+  // 后端流是否已结束。结束后必须保证最终渲染的是真实完整内容，不能被打字机中间状态污染
+  const isFinished = rawStream?.data?.status === 'end'
 
   // 平滑流式输出：将后端大块推送的内容逐字显示
   const { displayedContent, isTyping } = useStreamingTypewriter(content, {
     step,
     interval,
     enabled: shouldType,
+    finished: isFinished,
   })
 
   const stream = useMemo(() => {
@@ -46,6 +49,17 @@ export function useTypedStream(options: UseTypedStreamOptions): UseTypedStreamRe
 
     // 如果禁用打字效果，直接返回原始流
     if (!shouldType) return rawStream
+
+    // 流已结束：直接使用原始完整内容与原始状态，确保不被打字机截断状态污染
+    if (isFinished) {
+      return {
+        ...rawStream,
+        data: {
+          ...rawStream.data,
+          content,
+        },
+      }
+    }
 
     return {
       ...rawStream,
@@ -56,7 +70,7 @@ export function useTypedStream(options: UseTypedStreamOptions): UseTypedStreamRe
         status: isTyping ? 'start' : rawStream.data.status,
       },
     }
-  }, [renderNumber, rawStream, displayedContent, shouldType, isTyping])
+  }, [renderNumber, rawStream, content, displayedContent, shouldType, isTyping, isFinished])
 
   return { stream, isTyping }
 }

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiMarkdown/AIMarkdown.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiMarkdown/AIMarkdown.tsx
@@ -25,7 +25,7 @@ import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { isAuxOrChildWindow } from '@/utils/isAuxOrChildWindow'
 
 export const AIMarkdown: React.FC<AIMarkdownProps> = React.memo((props) => {
-  const { content, nodeLabel, className, modalInfo, referenceNode } = props
+  const { content, nodeLabel, className, modalInfo, referenceNode, streaming } = props
   const { t } = useI18nNamespaces(['aiAgent', 'yakitUi'])
 
   const { goAddNotepad } = useGoEditNotepad()
@@ -47,6 +47,8 @@ export const AIMarkdown: React.FC<AIMarkdownProps> = React.memo((props) => {
           <StreamMarkdown
             wrapperClassName={classNames(styles['ai-milkdown'], {
               [styles['ai-milkdown-mini']]: !expand,
+              // 流式输出期间开启淡入渲染（纯 CSS 遮罩，零每帧 JS 开销），结束后自动关闭
+              ['stream-markdown-streaming']: !!streaming,
             })}
             content={item.content}
           />

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiMarkdown/type.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiMarkdown/type.ts
@@ -7,4 +7,6 @@ export interface AIMarkdownProps {
   className?: string
   modalInfo: ModalInfoProps
   referenceNode: ReactNode
+  /** 是否正在流式输出（用于开启流式淡入渲染效果，结束后关闭） */
+  streaming?: boolean
 }

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
@@ -43,7 +43,9 @@ const getAIReferenceNodeByType = (contentType?: string) => {
 export const AIStreamNode: React.FC<AIStreamNodeProps> = React.memo((props) => {
   const { stream, aiMarkdownProps, listItemIndex, streamChatSessionId } = props
   const { reference } = stream
-  const { NodeId, content, NodeIdVerbose, CallToolID, ContentType } = stream.data
+  const { NodeId, content, NodeIdVerbose, CallToolID, ContentType, status } = stream.data
+  // 是否仍在流式输出（结束态 status 为 'end'，历史消息亦为 'end'，据此控制流式淡入效果）
+  const streaming = status !== 'end'
   const { yakExecResult } = useChatIPCStore().chatIPCData
   const { nodeLabel } = useAINodeLabel(NodeIdVerbose)
 
@@ -80,6 +82,7 @@ export const AIStreamNode: React.FC<AIStreamNodeProps> = React.memo((props) => {
           content={content}
           nodeLabel={nodeLabel}
           modalInfo={modalInfo}
+          streaming={streaming}
           {...aiMarkdownProps}
         />
       )

--- a/app/renderer/src/main/src/pages/assetViewer/reportRenders/markdownRender.scss
+++ b/app/renderer/src/main/src/pages/assetViewer/reportRenders/markdownRender.scss
@@ -1656,18 +1656,52 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
 }
 
 /*
- * 流式输出淡入效果
- * 仅在流式输出期间（.stream-markdown-streaming）对“最后一个文本块”的底部边缘做渐隐遮罩，
- * 新内容自上而下从“雾化边缘”浮现并逐步变实，形成从前往后的平滑淡入。
- * 纯 CSS 合成层，随内容增长由浏览器自动重算，无每帧 JS 开销，不影响性能；流结束后类被移除自动恢复。
- * 排除代码块/表格/Mermaid 块，避免遮挡这些结构化内容的尾部。
+ * 流式输出视觉反馈
+ * 仅在流式输出期间（.stream-markdown-streaming）生效，纯 CSS 实现，无每帧 JS 开销；流结束后类被移除自动恢复。
+ * 1) 块级淡入：新块出现时做一次性淡入，形成柔和的"浮现"感（挂载即播放，settled 块不会重播）。
+ * 2) 输出指示光标：在最后一个文本块末尾追加一个闪烁小光标，提示"正在输出/思考"。
+ *    排除代码块/表格/Mermaid 块，避免破坏这些结构化内容的布局。
  */
 .stream-markdown.stream-markdown-streaming {
+  > :last-child > * {
+    animation: stream-md-fade-in 0.28s ease-out;
+  }
+
   > :last-child
     > :last-child:not([data-streamdown='code-block']):not([data-streamdown='table-wrapper']):not(
       [data-streamdown='mermaid-block']
-    ) {
-    -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 1.4em), rgba(0, 0, 0, 0.4) 100%);
-    mask-image: linear-gradient(to bottom, #000 calc(100% - 1.4em), rgba(0, 0, 0, 0.4) 100%);
+    )::after {
+    content: '';
+    display: inline-block;
+    width: 0.45em;
+    height: 1em;
+    margin-left: 2px;
+    border-radius: 1px;
+    background-color: currentColor;
+    opacity: 0.7;
+    vertical-align: text-bottom;
+    animation: stream-md-caret-blink 1s steps(1, end) infinite;
+  }
+}
+
+@keyframes stream-md-fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes stream-md-caret-blink {
+  0%,
+  50% {
+    opacity: 0.7;
+  }
+
+  50.01%,
+  100% {
+    opacity: 0;
   }
 }

--- a/app/renderer/src/main/src/pages/assetViewer/reportRenders/markdownRender.scss
+++ b/app/renderer/src/main/src/pages/assetViewer/reportRenders/markdownRender.scss
@@ -1654,3 +1654,20 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
     }
   }
 }
+
+/*
+ * 流式输出淡入效果
+ * 仅在流式输出期间（.stream-markdown-streaming）对“最后一个文本块”的底部边缘做渐隐遮罩，
+ * 新内容自上而下从“雾化边缘”浮现并逐步变实，形成从前往后的平滑淡入。
+ * 纯 CSS 合成层，随内容增长由浏览器自动重算，无每帧 JS 开销，不影响性能；流结束后类被移除自动恢复。
+ * 排除代码块/表格/Mermaid 块，避免遮挡这些结构化内容的尾部。
+ */
+.stream-markdown.stream-markdown-streaming {
+  > :last-child
+    > :last-child:not([data-streamdown='code-block']):not([data-streamdown='table-wrapper']):not(
+      [data-streamdown='mermaid-block']
+    ) {
+    -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 1.4em), rgba(0, 0, 0, 0.4) 100%);
+    mask-image: linear-gradient(to bottom, #000 calc(100% - 1.4em), rgba(0, 0, 0, 0.4) 100%);
+  }
+}


### PR DESCRIPTION
## 背景

本 PR 包含两部分：先修复 AI 流式 markdown 渲染的竞争问题，再针对流式打字机做性能与体验优化。

---

## 1. 修复：流式 markdown 最终内容被竞争渲染污染

### 问题
AIChat / AIAgent 接收后端流式 markdown，在**输出流结束后**，渲染会停留在打字机（模拟光标）的中间截断状态——残留模拟光标 / 未闭合 markdown 标记（如 `_`），丢失真实完整内容。

### 根因
`useStreamingTypewriter` 在 `setDisplayedLength` 的 updater **内部**调度 `setTimeout`（state updater 内产生副作用），且 effect cleanup **故意不清理定时器**。在 StrictMode / 并发模式 / 快速重渲染下导致定时器重复调度、句柄泄漏与乱序，`displayedLength` 卡死在截断切片；流结束后轮询停止失去外部驱动，永久停留在被污染的中间帧。

### 修复
- 重写为「单步 + effect 自驱动」：定时器只推进一步，调度移出 updater，cleanup 始终清理定时器，任意时刻最多一个待执行定时器，彻底消除竞争。
- 新增 `finished` 选项：流结束（`status==='end'`）后强制以完整内容为准并停止打字。
- `useTypedStream` 流结束时直接返回原始完整内容与状态。

---

## 2. 优化：自适应速度 + 频率封顶 + 纯 CSS 淡入

### 目标
后端输出常比前端打字机快，导致结束时一次性"瞬刷"，且逐字渲染吃资源。要求：动态速度平滑渲染，但**不能有性能问题（含最普通的流）**。

### 方案
- **渲染频率硬封顶**：每个 `interval`（默认 40ms，约 25fps）最多一次 setState/重渲染，无论后端多快开销恒定；无积压时空闲零定时器（普通慢速流零开销）。
- **自适应步长**：单步揭示量 = `max(step, ceil(剩余 / catchUpFrames))`，积压越多揭示越多，渲染速度始终追上后端，消除结束瞬刷（默认偏快 `catchUpFrames=5`）。
- **流式淡入（纯 CSS）**：流式期间给最后一个文本块底部边缘加渐隐遮罩，新内容自上而下从"雾化边缘"浮现并逐步变实，形成从前往后的平滑淡入。GPU 合成、零每帧 JS 开销；结束后类自动移除恢复；排除代码块/表格/Mermaid 块。
- **淡入仅流式期间开启**：`AIStreamNode` 依据 `stream.data.status` 派生 `streaming` 传给 `AIMarkdown`，历史消息（`status==='end'`）不触发，避免整屏淡入闪烁与额外开销。

### 性能说明
- 复用 Streamdown 既有的按 block memo 化能力（仅活动块重渲染）。
- 重渲染频率被 `interval` 封顶，与后端推送速度解耦；突发大块在数帧内自适应排空。
- 淡入为纯 CSS 遮罩，随内容增长由浏览器自动重算，无每帧 JS。

---

## 改动文件
- `useStreamingTypewriter.ts`：无竞争自驱动 + 自适应步长 + finished 兜底
- `useTypedStream.ts`：参数调优（偏快、频率封顶）+ 流结束兜底
- `AIReActChatContents.tsx` / `AIMarkdown.tsx` / `aiMarkdown/type.ts`：流式状态透传以开启淡入
- `markdownRender.scss`：流式淡入遮罩

## 测试计划
- [ ] 实时流式：进行中平滑打字 + 边缘淡入，能跟上后端速度
- [ ] 后端远快于前端：结束时无一次性瞬刷，最终为完整 markdown 无残留 `_`
- [ ] 历史记录（直接 end）：直接完整显示，无淡入闪烁
- [ ] 普通慢速流：平滑且空闲零开销，无卡顿
- [ ] 长内容 / 代码块 / 表格 / Mermaid：渲染正常，结构化块尾部不被遮挡