### PR TITLE
ci(windows): 发布前对 Windows 安装包做 Authenticode 代码签名

### DIFF
--- a/.github/actions/sign-windows/action.yml
+++ b/.github/actions/sign-windows/action.yml
@@ -1,0 +1,95 @@
+name: "Sign Windows Executables"
+description: "Sign Windows .exe files with Azure Key Vault via AzureSignTool (consistent with yaklang engine signing)"
+
+inputs:
+  path:
+    description: "Directory that contains the .exe files to sign"
+    required: false
+    default: "release"
+  pattern:
+    description: "Filter pattern (Windows wildcard) used to match files under path"
+    required: false
+    default: "*windows*.exe"
+  key-vault-url:
+    description: "Azure Key Vault URI"
+    required: true
+  key-vault-client-id:
+    description: "Azure application (client) id"
+    required: true
+  key-vault-tenant-id:
+    description: "Azure directory (tenant) id"
+    required: true
+  key-vault-client-secret:
+    description: "Azure client secret"
+    required: true
+  key-vault-certificate:
+    description: "Certificate name inside the Key Vault"
+    required: true
+  timestamp-url:
+    description: "RFC3161 timestamp server url"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate signing inputs
+      shell: pwsh
+      run: |
+        $missing = @()
+        if (-not "${{ inputs.key-vault-url }}") { $missing += "key-vault-url" }
+        if (-not "${{ inputs.key-vault-client-id }}") { $missing += "key-vault-client-id" }
+        if (-not "${{ inputs.key-vault-tenant-id }}") { $missing += "key-vault-tenant-id" }
+        if (-not "${{ inputs.key-vault-client-secret }}") { $missing += "key-vault-client-secret" }
+        if (-not "${{ inputs.key-vault-certificate }}") { $missing += "key-vault-certificate" }
+        if (-not "${{ inputs.timestamp-url }}") { $missing += "timestamp-url" }
+        if ($missing.Count -gt 0) {
+          throw ("Missing required signing inputs: " + ($missing -join ", "))
+        }
+
+    - name: Set up .NET (for AzureSignTool)
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: "8.0.x"
+
+    - name: Install AzureSignTool
+      shell: pwsh
+      run: |
+        dotnet tool install --global AzureSignTool
+        "$env:USERPROFILE\.dotnet\tools" >> $env:GITHUB_PATH
+        AzureSignTool --version
+
+    - name: Sign Windows executables
+      shell: pwsh
+      run: |
+        $files = Get-ChildItem -Path "${{ inputs.path }}" -Recurse -Filter "${{ inputs.pattern }}"
+        if (-not $files) {
+          throw "No files matched pattern '${{ inputs.pattern }}' under '${{ inputs.path }}'"
+        }
+        foreach ($f in $files) {
+          Write-Host "Signing $($f.FullName)"
+          AzureSignTool sign `
+            -kvu "${{ inputs.key-vault-url }}" `
+            -kvi "${{ inputs.key-vault-client-id }}" `
+            -kvt "${{ inputs.key-vault-tenant-id }}" `
+            -kvs "${{ inputs.key-vault-client-secret }}" `
+            -kvc "${{ inputs.key-vault-certificate }}" `
+            -tr "${{ inputs.timestamp-url }}" `
+            -td sha256 `
+            -v `
+            "$($f.FullName)"
+          if ($LASTEXITCODE -ne 0) {
+            throw "AzureSignTool failed for $($f.FullName)"
+          }
+        }
+
+    - name: Verify signatures
+      shell: pwsh
+      run: |
+        $files = Get-ChildItem -Path "${{ inputs.path }}" -Recurse -Filter "${{ inputs.pattern }}"
+        foreach ($f in $files) {
+          $sig = Get-AuthenticodeSignature -FilePath $f.FullName
+          Write-Host "$($f.Name): status=$($sig.Status), signer=$($sig.SignerCertificate.Subject)"
+          if ($sig.Status -eq 'NotSigned') {
+            throw "File is still not signed: $($f.Name)"
+          }
+        }

--- a/.github/actions/sign-windows/action.yml
+++ b/.github/actions/sign-windows/action.yml
@@ -1,36 +1,36 @@
-name: "Sign Windows Executables"
-description: "Sign Windows .exe files with Azure Key Vault via AzureSignTool (consistent with yaklang engine signing)"
+name: 'Sign Windows Executables'
+description: 'Sign Windows .exe files with Azure Key Vault via AzureSignTool (consistent with yaklang engine signing)'
 
 inputs:
   path:
-    description: "Directory that contains the .exe files to sign"
+    description: 'Directory that contains the .exe files to sign'
     required: false
-    default: "release"
+    default: 'release'
   pattern:
-    description: "Filter pattern (Windows wildcard) used to match files under path"
+    description: 'Filter pattern (Windows wildcard) used to match files under path'
     required: false
-    default: "*windows*.exe"
+    default: '*windows*.exe'
   key-vault-url:
-    description: "Azure Key Vault URI"
+    description: 'Azure Key Vault URI'
     required: true
   key-vault-client-id:
-    description: "Azure application (client) id"
+    description: 'Azure application (client) id'
     required: true
   key-vault-tenant-id:
-    description: "Azure directory (tenant) id"
+    description: 'Azure directory (tenant) id'
     required: true
   key-vault-client-secret:
-    description: "Azure client secret"
+    description: 'Azure client secret'
     required: true
   key-vault-certificate:
-    description: "Certificate name inside the Key Vault"
+    description: 'Certificate name inside the Key Vault'
     required: true
   timestamp-url:
-    description: "RFC3161 timestamp server url"
+    description: 'RFC3161 timestamp server url'
     required: true
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Validate signing inputs
       shell: pwsh
@@ -49,7 +49,7 @@ runs:
     - name: Set up .NET (for AzureSignTool)
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: "8.0.x"
+        dotnet-version: '8.0.x'
 
     - name: Install AzureSignTool
       shell: pwsh

--- a/.github/workflows/build-multi-irify-prod.yml
+++ b/.github/workflows/build-multi-irify-prod.yml
@@ -198,6 +198,44 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # 给 Windows 安装包外壳做 Authenticode 签名(上传 Release/OSS 之前)
+  # 内置引擎已在 yaklang OSS 源头签名，此处只补安装包外壳这一层
+  sign_windows:
+    needs: build_yakit
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        artifact: [IRify, IRifyEnpriTrace]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download ${{ matrix.artifact }} artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}-artifacts
+          path: release
+
+      - name: Sign Windows installers
+        uses: ./.github/actions/sign-windows
+        with:
+          path: release
+          key-vault-url: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_URI }}
+          key-vault-client-id: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_APPLICATION_ID }}
+          key-vault-tenant-id: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_DIRECTORY_ID }}
+          key-vault-client-secret: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_CLIENT_SECRET }}
+          key-vault-certificate: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_CERT_NAME }}
+          timestamp-url: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_TIMESTAMP_URL }}
+
+      - name: Re-upload signed ${{ matrix.artifact }} artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}-artifacts
+          path: release
+          overwrite: true
+          if-no-files-found: error
+          retention-days: 1
+
   cleanup_engine_artifact:
     needs: build_yakit
     runs-on: ubuntu-latest
@@ -209,7 +247,7 @@ jobs:
 
   publish_software_to_oss:
     needs:
-      - build_yakit
+      - sign_windows
     strategy:
       matrix:
         artifact: [IRify, IRifyEnpriTrace] # 需要发布的软件名前缀

--- a/.github/workflows/build-multi-memfit-prod.yml
+++ b/.github/workflows/build-multi-memfit-prod.yml
@@ -112,8 +112,42 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  publish_memfit_to_oss:
+  # 给 Windows 安装包外壳做 Authenticode 签名(上传 OSS 之前)
+  # 内置引擎已在 yaklang OSS 源头签名，此处只补安装包外壳这一层
+  sign_windows:
     needs: build_memfit
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Memfit artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: Memfit-artifacts
+          path: release
+
+      - name: Sign Windows installers
+        uses: ./.github/actions/sign-windows
+        with:
+          path: release
+          key-vault-url: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_URI }}
+          key-vault-client-id: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_APPLICATION_ID }}
+          key-vault-tenant-id: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_DIRECTORY_ID }}
+          key-vault-client-secret: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_CLIENT_SECRET }}
+          key-vault-certificate: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_CERT_NAME }}
+          timestamp-url: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_TIMESTAMP_URL }}
+
+      - name: Re-upload signed Memfit artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Memfit-artifacts
+          path: release
+          overwrite: true
+          if-no-files-found: error
+          retention-days: 1
+
+  publish_memfit_to_oss:
+    needs: sign_windows
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-multi-prod.yml
+++ b/.github/workflows/build-multi-prod.yml
@@ -222,6 +222,44 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # 给 Windows 安装包外壳做 Authenticode 签名(上传 Release/OSS 之前)
+  # 内置引擎已在 yaklang OSS 源头签名，此处只补安装包外壳这一层
+  sign_windows:
+    needs: build_yakit
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        artifact: [Yakit, EnpriTrace]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download ${{ matrix.artifact }} artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}-artifacts
+          path: release
+
+      - name: Sign Windows installers
+        uses: ./.github/actions/sign-windows
+        with:
+          path: release
+          key-vault-url: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_URI }}
+          key-vault-client-id: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_APPLICATION_ID }}
+          key-vault-tenant-id: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_DIRECTORY_ID }}
+          key-vault-client-secret: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_CLIENT_SECRET }}
+          key-vault-certificate: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_CERT_NAME }}
+          timestamp-url: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_TIMESTAMP_URL }}
+
+      - name: Re-upload signed ${{ matrix.artifact }} artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}-artifacts
+          path: release
+          overwrite: true
+          if-no-files-found: error
+          retention-days: 1
+
   cleanup_engine_artifact:
     needs: build_yakit
     runs-on: ubuntu-latest
@@ -233,7 +271,7 @@ jobs:
 
   publish_software_to_oss:
     needs:
-      - build_yakit
+      - sign_windows
     strategy:
       matrix:
         artifact: [Yakit, EnpriTrace] # 需要发布的软件名前缀

--- a/.github/workflows/multi-platform-build.yml
+++ b/.github/workflows/multi-platform-build.yml
@@ -61,6 +61,8 @@ jobs:
         env:
             CI: ""
             NODE_OPTIONS: --max_old_space_size=4096
+        outputs:
+            win_artifact: ${{ steps.export_names.outputs.win_artifact }}
 
         steps:
             - name: Display incoming configuration parameters
@@ -212,6 +214,12 @@ jobs:
                   fi
             - name: Show ENV_Software_Name
               run: echo "ENV_Software_Name： $ENV_Software_Name"
+
+            - name: Export artifact names
+              id: export_names
+              shell: bash
+              run: |
+                  echo "win_artifact=${ENV_Software_Name}-${SOFTWARE_VERSION}-windows${{ inputs.legacy && '-legacy' || '' }}-amd64.exe" >> "$GITHUB_OUTPUT"
 
             - name: Build Yakit (MultiPlatform)
               if: ${{ inputs.platform == 'mwl' }}
@@ -443,5 +451,40 @@ jobs:
               with:
                   name: ${{ env.ENV_Software_Name }}-${{ env.SOFTWARE_VERSION }}-linux${{ inputs.legacy && '-legacy' || '' }}-arm64.run
                   path: ./release/${{env.ENV_Software_Name}}-${{env.SOFTWARE_VERSION}}-linux${{ inputs.legacy && '-legacy' || '' }}-arm64.run
+                  if-no-files-found: error
+                  retention-days: 7
+
+    # 给 Windows 安装包外壳做 Authenticode 签名(仅 windows/mwl 平台)
+    # 下载 build_yakit 产出的安装包，签名后用 overwrite 覆盖回同名 artifact
+    sign_windows:
+        needs: build_yakit
+        if: ${{ contains(fromJSON('["windows","mwl"]'), inputs.platform) }}
+        runs-on: windows-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Download windows installer artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: ${{ needs.build_yakit.outputs.win_artifact }}
+                  path: release
+
+            - name: Sign Windows installer
+              uses: ./.github/actions/sign-windows
+              with:
+                  path: release
+                  key-vault-url: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_URI }}
+                  key-vault-client-id: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_APPLICATION_ID }}
+                  key-vault-tenant-id: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_DIRECTORY_ID }}
+                  key-vault-client-secret: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_CLIENT_SECRET }}
+                  key-vault-certificate: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_CERT_NAME }}
+                  timestamp-url: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_TIMESTAMP_URL }}
+
+            - name: Re-upload signed windows installer
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ needs.build_yakit.outputs.win_artifact }}
+                  path: release
+                  overwrite: true
                   if-no-files-found: error
                   retention-days: 7

--- a/.github/workflows/publish-se-oss.yml
+++ b/.github/workflows/publish-se-oss.yml
@@ -195,9 +195,46 @@ jobs:
                   if-no-files-found: error
                   retention-days: 1
 
-    publish_yakit_se_to_oss:
+    # 给 Windows 安装包外壳做 Authenticode 签名(上传 OSS 之前)
+    # 内置引擎已在 yaklang OSS 源头签名，此处只补安装包外壳这一层
+    sign_windows:
         needs:
             - build_electron
+        runs-on: windows-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.ref_name }}
+
+            - name: Download SE artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: se-artifacts
+                  path: release
+
+            - name: Sign Windows installers
+              uses: ./.github/actions/sign-windows
+              with:
+                  path: release
+                  key-vault-url: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_URI }}
+                  key-vault-client-id: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_APPLICATION_ID }}
+                  key-vault-tenant-id: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_DIRECTORY_ID }}
+                  key-vault-client-secret: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_CLIENT_SECRET }}
+                  key-vault-certificate: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_CERT_NAME }}
+                  timestamp-url: ${{ secrets.AZURE_YAK_CODE_SIGN_KEY_VAULT_TIMESTAMP_URL }}
+
+            - name: Re-upload signed SE artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: se-artifacts
+                  path: release
+                  overwrite: true
+                  if-no-files-found: error
+                  retention-days: 1
+
+    publish_yakit_se_to_oss:
+        needs:
+            - sign_windows
         runs-on: ubuntu-latest
         steps:
             - name: Echo Package Version To Env

--- a/packageScript/script/sign-windows.sh
+++ b/packageScript/script/sign-windows.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# 给 Windows 安装包(.exe)做 Authenticode 代码签名。
+# 复用 yaklang 引擎同款 Azure Key Vault + AzureSignTool 方案，可在 macOS/Linux/Windows 本地执行，
+# 用于「本地打包后、对外分发前」给安装包外壳补签名。
+#
+# 用法:
+#   ./packageScript/script/sign-windows.sh [目标目录或文件 ...]
+#   不带参数时默认签名 ./release 目录下所有 *windows*.exe
+#
+# 依赖的环境变量(命名与 yaklang 仓库保持一致):
+#   AZURE_YAK_CODE_SIGN_KEY_VAULT_URI
+#   AZURE_YAK_CODE_SIGN_KEY_VAULT_APPLICATION_ID
+#   AZURE_YAK_CODE_SIGN_KEY_VAULT_DIRECTORY_ID
+#   AZURE_YAK_CODE_SIGN_KEY_VAULT_CLIENT_SECRET
+#   AZURE_YAK_CODE_SIGN_KEY_VAULT_CERT_NAME
+#   AZURE_YAK_CODE_SIGN_KEY_VAULT_TIMESTAMP_URL
+#
+# 前置条件: 已安装 .NET 8 SDK。脚本会在缺少 AzureSignTool 时自动 dotnet tool install。
+
+set -euo pipefail
+
+log() { echo "[sign-windows] $*"; }
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "[sign-windows] ERROR: missing required env: ${name}" >&2
+    exit 1
+  fi
+}
+
+require_env AZURE_YAK_CODE_SIGN_KEY_VAULT_URI
+require_env AZURE_YAK_CODE_SIGN_KEY_VAULT_APPLICATION_ID
+require_env AZURE_YAK_CODE_SIGN_KEY_VAULT_DIRECTORY_ID
+require_env AZURE_YAK_CODE_SIGN_KEY_VAULT_CLIENT_SECRET
+require_env AZURE_YAK_CODE_SIGN_KEY_VAULT_CERT_NAME
+require_env AZURE_YAK_CODE_SIGN_KEY_VAULT_TIMESTAMP_URL
+
+# 确保 AzureSignTool 可用(优先用已安装的，否则尝试通过 dotnet 安装)
+ensure_tool() {
+  if command -v AzureSignTool >/dev/null 2>&1; then
+    return 0
+  fi
+  if command -v dotnet >/dev/null 2>&1; then
+    log "AzureSignTool not found, installing via dotnet global tool ..."
+    dotnet tool install --global AzureSignTool >/dev/null 2>&1 || dotnet tool update --global AzureSignTool >/dev/null 2>&1 || true
+    export PATH="${HOME}/.dotnet/tools:${PATH}"
+  fi
+  if ! command -v AzureSignTool >/dev/null 2>&1; then
+    echo "[sign-windows] ERROR: AzureSignTool is not available." >&2
+    echo "[sign-windows] Install .NET 8 SDK first, then: dotnet tool install --global AzureSignTool" >&2
+    exit 1
+  fi
+}
+
+ensure_tool
+log "using $(AzureSignTool --version 2>/dev/null | head -n 1)"
+
+# 收集待签名文件
+declare -a targets=()
+if [ "$#" -eq 0 ]; then
+  set -- ./release
+fi
+for p in "$@"; do
+  if [ -d "${p}" ]; then
+    while IFS= read -r f; do
+      targets+=("${f}")
+    done < <(find "${p}" -type f -name '*windows*.exe')
+  elif [ -f "${p}" ]; then
+    targets+=("${p}")
+  else
+    log "skip non-existent path: ${p}"
+  fi
+done
+
+if [ "${#targets[@]}" -eq 0 ]; then
+  echo "[sign-windows] ERROR: no windows .exe found to sign" >&2
+  exit 1
+fi
+
+sign_one() {
+  local file="$1"
+  log "signing: ${file}"
+  AzureSignTool sign \
+    -kvu "${AZURE_YAK_CODE_SIGN_KEY_VAULT_URI}" \
+    -kvi "${AZURE_YAK_CODE_SIGN_KEY_VAULT_APPLICATION_ID}" \
+    -kvt "${AZURE_YAK_CODE_SIGN_KEY_VAULT_DIRECTORY_ID}" \
+    -kvs "${AZURE_YAK_CODE_SIGN_KEY_VAULT_CLIENT_SECRET}" \
+    -kvc "${AZURE_YAK_CODE_SIGN_KEY_VAULT_CERT_NAME}" \
+    -tr "${AZURE_YAK_CODE_SIGN_KEY_VAULT_TIMESTAMP_URL}" \
+    -td sha256 \
+    -v \
+    "${file}"
+}
+
+for f in "${targets[@]}"; do
+  sign_one "${f}"
+done
+
+log "done. signed ${#targets[@]} file(s)."


### PR DESCRIPTION
## 背景 / 问题

杀软(卡巴等)对 Windows 端报毒。排查发现：

- 引擎 `yak.exe` 在 yaklang 侧 `exp-cross-build.yml` 上传 OSS 前**已强制 Azure 签名**；
- 但 Yakit 全系列的 Windows 安装包(NSIS `.exe`)**完全没有签名**——所有 `pack-win*` 走的是 `nonSign*`(`CSC_IDENTITY_AUTO_DISCOVERY=false`)，`electron-builder` 配置里也没有任何 Windows 证书字段，只有 macOS 做了 codesign + 公证。

也就是说"内置引擎已签、安装包外壳裸奔"，这就是报毒现象的根因。本 PR 补齐安装包外壳这一层签名。

## 改动

- 新增复用的复合 Action `.github/actions/sign-windows`：复用 yaklang 引擎同款 `Azure Key Vault + AzureSignTool` 方案(同一套 `AZURE_YAK_CODE_SIGN_KEY_VAULT_*` secrets)，在 `windows-latest` 上对 `*windows*.exe` 签名 + 校验。
- 新增本地脚本 `packageScript/script/sign-windows.sh`：本地打包后对外分发前可直接签名(macOS/Linux/Windows 通用)。
- 在四条生产发布流水线(CE/EE、IRify/IRifyEE、Memfit、SE)上传 Release/OSS **之前**插入 `sign_windows` job，并把 publish 的依赖改为 `sign_windows`，确保发出去的安装包一定已签名。
- 给开发构建线 `multi-platform-build.yml` 也接上签名，便于出临时测试包。

> 内置引擎在 OSS 源头已 Azure 签名，故本 PR 不重复签引擎，只补安装包外壳这一层。

## 验证

已用开发构建线在分支上真实跑通(run 27934223010)：

- `AzureSignTool 7.0.1` 安装成功 → `Signing completed successfully`
- 签名校验：`status=Valid, signer=CN=四维创智（北京）科技发展有限公司`

## Test plan

- [ ] 安装签名后的 `Yakit-*-windows-amd64.exe`，右键属性→数字签名 显示有效
- [ ] 杀软(卡巴等)不再报毒
- [ ] 合并后用一条正式 tag 验证生产流水线 `sign_windows` job 正常签名并发布

## 前置条件

- 仓库需可读取 `AZURE_YAK_CODE_SIGN_KEY_VAULT_URI/_APPLICATION_ID/_DIRECTORY_ID/_CLIENT_SECRET/_CERT_NAME/_TIMESTAMP_URL` 这 6 个 secrets(已与 yaklang 一致配置)。

Made with [Cursor](https://cursor.com)