### PR TITLE
优化添加第三方应用表单的文案与帮助信息

### DIFF
--- a/app/renderer/src/main/src/components/configNetwork/NewThirdPartyApplicationConfig.tsx
+++ b/app/renderer/src/main/src/components/configNetwork/NewThirdPartyApplicationConfig.tsx
@@ -36,7 +36,7 @@ import { TFunction, useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { OutlineClipboardcopyIcon } from '@/assets/icon/outline'
 import { setClipboardText } from '@/utils/clipboard'
 import { YakitInputNumber } from '../yakitUI/YakitInputNumber/YakitInputNumber'
-import { EnableThinkingOptions, ModelNameOptionLabel } from '@/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelect'
+import { EnableThinkingOptions } from '@/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelect'
 const { ipcRenderer } = window.require('electron')
 
 export interface ThirdPartyAppConfigItemTemplate {
@@ -803,43 +803,12 @@ export const NewAIThirdPartyApplicationConfigBase: React.FC<NewAIThirdPartyAppli
       { wait: 500 },
     )
 
-    /**
-     * @description 展示模型名称选项，memfit开头的展示aibalance图标，free结尾的展示免费标签
-     * TODO - 先保留，等后续反馈，看是否需要更换为下面展示UI
-     */
-    const showModelNameAllOptions = useCreation(() => {
-      return modelNameAllOptions.map((item) => {
-        return {
-          label: <ModelNameOptionLabel name={item.value} />,
-          value: item.value,
-        }
-      })
-    }, [modelNameAllOptions])
-
     const newDefaultAIFormItemsOfAI = useCreation(() => {
-      let newAIFormItemsOfAI = cloneDeep(defaultAIFormItemsOfAI(t))
-      const { isRequired, data } = isShowRequiredApiKey(typeVal)
-      if (isRequired) {
-        const modelIndex = newAIFormItemsOfAI.findIndex((item) => item.Name === 'model')
-        if (modelIndex !== -1) {
-          newAIFormItemsOfAI.splice(modelIndex, 0, data)
-        } else {
-          newAIFormItemsOfAI.push(data)
-        }
-      }
-      return newAIFormItemsOfAI
+      return buildDefaultAIFormItemsForType(typeVal, t)
     }, [typeVal, i18n.language])
 
     const newOptionalAIFormItemsOfAI = useCreation(() => {
-      let newData = cloneDeep(optionalAIFormItemsOfAI)
-      const { isRequired, data } = isShowRequiredApiKey(typeVal)
-      if (!isRequired) {
-        newData.unshift(data)
-      }
-      if (enableEndpointWatch) {
-        return newData.filter((item) => item.Name !== 'base_url')
-      }
-      return newData.filter((item) => item.Name !== 'endpoint')
+      return buildOptionalAIFormItemsForType(typeVal, enableEndpointWatch)
     }, [enableEndpointWatch, typeVal])
 
     const allAIFormItemsOfAI = useCreation(() => {
@@ -899,6 +868,9 @@ export const NewAIThirdPartyApplicationConfigBase: React.FC<NewAIThirdPartyAppli
               title: item.Desc,
             }
           : null,
+        help:
+          item.Name === 'api_type' &&
+          '决定请求的接口路径：chat/completions 是主流兼容格式（/v1/chat/completions）， responses 是 OpenAI新一代格式（/v1/responses）',
       }
       switch (item.Type) {
         case 'string':
@@ -967,36 +939,15 @@ export const NewAIThirdPartyApplicationConfigBase: React.FC<NewAIThirdPartyAppli
             }
             return <AIConfigAPIKeyFormItem aiType={typeVal} formProps={formProps} />
           }
-          if (item.Name === 'api_type') {
-            let selectProps: YakitSelectProps = {}
-            try {
-              selectProps.options = item.Extra ? JSONParseLog(item.Extra)?.options : []
-            } catch (error) {}
-            return (
-              <Form.Item
-                {...formProps}
-                tooltip={null}
-                help={
-                  <div style={{ fontSize: 12, color: '#b4bbca', lineHeight: '20px' }}>
-                    决定请求的接口路径：chat/completions 是主流兼容格式（/v1/chat/completions）， responses 是 OpenAI
-                    新一代格式（/v1/responses）
-                  </div>
-                }
-              >
-                <YakitSelect {...selectProps} disabled={IsOnline} />
-              </Form.Item>
-            )
-          } else {
-            let selectProps: YakitSelectProps = {}
-            try {
-              selectProps.options = item.Extra ? JSONParseLog(item.Extra)?.options : []
-            } catch (error) {}
-            return (
-              <Form.Item {...formProps}>
-                <YakitSelect {...selectProps} disabled={IsOnline} />
-              </Form.Item>
-            )
-          }
+          let selectProps: YakitSelectProps = {}
+          try {
+            selectProps.options = item.Extra ? JSONParseLog(item.Extra)?.options : []
+          } catch (error) {}
+          return (
+            <Form.Item {...formProps}>
+              <YakitSelect {...selectProps} disabled={IsOnline} />
+            </Form.Item>
+          )
         default:
           return <></>
       }

--- a/app/renderer/src/main/src/components/configNetwork/NewThirdPartyApplicationConfig.tsx
+++ b/app/renderer/src/main/src/components/configNetwork/NewThirdPartyApplicationConfig.tsx
@@ -461,7 +461,7 @@ const defaultAIFormItemsOfAI: (t: TFunction) => ThirdPartyAppConfigItemTemplate[
       Required: true,
       Type: 'list',
       DefaultValue: DEFAULT_AI_API_TYPE,
-      Desc: '可选值: chat_completions / responses',
+      Desc: '',
       Extra: `${JSON.stringify({
         options: aiAPITypeOptions,
       })}`,
@@ -525,7 +525,12 @@ const buildDefaultAIFormItemsForType = (typeVal: string, t: TFunction) => {
   const items = cloneDeep(defaultAIFormItemsOfAI(t))
   const { isRequired, data } = isShowRequiredApiKey(typeVal)
   if (isRequired) {
-    items.push(data)
+    const modelIndex = items.findIndex((item) => item.Name === 'model')
+    if (modelIndex !== -1) {
+      items.splice(modelIndex, 0, data)
+    } else {
+      items.push(data)
+    }
   }
   return items
 }
@@ -545,7 +550,7 @@ const buildOptionalAIFormItemsForType = (typeVal: string, enableEndpoint: boolea
 const optionalAIFormItemsOfAI: ThirdPartyAppConfigItemTemplate[] = [
   {
     DefaultValue: '',
-    Desc: '对于非标准openai风格的第三方api，可以自定义endpoint',
+    Desc: '开启后使用完整 Endpoint 地址发送请求，替代 BaseURL 自动拼接路径的方式',
     Extra: '',
     Name: 'enable_endpoint',
     Required: false,
@@ -554,27 +559,27 @@ const optionalAIFormItemsOfAI: ThirdPartyAppConfigItemTemplate[] = [
   },
   {
     DefaultValue: '',
-    Desc: '可填写域名和URL，例如api.openai.com、https://api.openai.com/、https://api.openai.com/v1、https://api.openai.com//v1/chat/completions',
+    Desc: 'API 地址前缀，系统会自动拼接接口路径（如 /v1/chat/completions）',
     Extra: '',
     Name: 'base_url',
     Required: false,
     Type: 'string',
     Verbose: 'BaseURL',
-    Placeholder: '例如 api.openai.com、https://api.openai.com/',
+    Placeholder: '如 api.openai.com 或 https://api.openai.com/v1',
   },
   {
     DefaultValue: '',
-    Desc: 'Endpoint',
+    Desc: '完整的请求地址，启用后将跳过路径拼接，直接使用该地址发送请求',
     Extra: '',
     Name: 'endpoint',
     Required: false,
     Type: 'string',
     Verbose: 'Endpoint',
-    Placeholder: '例如 https://api.openai.com/v1/chat/completions',
+    Placeholder: '如 https://api.openai.com/v1/chat/completions',
   },
   {
     DefaultValue: '',
-    Desc: '代理地址',
+    Desc: 'HTTP/SOCKS5 代理地址',
     Extra: '',
     Name: 'proxy',
     Required: false,
@@ -655,7 +660,16 @@ const AIThirdPartyConfigReadonlyPanel: React.FC<AIThirdPartyConfigReadonlyPanelP
         bordered={false}
         className={styles['ai-third-party-application-config-collapse']}
       >
-        <Collapse.Panel header="高级配置" key="1" forceRender={true}>
+        <Collapse.Panel
+          header={
+            <div className={styles['panel-heard']}>
+              <span className={styles['title']}>高级配置</span>
+              <span className={styles['tip']}>可配置自定义 Endpoint / BaseURL 等</span>
+            </div>
+          }
+          key="1"
+          forceRender={true}
+        >
           {optionalItems.map((item) => renderFieldByTemplate(item))}
           {renderCopyRow('Headers', 'Header', headersPack.display, headersPack.copy)}
         </Collapse.Panel>
@@ -806,7 +820,12 @@ export const NewAIThirdPartyApplicationConfigBase: React.FC<NewAIThirdPartyAppli
       let newAIFormItemsOfAI = cloneDeep(defaultAIFormItemsOfAI(t))
       const { isRequired, data } = isShowRequiredApiKey(typeVal)
       if (isRequired) {
-        newAIFormItemsOfAI.push(data)
+        const modelIndex = newAIFormItemsOfAI.findIndex((item) => item.Name === 'model')
+        if (modelIndex !== -1) {
+          newAIFormItemsOfAI.splice(modelIndex, 0, data)
+        } else {
+          newAIFormItemsOfAI.push(data)
+        }
       }
       return newAIFormItemsOfAI
     }, [typeVal, i18n.language])
@@ -947,6 +966,26 @@ export const NewAIThirdPartyApplicationConfigBase: React.FC<NewAIThirdPartyAppli
               )
             }
             return <AIConfigAPIKeyFormItem aiType={typeVal} formProps={formProps} />
+          }
+          if (item.Name === 'api_type') {
+            let selectProps: YakitSelectProps = {}
+            try {
+              selectProps.options = item.Extra ? JSONParseLog(item.Extra)?.options : []
+            } catch (error) {}
+            return (
+              <Form.Item
+                {...formProps}
+                tooltip={null}
+                help={
+                  <div style={{ fontSize: 12, color: '#b4bbca', lineHeight: '20px' }}>
+                    决定请求的接口路径：chat/completions 是主流兼容格式（/v1/chat/completions）， responses 是 OpenAI
+                    新一代格式（/v1/responses）
+                  </div>
+                }
+              >
+                <YakitSelect {...selectProps} disabled={IsOnline} />
+              </Form.Item>
+            )
           } else {
             let selectProps: YakitSelectProps = {}
             try {
@@ -1072,7 +1111,16 @@ export const NewAIThirdPartyApplicationConfigBase: React.FC<NewAIThirdPartyAppli
             bordered={false}
             className={styles['ai-third-party-application-config-collapse']}
           >
-            <YakitCollapse.YakitPanel header="高级配置" key="1" forceRender={true}>
+            <YakitCollapse.YakitPanel
+              header={
+                <div className={styles['panel-heard']}>
+                  <span className={styles['title']}>高级配置</span>
+                  <span className={styles['tip']}>可配置自定义 Endpoint / BaseURL 等</span>
+                </div>
+              }
+              key="1"
+              forceRender={true}
+            >
               {/* 可选的表单项 */}
               {renderOptionalFormItems()}
               <Form.Item label={'Header'} name="Headers">

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiApiTypeOptions.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiApiTypeOptions.ts
@@ -2,11 +2,11 @@
 
 export const AI_API_TYPE_OPTIONS = [
   {
-    label: 'OpenAI(兼容性好 chat/completions )',
+    label: 'chat/completions（标准，兼容性好）',
     value: 'chat_completions',
   },
   {
-    label: 'OpenAI Responses(新格式)',
+    label: 'responses（OpenAI 新格式）',
     value: 'responses',
   },
 ] as const


### PR DESCRIPTION
## Summary
- 对调「模型名称」和「ApiKey」的表单位置，ApiKey 在前、模型名称在后，符合填写顺序（先鉴权再选模型）
- API 类型下拉标签文案简化为 `chat/completions（标准，兼容性好）` / `responses（OpenAI 新格式）`
- API 类型字段去除问号 tooltip，改为内联帮助文本，说明两种接口路径的区别
- 「高级配置」折叠面板标题增加小字提示「可配置自定义 Endpoint / BaseURL 等」
- 高级配置中 Endpoint/BaseURL/启用Endpoint/代理 等配置项的描述文案更新，贴合 yaklang 后端实际语义
- 只读预览面板同步以上所有文案变更

## Test plan
- [ ] 打开「添加第三方应用」弹窗，确认 ApiKey 在模型名称之前
- [ ] 确认 API 类型下拉项标签为新文案，无问号 tooltip，有内联帮助说明
- [ ] 确认高级配置标题右侧有「可配置自定义 Endpoint / BaseURL 等」小字
- [ ] 展开高级配置，确认各字段 tooltip 描述符合新文案
- [ ] 编辑已有模型，确认只读预览面板也同步显示新文案

Made with [Cursor](https://cursor.com)