### PR TITLE
feat: 设置菜单在配置插件源下新增网络代理管理与全局热加载管理入口

### DIFF
--- a/app/renderer/src/main/src/components/layout/FuncDomain.tsx
+++ b/app/renderer/src/main/src/components/layout/FuncDomain.tsx
@@ -18,7 +18,7 @@ import { YakitSettingCallbackType, YakitSystem, YaklangEngineMode } from '@/yaki
 import { showConfigSystemProxyForm } from '@/utils/ConfigSystemProxy'
 import { showConfigYaklangEnvironment } from '@/utils/ConfigYaklangEnvironment'
 import Login from '@/pages/Login'
-import { useEeSystemConfig, useStore, yakitDynamicStatus } from '@/store'
+import { useConfigManagementTab, useEeSystemConfig, useStore, yakitDynamicStatus } from '@/store'
 import { defaultUserInfo, SetUserInfo } from '@/pages/MainOperator'
 import { loginOut } from '@/utils/login'
 import { UserPlatformType } from '@/pages/globalVariable'
@@ -1138,6 +1138,14 @@ const GetUIOpSettingMenu = () => {
       label: '配置插件源',
     },
     {
+      key: 'proxy-management',
+      label: '网络代理管理',
+    },
+    {
+      key: 'hotPatch-management',
+      label: '全局热加载管理',
+    },
+    {
       key: 'cve-database',
       label: 'CVE 数据库',
       children: [
@@ -1196,6 +1204,7 @@ const UIOpSetting: React.FC<UIOpSettingProp> = React.memo((props) => {
   const [available, setAvailable] = useState(false) // cve数据库是否可用
   const [isDiffUpdate, setIsDiffUpdate] = useState(false)
   const { dynamicStatus } = yakitDynamicStatus()
+  const { setConfigManagementActiveTab } = useConfigManagementTab()
   const { delTemporaryProject } = useTemporaryProjectStore()
   const [configMcpModalVisible, setConfigMcpModalVisible] = useState<boolean>(false)
   /** 当前主题 */
@@ -1244,6 +1253,14 @@ const UIOpSetting: React.FC<UIOpSettingProp> = React.memo((props) => {
           content: <ConfigPrivateDomain onClose={() => m.destroy()} />,
         })
         return m
+      case 'proxy-management':
+        setConfigManagementActiveTab('proxy')
+        emiter.emit('menuOpenPage', JSON.stringify({ route: YakitRoute.ConfigManagement }))
+        return
+      case 'hotPatch-management':
+        setConfigManagementActiveTab('hotPatch')
+        emiter.emit('menuOpenPage', JSON.stringify({ route: YakitRoute.ConfigManagement }))
+        return
       case 'reverse':
         showYakitModal({
           type: 'white',


### PR DESCRIPTION
## 背景

原先「代理管理」「热加载管理」入口挂在 WebFuzzer 顶部的「字典管理」下拉里，位置不够合理。

## 改动

在设置（齿轮）下拉菜单的「配置插件源」下方新增两个入口：

- 网络代理管理：打开配置管理页并切换到「代理管理」标签
- 全局热加载管理：打开配置管理页并切换到「热加载管理」标签

复用现有的 `useConfigManagementTab` store 与 `YakitRoute.ConfigManagement` 页面，未新增页面或接口。

## 验证

- `npx tsc -p tsconfig.json --noEmit` 通过
- `npx eslint`（0 error）
- `prettier --check` 通过
- `node scripts/locale-parity.js` 通过

Made with [Cursor](https://cursor.com)