### PR TITLE
feat: 添加插件执行历史功能

### DIFF
--- a/app/renderer/src/main/public/locales/en/layout.json
+++ b/app/renderer/src/main/public/locales/en/layout.json
@@ -79,7 +79,15 @@
       "restoreMenu": "Restore Menu",
       "restoreMenuTip": "Restore Menu Reminder",
       "confirmRestoreMenu": "After confirming restore, the frequently used plugins menu bar will be reset. Do you want to proceed?",
-      "commonPlugins": "Common Plugins"
+      "commonPlugins": "Common Plugins",
+      "pluginHistory": "Plugin History",
+      "pluginHistoryRecent": "Recent {{count}}/{{limit}}",
+      "pluginHistoryRestore": "Restore",
+      "pluginHistoryEmpty": "No plugin execution history",
+      "pluginHistorySourceHub": "Plugin Store",
+      "pluginHistorySourceExecution": "Plugin Execution Page",
+      "pluginHistoryStatusFinished": "Completed",
+      "pluginHistoryStatusStopped": "Stopped"
     },
     "MenuMode": {
       "bruteForce": "Brute Force",

--- a/app/renderer/src/main/public/locales/zh-TW/layout.json
+++ b/app/renderer/src/main/public/locales/zh-TW/layout.json
@@ -79,7 +79,15 @@
       "restoreMenu": "復原選單",
       "restoreMenuTip": "復原選單提醒",
       "confirmRestoreMenu": "確認復原後，將重置常用外掛選單欄。是否確認復原？",
-      "commonPlugins": "常用外掛"
+      "commonPlugins": "常用外掛",
+      "pluginHistory": "外掛歷史",
+      "pluginHistoryRecent": "最近 {{count}}/{{limit}}",
+      "pluginHistoryRestore": "找回",
+      "pluginHistoryEmpty": "暫無外掛執行歷史",
+      "pluginHistorySourceHub": "外掛商店",
+      "pluginHistorySourceExecution": "外掛執行頁",
+      "pluginHistoryStatusFinished": "已完成",
+      "pluginHistoryStatusStopped": "已停止"
     },
     "MenuMode": {
       "bruteForce": "爆破",

--- a/app/renderer/src/main/public/locales/zh/layout.json
+++ b/app/renderer/src/main/public/locales/zh/layout.json
@@ -79,7 +79,15 @@
       "restoreMenu": "复原菜单",
       "restoreMenuTip": "复原菜单提醒",
       "confirmRestoreMenu": "确认复原后，将重置常用插件菜单栏。是否确认复原？",
-      "commonPlugins": "常用插件"
+      "commonPlugins": "常用插件",
+      "pluginHistory": "插件历史",
+      "pluginHistoryRecent": "最近 {{count}}/{{limit}}",
+      "pluginHistoryRestore": "找回",
+      "pluginHistoryEmpty": "暂无插件执行历史",
+      "pluginHistorySourceHub": "插件商店",
+      "pluginHistorySourceExecution": "插件执行页",
+      "pluginHistoryStatusFinished": "已完成",
+      "pluginHistoryStatusStopped": "已停止"
     },
     "MenuMode": {
       "bruteForce": "爆破",

--- a/app/renderer/src/main/src/enums/plugin.ts
+++ b/app/renderer/src/main/src/enums/plugin.ts
@@ -1,4 +1,7 @@
 export enum RemotePluginGV {
+  /** @name 最近使用的单插件执行记录 */
+  SinglePluginExecutionHistory = 'single-plugin-execution-history',
+
   /** @name 插件详情-本地功能自动下载插件 */
   AutoDownloadPlugin = 'auto-download-plugin',
 

--- a/app/renderer/src/main/src/hook/useHoldGRPCStream/useHoldGRPCStream.ts
+++ b/app/renderer/src/main/src/hook/useHoldGRPCStream/useHoldGRPCStream.ts
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { info, yakitFailed } from '../../utils/notification'
-import { useGetState, useMemoizedFn } from 'ahooks'
+import { useMemoizedFn } from 'ahooks'
 import { HoldGRPCStreamInfo, HoldGRPCStreamProps, StreamResult } from './useHoldGRPCStreamType'
 import { DefaultTabs } from './constant'
 import { DEFAULT_LOG_LIMIT, LIMIT_LOG_NUM_NAME } from '@/defaultConstants/HoldGRPCStream'
@@ -103,7 +103,7 @@ export default function useHoldGRPCStream(params: HoldGRPCStreamParams) {
     return () => emiter.off('onUpdateLimitLogNum', setLimitLogNum)
   }, [])
 
-  const [streamInfo, setStreamInfo, getStreamInfo] = useGetState<HoldGRPCStreamInfo>({
+  const [streamInfo, setStreamInfo] = useState<HoldGRPCStreamInfo>({
     progressState: [],
     cardState: [],
     tabsState: [],
@@ -341,9 +341,9 @@ export default function useHoldGRPCStream(params: HoldGRPCStreamParams) {
     // token-end
     const offEnd = yakitStream.onEnd(token, () => {
       isShowEnd && info(`[Mod] ${taskName} finished`)
-      handleResults()
+      const finalStreamInfo = handleResults()
       if (onEnd) {
-        onEnd(getStreamInfo())
+        onEnd(finalStreamInfo)
       }
     })
 
@@ -409,7 +409,7 @@ export default function useHoldGRPCStream(params: HoldGRPCStreamParams) {
     // rules
     const rules: StreamResult.RuleData[] = [...ruleData.current]
 
-    setStreamInfo({
+    const nextStreamInfo: HoldGRPCStreamInfo = {
       progressState: cacheProgress,
       cardState: cacheCard,
       tabsState: tabs,
@@ -417,7 +417,9 @@ export default function useHoldGRPCStream(params: HoldGRPCStreamParams) {
       riskState: risks,
       logState: logs,
       rulesState: rules,
-    })
+    }
+    setStreamInfo(nextStreamInfo)
+    return nextStreamInfo
   })
 
   useEffect(() => {
@@ -472,5 +474,10 @@ export default function useHoldGRPCStream(params: HoldGRPCStreamParams) {
     ruleData.current = []
   })
 
-  return [streamInfo, { start, stop, cancel, reset }] as const
+  /** 立即刷新并返回当前已经接收到的流结果，用于停止任务前保留部分执行结果 */
+  const snapshot = useMemoizedFn(() => {
+    return handleResults()
+  })
+
+  return [streamInfo, { start, stop, cancel, reset, snapshot }] as const
 }

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -2469,7 +2469,13 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
   const extraOpenMenuPage = useMemoizedFn((routeInfo: RouteToPageProps) => {
     // 插件页面新开一级tab页（特殊处理）
     if (routeInfo.route === YakitRoute.Plugin_OP) {
-      openMenuPage(routeInfo)
+      openMenuPage(routeInfo, {
+        pageParams: routeInfo.pluginOpPageInfo
+          ? {
+              pluginOpPageInfo: routeInfo.pluginOpPageInfo,
+            }
+          : undefined,
+      })
       return
     }
     // 判断页面是否打开，打开则定位该页面，未打开则打开页面

--- a/app/renderer/src/main/src/pages/layout/publicMenu/MenuPlugin.module.scss
+++ b/app/renderer/src/main/src/pages/layout/publicMenu/MenuPlugin.module.scss
@@ -341,6 +341,113 @@
     .restore-style:hover {
       color: var(--Colors-Use-Main-Hover);
     }
+    .list-actions {
+      display: flex;
+      align-items: center;
+      gap: 20px;
+    }
+    .history-entry {
+      color: var(--Colors-Use-Main-Primary);
+      svg {
+        color: var(--Colors-Use-Main-Primary);
+      }
+    }
+    .history-entry:hover {
+      color: var(--Colors-Use-Main-Hover);
+      svg {
+        color: var(--Colors-Use-Main-Hover);
+      }
+    }
+  }
+
+  .history-body {
+    min-height: 320px;
+    max-height: 420px;
+    display: flex;
+    flex-direction: column;
+    background: var(--Colors-Use-Basic-Background);
+    border: 1px solid var(--Colors-Use-Neutral-Border);
+    border-radius: 4px;
+  }
+  .history-header {
+    height: 48px;
+    flex: 0 0 48px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 16px;
+    border-bottom: 1px solid var(--Colors-Use-Neutral-Border);
+    .history-title {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--Colors-Use-Neutral-Text-1-Title);
+    }
+    .history-count {
+      margin-left: auto;
+      font-size: 12px;
+      color: var(--Colors-Use-Neutral-Text-3-Secondary);
+    }
+  }
+  .history-list {
+    flex: 1;
+    overflow: hidden auto;
+    padding: 0 16px;
+  }
+  .history-item {
+    min-height: 64px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    border-bottom: 1px solid var(--Colors-Use-Neutral-Border);
+    .history-avatar {
+      flex: 0 0 32px;
+      width: 32px;
+      height: 32px;
+      background: transparent;
+      :global {
+        img {
+          border-radius: 50%;
+        }
+      }
+      svg {
+        width: 32px;
+        height: 32px;
+      }
+    }
+    .history-info {
+      min-width: 0;
+      flex: 1;
+    }
+    .history-name {
+      font-size: 13px;
+      line-height: 20px;
+      color: var(--Colors-Use-Neutral-Text-1-Title);
+    }
+    .history-meta {
+      display: flex;
+      gap: 12px;
+      font-size: 11px;
+      line-height: 16px;
+      color: var(--Colors-Use-Neutral-Text-3-Secondary);
+    }
+  }
+  .history-item:last-child {
+    border-bottom: 0;
+  }
+  .history-empty {
+    min-height: 270px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--Colors-Use-Neutral-Text-3-Secondary);
+    svg {
+      width: 32px;
+      height: 32px;
+      color: var(--Colors-Use-Neutral-Text-4-Help-text);
+    }
   }
 }
 @media screen and (max-width: 1280px) {

--- a/app/renderer/src/main/src/pages/layout/publicMenu/MenuPlugin.tsx
+++ b/app/renderer/src/main/src/pages/layout/publicMenu/MenuPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { ChevronDownIcon, ChevronUpIcon, SMViewGridAddIcon } from '@/assets/newIcon'
 import { PublicDefaultPluginIcon } from '@/routes/publicIcon'
 import { YakitPopover } from '@/components/yakitUI/YakitPopover/YakitPopover'
@@ -17,6 +17,16 @@ import styles from './MenuPlugin.module.scss'
 import { YakitHint } from '@/components/yakitUI/YakitHint/YakitHint'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { JSONParseLog } from '@/utils/tool'
+import {
+  getPluginExecutionHistoryPageInfo,
+  PLUGIN_EXECUTION_HISTORY_LIMIT,
+  PluginExecutionHistoryItem,
+  queryPluginExecutionHistory,
+} from '@/pages/plugins/pluginExecutionHistory'
+import emiter from '@/utils/eventBus/eventBus'
+import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
+import { OutlineArrowleftIcon, OutlileHistoryIcon } from '@/assets/icon/outline'
+import { formatTimestamp } from '@/utils/timeUtil'
 
 const { ipcRenderer } = window.require('electron')
 
@@ -30,7 +40,20 @@ interface MenuPluginProps {
 
 export const MenuPlugin: React.FC<MenuPluginProps> = React.memo((props) => {
   const { loading, pluginList, onMenuSelect, onRestore: restoreCallback } = props
-  const { t, i18n } = useI18nNamespaces(['yakitRoute', 'layout', 'yakitUi'])
+  const { t } = useI18nNamespaces(['yakitRoute', 'layout', 'yakitUi'])
+
+  const [executionHistory, setExecutionHistory] = useState<PluginExecutionHistoryItem[]>([])
+  const [historyVisible, setHistoryVisible] = useState<boolean>(false)
+  const refreshExecutionHistory = useMemoizedFn(() => {
+    queryPluginExecutionHistory()
+      .then(setExecutionHistory)
+      .catch(() => setExecutionHistory([]))
+  })
+  useEffect(() => {
+    refreshExecutionHistory()
+    emiter.on('refreshPluginExecutionHistory', refreshExecutionHistory)
+    return () => emiter.off('refreshPluginExecutionHistory', refreshExecutionHistory)
+  }, [refreshExecutionHistory])
 
   /** 转换成菜单组件统一处理的数据格式，插件是否下载的验证由菜单组件处理，这里不处理 */
   const onMenu = useMemoizedFn((pluginId: number, pluginName: string) => {
@@ -40,6 +63,16 @@ export const MenuPlugin: React.FC<MenuPluginProps> = React.memo((props) => {
       route: YakitRoute.Plugin_OP,
       pluginId: pluginId || 0,
       pluginName: pluginName || '',
+    })
+    setListShow(false)
+  })
+
+  const onHistoryMenu = useMemoizedFn((item: PluginExecutionHistoryItem) => {
+    onMenuSelect({
+      route: YakitRoute.Plugin_OP,
+      pluginId: item.pluginId,
+      pluginName: item.pluginName,
+      pluginOpPageInfo: getPluginExecutionHistoryPageInfo(item),
     })
     setListShow(false)
   })
@@ -87,7 +120,65 @@ export const MenuPlugin: React.FC<MenuPluginProps> = React.memo((props) => {
   })
 
   const [listShow, setListShow] = useState<boolean>(false)
+  const onOpenHistory = useMemoizedFn(() => {
+    refreshExecutionHistory()
+    setHistoryVisible(true)
+  })
+  const historyDom = useMemo(() => {
+    return (
+      <div className={styles['plugin-list-wrapper']}>
+        <div className={styles['history-body']}>
+          <div className={styles['history-header']}>
+            <YakitButton type="text2" icon={<OutlineArrowleftIcon />} onClick={() => setHistoryVisible(false)} />
+            <div className={styles['history-title']}>{t('Layout.MenuPlugin.pluginHistory')}</div>
+            <div className={styles['history-count']}>
+              {t('Layout.MenuPlugin.pluginHistoryRecent', {
+                count: executionHistory.length,
+                limit: PLUGIN_EXECUTION_HISTORY_LIMIT,
+              })}
+            </div>
+          </div>
+          <div className={styles['history-list']}>
+            {executionHistory.length > 0 ? (
+              executionHistory.map((item) => (
+                <div className={styles['history-item']} key={item.id}>
+                  <Avatar className={styles['history-avatar']} src={item.headImg} icon={<PublicDefaultPluginIcon />} />
+                  <div className={styles['history-info']}>
+                    <div className={classNames(styles['history-name'], 'content-ellipsis')} title={item.pluginName}>
+                      {item.pluginName}
+                    </div>
+                    <div className={styles['history-meta']}>
+                      <span>
+                        {item.source === 'plugin-hub'
+                          ? t('Layout.MenuPlugin.pluginHistorySourceHub')
+                          : t('Layout.MenuPlugin.pluginHistorySourceExecution')}
+                      </span>
+                      <span>
+                        {item.resultStatus === 'stopped'
+                          ? t('Layout.MenuPlugin.pluginHistoryStatusStopped')
+                          : t('Layout.MenuPlugin.pluginHistoryStatusFinished')}
+                      </span>
+                      <span>{formatTimestamp(Math.floor(item.executedAt / 1000))}</span>
+                    </div>
+                  </div>
+                  <YakitButton type="outline1" onClick={() => onHistoryMenu(item)}>
+                    {t('Layout.MenuPlugin.pluginHistoryRestore')}
+                  </YakitButton>
+                </div>
+              ))
+            ) : (
+              <div className={styles['history-empty']}>
+                <OutlileHistoryIcon />
+                <span>{t('Layout.MenuPlugin.pluginHistoryEmpty')}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    )
+  }, [executionHistory, onHistoryMenu, t])
   const listDom = useMemo(() => {
+    if (historyVisible) return historyDom
     return (
       <div className={styles['plugin-list-wrapper']}>
         <div className={styles['list-body']}>
@@ -146,13 +237,19 @@ export const MenuPlugin: React.FC<MenuPluginProps> = React.memo((props) => {
             <SMViewGridAddIcon />
             {t('YakitButton.custom')}...
           </div>
-          <div className={classNames(styles['btn-style'], styles['restore-style'])} onClick={onClickRestore}>
-            {t('Layout.MenuPlugin.restoreMenu')}
+          <div className={styles['list-actions']}>
+            <div className={classNames(styles['btn-style'], styles['history-entry'])} onClick={onOpenHistory}>
+              <OutlileHistoryIcon />
+              {t('Layout.MenuPlugin.pluginHistory')}
+            </div>
+            <div className={classNames(styles['btn-style'], styles['restore-style'])} onClick={onClickRestore}>
+              {t('Layout.MenuPlugin.restoreMenu')}
+            </div>
           </div>
         </div>
       </div>
     )
-  }, [pluginList, loading, i18n.language])
+  }, [historyVisible, historyDom, pluginList, loading, onMenu, onCustom, onOpenHistory, onClickRestore, t])
 
   if (props.children) {
     return (
@@ -164,7 +261,10 @@ export const MenuPlugin: React.FC<MenuPluginProps> = React.memo((props) => {
           trigger={'click'}
           content={listDom}
           visible={listShow}
-          onVisibleChange={(visible) => setListShow(visible)}
+          onVisibleChange={(visible) => {
+            setListShow(visible)
+            if (!visible) setHistoryVisible(false)
+          }}
         >
           <div className={styles['body-style']}>{props.children}</div>
         </YakitPopover>
@@ -229,7 +329,10 @@ export const MenuPlugin: React.FC<MenuPluginProps> = React.memo((props) => {
               trigger={'click'}
               content={listDom}
               visible={listShow}
-              onVisibleChange={(visible) => setListShow(visible)}
+              onVisibleChange={(visible) => {
+                setListShow(visible)
+                if (!visible) setHistoryVisible(false)
+              }}
             >
               <div className={styles['body-style']}>{listShow ? <ChevronUpIcon /> : <ChevronDownIcon />}</div>
             </YakitPopover>

--- a/app/renderer/src/main/src/pages/layout/publicMenu/PublicMenu.tsx
+++ b/app/renderer/src/main/src/pages/layout/publicMenu/PublicMenu.tsx
@@ -20,7 +20,7 @@ import { MenuDNSLog } from './MenuDNSLog'
 import { MenuMode } from './MenuMode'
 import { useMemoizedFn } from 'ahooks'
 import { YakitPopover } from '@/components/yakitUI/YakitPopover/YakitPopover'
-import { YakitMenu } from '@/components/yakitUI/YakitMenu/YakitMenu'
+import { YakitMenu, YakitMenuItemProps } from '@/components/yakitUI/YakitMenu/YakitMenu'
 import { MenuPlugin } from './MenuPlugin'
 import { yakitNotify } from '@/utils/notification'
 import { useStore } from '@/store'
@@ -56,8 +56,22 @@ import emiter from '@/utils/eventBus/eventBus'
 import { grpcQueryNote } from '@/pages/notepadManage/notepadManage/utils'
 import { defaultNoteFilter } from '@/defaultConstants/ModifyNotepad'
 import { genDefaultPagination } from '@/pages/invoker/schema'
+import type { PluginOpPageInfoProps } from '@/store/pageInfo'
+import { Avatar } from 'antd'
+import { YakitModal } from '@/components/yakitUI/YakitModal/YakitModal'
+import {
+  getPluginExecutionHistoryPageInfo,
+  PLUGIN_EXECUTION_HISTORY_LIMIT,
+  PluginExecutionHistoryItem,
+  queryPluginExecutionHistory,
+} from '@/pages/plugins/pluginExecutionHistory'
+import { PublicDefaultPluginIcon } from '@/routes/publicIcon'
+import { OutlileHistoryIcon } from '@/assets/icon/outline'
+import { formatTimestamp } from '@/utils/timeUtil'
+import menuPluginStyles from './MenuPlugin.module.scss'
 
 const { ipcRenderer } = window.require('electron')
+const PLUGIN_HISTORY_MENU_KEY = 'plugin-execution-history'
 
 /**
  * @name Route信息(用于打开页面)
@@ -69,6 +83,7 @@ export interface RouteToPageProps {
   route: YakitRoute
   pluginId?: number
   pluginName?: string
+  pluginOpPageInfo?: PluginOpPageInfoProps
 }
 interface PublicMenuProps {
   defaultExpand: boolean
@@ -369,6 +384,7 @@ const PublicMenu: React.FC<PublicMenuProps> = React.memo((props) => {
             route: YakitRoute.Plugin_OP,
             pluginName: info.ScriptName || menuItem.pluginName,
             pluginId: +info.Id || 0,
+            pluginOpPageInfo: menuItem.pluginOpPageInfo,
           })
           updateSingleMenu({ pluginName: info.ScriptName, pluginId: +info.Id || 0, headImg: info.HeadImg }, source)
         } else {
@@ -409,6 +425,10 @@ const PublicMenu: React.FC<PublicMenuProps> = React.memo((props) => {
 
   // 收起菜单的点击回调
   const onNoExpandClickMenu = useMemoizedFn((key: string, keyPath: string[]) => {
+    if (key === PLUGIN_HISTORY_MENU_KEY) {
+      onOpenPluginHistory()
+      return
+    }
     setNoExpandMenu(-1)
     const data = keyToRouteInfo(key)
 
@@ -431,6 +451,27 @@ const PublicMenu: React.FC<PublicMenuProps> = React.memo((props) => {
   })
 
   const [noExpandMenu, setNoExpandMenu] = useState<number>(-1)
+  const [pluginHistoryVisible, setPluginHistoryVisible] = useState<boolean>(false)
+  const [pluginHistory, setPluginHistory] = useState<PluginExecutionHistoryItem[]>([])
+  const onOpenPluginHistory = useMemoizedFn(() => {
+    setNoExpandMenu(-1)
+    queryPluginExecutionHistory()
+      .then(setPluginHistory)
+      .catch(() => setPluginHistory([]))
+      .finally(() => setPluginHistoryVisible(true))
+  })
+  const onRestorePluginHistory = useMemoizedFn((item: PluginExecutionHistoryItem) => {
+    setPluginHistoryVisible(false)
+    onCheckPlugin(
+      {
+        route: YakitRoute.Plugin_OP,
+        pluginId: item.pluginId,
+        pluginName: item.pluginName,
+        pluginOpPageInfo: getPluginExecutionHistoryPageInfo(item),
+      },
+      'plugin',
+    )
+  })
   // 收起状态下的菜单组件
   const noExpand = useMemo(() => {
     const plugins: EnhancedPublicRouteMenuProps[] = []
@@ -443,24 +484,29 @@ const PublicMenu: React.FC<PublicMenuProps> = React.memo((props) => {
     return (
       <>
         {defaultMenu.map((item, index) => {
-          const data =
-            item.label === '插件'
-              ? routeToMenu(
-                  (item.children || []).concat(
-                    plugins.length === 0
-                      ? []
-                      : [
-                          {
-                            page: undefined,
-                            label: t('Layout.MenuPlugin.commonPlugins'),
-                            menuName: '常用插件',
-                            children: plugins,
-                          },
-                        ],
-                  ),
-                  t,
-                )
-              : routeToMenu(item.children || [], t)
+          let data: YakitMenuItemProps[] = []
+          if (item.label === '插件') {
+            data = routeToMenu(
+              (item.children || []).concat([
+                {
+                  page: undefined,
+                  label: t('Layout.MenuPlugin.commonPlugins'),
+                  menuName: '常用插件',
+                  children: plugins,
+                },
+              ]),
+              t,
+            )
+            const commonPluginMenu = data.find((menu) => menu.key.includes('常用插件'))
+            if (commonPluginMenu && !commonPluginMenu.children) commonPluginMenu.children = []
+            commonPluginMenu?.children?.unshift({
+              label: t('Layout.MenuPlugin.pluginHistory'),
+              key: PLUGIN_HISTORY_MENU_KEY,
+              itemIcon: <OutlileHistoryIcon />,
+            })
+          } else {
+            data = routeToMenu(item.children || [], t)
+          }
           const isOnlyFirst = !item.children && item.page
           return (
             <YakitPopover
@@ -719,6 +765,65 @@ const PublicMenu: React.FC<PublicMenuProps> = React.memo((props) => {
           </div>
         )}
       </div>
+      <YakitModal
+        visible={pluginHistoryVisible}
+        title={t('Layout.MenuPlugin.pluginHistory')}
+        subTitle={t('Layout.MenuPlugin.pluginHistoryRecent', {
+          count: pluginHistory.length,
+          limit: PLUGIN_EXECUTION_HISTORY_LIMIT,
+        })}
+        width={640}
+        footer={null}
+        bodyStyle={{ padding: 0 }}
+        onCancel={() => setPluginHistoryVisible(false)}
+      >
+        <div className={menuPluginStyles['plugin-list-wrapper']} style={{ width: '100%' }}>
+          <div className={menuPluginStyles['history-body']}>
+            <div className={menuPluginStyles['history-list']}>
+              {pluginHistory.length > 0 ? (
+                pluginHistory.map((item) => (
+                  <div className={menuPluginStyles['history-item']} key={item.id}>
+                    <Avatar
+                      className={menuPluginStyles['history-avatar']}
+                      src={item.headImg}
+                      icon={<PublicDefaultPluginIcon />}
+                    />
+                    <div className={menuPluginStyles['history-info']}>
+                      <div
+                        className={classNames(menuPluginStyles['history-name'], 'content-ellipsis')}
+                        title={item.pluginName}
+                      >
+                        {item.pluginName}
+                      </div>
+                      <div className={menuPluginStyles['history-meta']}>
+                        <span>
+                          {item.source === 'plugin-hub'
+                            ? t('Layout.MenuPlugin.pluginHistorySourceHub')
+                            : t('Layout.MenuPlugin.pluginHistorySourceExecution')}
+                        </span>
+                        <span>
+                          {item.resultStatus === 'stopped'
+                            ? t('Layout.MenuPlugin.pluginHistoryStatusStopped')
+                            : t('Layout.MenuPlugin.pluginHistoryStatusFinished')}
+                        </span>
+                        <span>{formatTimestamp(Math.floor(item.executedAt / 1000))}</span>
+                      </div>
+                    </div>
+                    <YakitButton type="outline1" onClick={() => onRestorePluginHistory(item)}>
+                      {t('Layout.MenuPlugin.pluginHistoryRestore')}
+                    </YakitButton>
+                  </div>
+                ))
+              ) : (
+                <div className={menuPluginStyles['history-empty']}>
+                  <OutlileHistoryIcon />
+                  <span>{t('Layout.MenuPlugin.pluginHistoryEmpty')}</span>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </YakitModal>
     </div>
   )
 })

--- a/app/renderer/src/main/src/pages/pluginHub/pluginHubDetail/PluginHubDetail.tsx
+++ b/app/renderer/src/main/src/pages/pluginHub/pluginHubDetail/PluginHubDetail.tsx
@@ -778,6 +778,7 @@ export const PluginHubDetail: React.FC<PluginHubDetailProps> = memo(
                           isHiddenUUID={true}
                           infoExtra={infoExtraNode}
                           hiddenUpdateBtn={true}
+                          historySource="plugin-hub"
                         />
                       ) : (
                         <div className={styles['tab-pane-empty']}>

--- a/app/renderer/src/main/src/pages/plugins/__test__/pluginExecutionHistory.test.ts
+++ b/app/renderer/src/main/src/pages/plugins/__test__/pluginExecutionHistory.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  PluginExecutionHistoryItem,
+  queryPluginExecutionHistory,
+  savePluginExecutionHistory,
+} from '../pluginExecutionHistory'
+
+const mockGetRemoteValue = vi.fn()
+const mockSetRemoteValue = vi.fn()
+const mockEmit = vi.fn()
+
+vi.mock('@/utils/kv', () => ({
+  getRemoteValue: (...args: unknown[]) => mockGetRemoteValue(...args),
+  setRemoteValue: (...args: unknown[]) => mockSetRemoteValue(...args),
+}))
+
+vi.mock('@/utils/eventBus/eventBus', () => ({
+  default: {
+    emit: (...args: unknown[]) => mockEmit(...args),
+  },
+}))
+
+const createHistoryItem = (pluginId: number, executedAt = pluginId): PluginExecutionHistoryItem => ({
+  id: `history-${pluginId}-${executedAt}`,
+  pluginId,
+  pluginName: `plugin-${pluginId}`,
+  pluginType: 'yak',
+  source: 'plugin-op',
+  executedAt,
+  resultRecorded: true,
+  resultStatus: 'finished',
+  execParams: [{ Key: 'target', Value: `https://example.com/${pluginId}` }],
+  formValue: { target: `https://example.com/${pluginId}` },
+  extraParamsValue: {} as PluginExecutionHistoryItem['extraParamsValue'],
+})
+
+describe('plugin execution history', () => {
+  let storedValue = ''
+
+  beforeEach(() => {
+    storedValue = ''
+    mockGetRemoteValue.mockReset().mockImplementation(async () => storedValue)
+    mockSetRemoteValue.mockReset().mockImplementation(async (_key: string, value: string) => {
+      storedValue = value
+    })
+    mockEmit.mockReset()
+  })
+
+  it('deduplicates a plugin and keeps its latest execution first', async () => {
+    await savePluginExecutionHistory(createHistoryItem(1, 1))
+    await savePluginExecutionHistory(createHistoryItem(2, 2))
+    await savePluginExecutionHistory(createHistoryItem(1, 3))
+
+    const history = await queryPluginExecutionHistory()
+
+    expect(history.map((item) => item.pluginId)).toEqual([1, 2])
+    expect(history[0].executedAt).toBe(3)
+  })
+
+  it('keeps at most ten recent plugins', async () => {
+    for (let pluginId = 1; pluginId <= 12; pluginId += 1) {
+      await savePluginExecutionHistory(createHistoryItem(pluginId))
+    }
+
+    const history = await queryPluginExecutionHistory()
+
+    expect(history).toHaveLength(10)
+    expect(history.map((item) => item.pluginId)).toEqual([12, 11, 10, 9, 8, 7, 6, 5, 4, 3])
+  })
+
+  it('restores binary form and HTTP request values', async () => {
+    const item = createHistoryItem(1)
+    item.formValue = { packet: new Uint8Array([1, 2, 3]) }
+    item.extraParamsValue = {
+      RawHTTPRequest: Buffer.from('GET / HTTP/1.1'),
+    } as PluginExecutionHistoryItem['extraParamsValue']
+
+    await savePluginExecutionHistory(item)
+    const [restored] = await queryPluginExecutionHistory()
+
+    expect(restored.formValue.packet).toBeInstanceOf(Uint8Array)
+    expect(Array.from(restored.formValue.packet as Uint8Array)).toEqual([1, 2, 3])
+    expect(restored.extraParamsValue.RawHTTPRequest).toBeInstanceOf(Uint8Array)
+    expect(Buffer.from(restored.extraParamsValue.RawHTTPRequest).toString()).toBe('GET / HTTP/1.1')
+  })
+
+  it('restores the runtime id and custom table result snapshot', async () => {
+    const item = createHistoryItem(1)
+    item.runtimeId = 'runtime-1'
+    item.resultStatus = 'stopped'
+    item.streamInfo = {
+      progressState: [{ id: 'main', progress: 1 }],
+      cardState: [],
+      tabsState: [{ tabName: '结果', type: 'table' }],
+      tabsInfoState: {
+        结果: {
+          name: '结果',
+          columns: [{ title: '目标', dataKey: 'target' }],
+          data: [{ uuid: 'row-1', target: 'https://example.com' }],
+        },
+      },
+      riskState: [],
+      logState: [],
+      rulesState: [],
+    }
+
+    await savePluginExecutionHistory(item)
+    const [restored] = await queryPluginExecutionHistory()
+
+    expect(restored.runtimeId).toBe('runtime-1')
+    expect(restored.resultStatus).toBe('stopped')
+    expect(restored.streamInfo?.tabsInfoState['结果'].data).toEqual([{ uuid: 'row-1', target: 'https://example.com' }])
+  })
+})

--- a/app/renderer/src/main/src/pages/plugins/local/LocalPluginExecute.tsx
+++ b/app/renderer/src/main/src/pages/plugins/local/LocalPluginExecute.tsx
@@ -12,6 +12,10 @@ import { apiDownloadPluginOther } from '../utils'
 import emiter from '@/utils/eventBus/eventBus'
 import { YakitSpin } from '@/components/yakitUI/YakitSpin/YakitSpin'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import cloneDeep from 'lodash/cloneDeep'
+import { savePluginExecutionHistory } from '../pluginExecutionHistory'
+import type { PluginExecutionHistoryItem, PluginExecutionHistoryStatus } from '../pluginExecutionHistory'
+import type { HoldGRPCStreamInfo } from '@/hook/useHoldGRPCStream/useHoldGRPCStreamType'
 
 export const LocalPluginExecute: React.FC<LocalPluginExecuteProps> = React.memo((props) => {
   const {
@@ -26,31 +30,74 @@ export const LocalPluginExecute: React.FC<LocalPluginExecuteProps> = React.memo(
     input,
     noHTTPRequestTemplate,
     autoExecute,
+    historySource,
+    initFormValue,
+    initExtraParamsValue,
+    initRuntimeId,
+    initStreamInfo,
   } = props
   const { t } = useI18nNamespaces(['plugin'])
   /**执行状态 */
   const [executeStatus, setExecuteStatus] = useState<ExpandAndRetractExcessiveState>('default')
-  const [runtimeId, setRuntimeId] = useState<string>('')
+  const [runtimeId, setRuntimeId] = useState<string>(initRuntimeId || '')
+  const [restoredStreamInfo, setRestoredStreamInfo] = useState(initStreamInfo)
   const [downLoading, setDownLoading] = useState<boolean>(false)
 
   const tokenRef = useRef<string>(randomString(40))
+  const runtimeIdRef = useRef<string>(initRuntimeId || '')
+  const historyItemRef = useRef<PluginExecutionHistoryItem>()
+  const historySaveQueueRef = useRef<Promise<void>>(Promise.resolve())
+
+  const queueHistorySave = useMemoizedFn((item: PluginExecutionHistoryItem) => {
+    historySaveQueueRef.current = historySaveQueueRef.current
+      .catch(() => undefined)
+      .then(() => savePluginExecutionHistory(item))
+      .catch(() => undefined)
+  })
+  const persistExecutionHistory = useMemoizedFn(
+    (finalStreamInfo: HoldGRPCStreamInfo, resultStatus: PluginExecutionHistoryStatus) => {
+      if (!historyItemRef.current) return
+      queueHistorySave({
+        ...historyItemRef.current,
+        runtimeId: runtimeIdRef.current,
+        streamInfo: cloneDeep(finalStreamInfo),
+        resultRecorded: true,
+        resultStatus,
+      })
+      historyItemRef.current = undefined
+    },
+  )
+  const onRuntimeIdChange = useMemoizedFn((rId: string) => {
+    runtimeIdRef.current = rId
+    setRuntimeId(rId)
+    if (!rId) setRestoredStreamInfo(undefined)
+  })
+  const onExecutionHistoryStart = useMemoizedFn((item: PluginExecutionHistoryItem) => {
+    historyItemRef.current = item
+  })
+
   useEffect(() => {
     setExecuteStatus('default')
-  }, [plugin.ScriptName])
+    historyItemRef.current = undefined
+    runtimeIdRef.current = initRuntimeId || ''
+    setRuntimeId(initRuntimeId || '')
+    setRestoredStreamInfo(initStreamInfo)
+  }, [plugin.ScriptName, initRuntimeId, initStreamInfo])
 
   const [streamInfo, debugPluginStreamEvent] = useHoldGRPCStream({
     taskName: 'debug-plugin',
     apiKey: 'DebugPlugin',
     token: tokenRef.current,
-    onEnd: () => {
+    onEnd: (finalStreamInfo) => {
       debugPluginStreamEvent.stop()
+      if (finalStreamInfo) persistExecutionHistory(finalStreamInfo, 'finished')
       setTimeout(() => {
         setExecuteStatus('finished')
       }, 300)
     },
     setRuntimeId: (rId) => {
       yakitNotify('info', `调试任务启动成功，运行时 ID: ${rId}`)
-      setRuntimeId(rId)
+      onRuntimeIdChange(rId)
     },
   })
   const isExecuting = useCreation(() => {
@@ -58,8 +105,9 @@ export const LocalPluginExecute: React.FC<LocalPluginExecuteProps> = React.memo(
     return false
   }, [executeStatus])
   const isShowResult = useMemo(() => {
-    return isExecuting || runtimeId
-  }, [isExecuting, runtimeId])
+    return isExecuting || runtimeId || restoredStreamInfo
+  }, [isExecuting, runtimeId, restoredStreamInfo])
+  const resultStreamInfo = useMemo(() => restoredStreamInfo || streamInfo, [restoredStreamInfo, streamInfo])
   /**更新:下载插件 */
   const onDownPlugin = useMemoizedFn(() => {
     if (!plugin.UUID) return
@@ -87,7 +135,7 @@ export const LocalPluginExecute: React.FC<LocalPluginExecuteProps> = React.memo(
         debugPluginStreamEvent={debugPluginStreamEvent}
         progressList={streamInfo.progressState}
         runtimeId={runtimeId}
-        setRuntimeId={setRuntimeId}
+        setRuntimeId={onRuntimeIdChange}
         executeStatus={executeStatus}
         setExecuteStatus={setExecuteStatus}
         linkPluginConfig={linkPluginConfig}
@@ -100,10 +148,15 @@ export const LocalPluginExecute: React.FC<LocalPluginExecuteProps> = React.memo(
         input={input}
         noHTTPRequestTemplate={noHTTPRequestTemplate}
         autoExecute={autoExecute}
+        historySource={historySource}
+        initFormValue={initFormValue}
+        initExtraParamsValue={initExtraParamsValue}
+        onExecutionHistoryStart={onExecutionHistoryStart}
+        onExecutionHistoryStop={(stoppedStreamInfo) => persistExecutionHistory(stoppedStreamInfo, 'stopped')}
       />
       {isShowResult && (
         <PluginExecuteResult
-          streamInfo={streamInfo}
+          streamInfo={resultStreamInfo}
           runtimeId={runtimeId}
           loading={isExecuting}
           defaultActiveKey={plugin.Type === 'yak' ? t('PluginExecResultDefaultTabs.log') : undefined}

--- a/app/renderer/src/main/src/pages/plugins/local/PluginsLocalDetail.tsx
+++ b/app/renderer/src/main/src/pages/plugins/local/PluginsLocalDetail.tsx
@@ -37,6 +37,11 @@ export const PluginDetailsTab: React.FC<PluginDetailsTabProps> = React.memo((pro
     input,
     noHTTPRequestTemplate,
     autoExecute,
+    historySource,
+    initFormValue,
+    initExtraParamsValue,
+    initRuntimeId,
+    initStreamInfo,
   } = props
 
   // 激活tab
@@ -65,6 +70,11 @@ export const PluginDetailsTab: React.FC<PluginDetailsTabProps> = React.memo((pro
                 input={input}
                 noHTTPRequestTemplate={noHTTPRequestTemplate}
                 autoExecute={autoExecute}
+                historySource={historySource}
+                initFormValue={initFormValue}
+                initExtraParamsValue={initExtraParamsValue}
+                initRuntimeId={initRuntimeId}
+                initStreamInfo={initStreamInfo}
               />
             ) : (
               <YakitSpin wrapperClassName={styles['plugin-execute-spin']} />

--- a/app/renderer/src/main/src/pages/plugins/local/PluginsLocalType.d.ts
+++ b/app/renderer/src/main/src/pages/plugins/local/PluginsLocalType.d.ts
@@ -1,6 +1,12 @@
 import { QueryYakScriptRequest, YakScript } from '@/pages/invoker/schema'
 import { API } from '@/services/swagger/resposeType'
 import { ReactNode } from 'react'
+import type { PluginExecutionHistorySource } from '../pluginExecutionHistory'
+import type { HoldGRPCStreamInfo } from '@/hook/useHoldGRPCStream/useHoldGRPCStreamType'
+import type {
+  CustomPluginExecuteFormValue,
+  PluginExecuteExtraFormValue,
+} from '../operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeardType'
 
 export interface LocalPluginExecuteProps {
   plugin: YakScript
@@ -17,6 +23,11 @@ export interface LocalPluginExecuteProps {
   input?: string
   noHTTPRequestTemplate?: boolean
   autoExecute?: boolean
+  historySource?: PluginExecutionHistorySource
+  initFormValue?: CustomPluginExecuteFormValue
+  initExtraParamsValue?: PluginExecuteExtraFormValue
+  initRuntimeId?: string
+  initStreamInfo?: HoldGRPCStreamInfo
 }
 
 export interface ExportYakScriptStreamRequest {
@@ -49,6 +60,11 @@ export interface PluginDetailsTabProps {
   input?: string
   noHTTPRequestTemplate?: boolean
   autoExecute?: boolean
+  historySource?: PluginExecutionHistorySource
+  initFormValue?: CustomPluginExecuteFormValue
+  initExtraParamsValue?: PluginExecuteExtraFormValue
+  initRuntimeId?: string
+  initStreamInfo?: HoldGRPCStreamInfo
 }
 export interface PluginGroupList extends API.PluginsSearch {
   groupExtraOptBtn?: React.ReactElement

--- a/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard.tsx
+++ b/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard.tsx
@@ -46,6 +46,7 @@ import { grpcFetchExpressionToResult } from '@/pages/pluginHub/utils/grpc'
 import { getJsonSchemaListResult, JsonFormWrapper } from '@/components/JsonFormWrapper/JsonFormWrapper'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { JSONParseLog } from '@/utils/tool'
+import type { PluginExecutionHistoryItem } from '../../pluginExecutionHistory'
 
 const PluginExecuteExtraParams = React.lazy(() => import('./PluginExecuteExtraParams'))
 
@@ -71,6 +72,11 @@ export const LocalPluginExecuteDetailHeard: React.FC<PluginExecuteDetailHeardPro
     input,
     noHTTPRequestTemplate,
     autoExecute,
+    historySource,
+    initFormValue: historyFormValue,
+    initExtraParamsValue: historyExtraParamsValue,
+    onExecutionHistoryStart,
+    onExecutionHistoryStop,
   } = props
 
   const [form] = Form.useForm()
@@ -79,11 +85,13 @@ export const LocalPluginExecuteDetailHeard: React.FC<PluginExecuteDetailHeardPro
   /**是否显示更新按钮 */
   const [isShowUpdate, setIsShowUpdate] = useState<boolean>(false)
 
-  const [isExpand, setIsExpand] = useState<boolean>(true)
+  // 历史找回页已有 runtimeId，默认收起参数区，直接露出上次执行结果
+  const [isExpand, setIsExpand] = useState<boolean>(!runtimeId)
   /**额外参数弹出框 */
   const [extraParamsVisible, setExtraParamsVisible] = useState<boolean>(false)
   const [extraParamsValue, setExtraParamsValue] = useState<PluginExecuteExtraFormValue>({
     ...defPluginExecuteFormValue,
+    ...historyExtraParamsValue,
   })
 
   const [customExtraParamsValue, setCustomExtraParamsValue] = useState<CustomPluginExecuteFormValue>({})
@@ -184,9 +192,10 @@ export const LocalPluginExecuteDetailHeard: React.FC<PluginExecuteDetailHeardPro
       initRequiredFormValue.Input = input
     }
     // console.log('必填参数', initRequiredFormValue)
-    form.setFieldsValue(initRequiredFormValue)
+    form.setFieldsValue({ ...initRequiredFormValue, ...historyFormValue })
   })
   const initExtraFormValue = useMemoizedFn(() => {
+    setExtraParamsValue({ ...defPluginExecuteFormValue, ...historyExtraParamsValue })
     // 额外参数
     let initExtraFormValue: CustomPluginExecuteFormValue = {}
     const extraParamsList = plugin.Params?.filter((ele) => !ele.Required) || []
@@ -220,6 +229,7 @@ export const LocalPluginExecuteDetailHeard: React.FC<PluginExecuteDetailHeardPro
             pluginType={plugin.Type}
             isExecuting={isExecuting}
             jsonSchemaListRef={jsonSchemaListRef}
+            jsonSchemaInitial={initExecParamsValue}
             isInline
           />
         )
@@ -240,6 +250,7 @@ export const LocalPluginExecuteDetailHeard: React.FC<PluginExecuteDetailHeardPro
                 pluginType={plugin.Type}
                 isExecuting={isExecuting}
                 jsonSchemaListRef={jsonSchemaListRef}
+                jsonSchemaInitial={initExecParamsValue}
               />
             ) : null}
             <OutputFormComponentsByType
@@ -259,6 +270,7 @@ export const LocalPluginExecuteDetailHeard: React.FC<PluginExecuteDetailHeardPro
                 pluginType={plugin.Type}
                 isExecuting={isExecuting}
                 jsonSchemaListRef={jsonSchemaListRef}
+                jsonSchemaInitial={initExecParamsValue}
               />
             ) : null}
             <PluginFixFormParams form={form} disabled={isExecuting} />
@@ -316,6 +328,27 @@ export const LocalPluginExecuteDetailHeard: React.FC<PluginExecuteDetailHeardPro
       token: token,
       pluginCustomParams: plugin.Params,
     }).then(() => {
+      if (historySource && onExecutionHistoryStart) {
+        const historyItem: PluginExecutionHistoryItem = {
+          id: `${plugin.UUID || plugin.Id || plugin.ScriptName}-${Date.now()}`,
+          pluginId: Number(plugin.Id) || 0,
+          pluginName: plugin.ScriptName,
+          pluginUUID: plugin.UUID || undefined,
+          pluginType: plugin.Type,
+          headImg: plugin.HeadImg || undefined,
+          source: historySource,
+          executedAt: Date.now(),
+          input: value['Input'],
+          execParams: yakExecutorParams,
+          formValue: { ...value, ...customExtraParamsValue },
+          extraParamsValue: { ...extraParamsValue },
+          httpRequestTemplate: executeParams.HTTPRequestTemplate,
+          linkPluginConfig,
+          code: code || undefined,
+          noHTTPRequestTemplate,
+        }
+        onExecutionHistoryStart(historyItem)
+      }
       setExecuteStatus('process')
       setIsExpand(false)
       debugPluginStreamEvent.start()
@@ -325,6 +358,8 @@ export const LocalPluginExecuteDetailHeard: React.FC<PluginExecuteDetailHeardPro
   const onStopExecute = useMemoizedFn((e) => {
     e.stopPropagation()
     apiCancelDebugPlugin(token).then(() => {
+      const stoppedStreamInfo = debugPluginStreamEvent.snapshot()
+      onExecutionHistoryStop?.(stoppedStreamInfo)
       debugPluginStreamEvent.stop()
       setExecuteStatus('finished')
     })
@@ -524,6 +559,7 @@ export const LocalPluginExecuteDetailHeard: React.FC<PluginExecuteDetailHeardPro
           setVisible={setExtraParamsVisible}
           onSave={onSaveExtraParams}
           jsonSchemaListRef={jsonSchemaListRef}
+          jsonSchemaInitial={initExecParamsValue}
         />
       </React.Suspense>
     </>

--- a/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeardType.d.ts
+++ b/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeardType.d.ts
@@ -3,10 +3,11 @@ import { ReactNode } from 'react'
 import { YakParamProps } from '../../pluginsType'
 import { KVPair } from '@/models/kv'
 import { HTTPRequestBuilderParams } from '@/models/HTTPRequestBuilder'
-import { StreamResult } from '@/hook/useHoldGRPCStream/useHoldGRPCStreamType'
+import { HoldGRPCStreamInfo, StreamResult } from '@/hook/useHoldGRPCStream/useHoldGRPCStreamType'
 import { FormInstance } from 'antd'
 import { ExpandAndRetractExcessiveState } from '../expandAndRetract/ExpandAndRetract'
 import { JsonFormSchemaListWrapper } from '@/components/JsonFormWrapper/JsonFormWrapper'
+import type { PluginExecutionHistoryItem, PluginExecutionHistorySource } from '../../pluginExecutionHistory'
 export interface PluginExecuteDetailHeardProps {
   token: string
   /**插件 */
@@ -18,6 +19,7 @@ export interface PluginExecuteDetailHeardProps {
     stop: () => void
     cancel: () => void
     reset: () => void
+    snapshot: () => HoldGRPCStreamInfo
   }
   progressList: StreamResult.Progress[]
   runtimeId: string
@@ -37,6 +39,11 @@ export interface PluginExecuteDetailHeardProps {
   input?: string
   noHTTPRequestTemplate?: boolean
   autoExecute?: boolean
+  historySource?: PluginExecutionHistorySource
+  initFormValue?: CustomPluginExecuteFormValue
+  initExtraParamsValue?: PluginExecuteExtraFormValue
+  onExecutionHistoryStart?: (item: PluginExecutionHistoryItem) => void
+  onExecutionHistoryStop?: (streamInfo: HoldGRPCStreamInfo) => void
 }
 
 export interface YakExtraParamProps {

--- a/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/PluginExecuteExtraParams.tsx
+++ b/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/PluginExecuteExtraParams.tsx
@@ -58,6 +58,7 @@ const PluginExecuteExtraParams: React.FC<PluginExecuteExtraParamsProps> = React.
       setVisible,
       onSave,
       jsonSchemaListRef,
+      jsonSchemaInitial,
     } = props
 
     const [form] = Form.useForm()
@@ -72,7 +73,7 @@ const PluginExecuteExtraParams: React.FC<PluginExecuteExtraParamsProps> = React.
       if (visible) {
         form.setFieldsValue({ ...extraParamsValue })
       }
-    }, [visible, extraParamsValue])
+    }, [form, visible, extraParamsValue])
     const onClose = useMemoizedFn(() => {
       onSaveSetting()
     })
@@ -121,6 +122,7 @@ const PluginExecuteExtraParams: React.FC<PluginExecuteExtraParamsProps> = React.
                 extraParamsGroup={extraParamsGroup}
                 pluginType={pluginType}
                 jsonSchemaListRef={jsonSchemaListRef}
+                jsonSchemaInitial={jsonSchemaInitial}
               />
               <div className={styles['to-end']}>已经到底啦～</div>
             </Form>
@@ -135,7 +137,12 @@ const PluginExecuteExtraParams: React.FC<PluginExecuteExtraParamsProps> = React.
                     <div className={styles['text-style']}>自定义参数 (非必填)</div>
                     <div className={styles['divider-style']}></div>
                   </div>
-                  <ExtraParamsNodeByType extraParamsGroup={extraParamsGroup} pluginType={pluginType} />
+                  <ExtraParamsNodeByType
+                    extraParamsGroup={extraParamsGroup}
+                    pluginType={pluginType}
+                    jsonSchemaListRef={jsonSchemaListRef}
+                    jsonSchemaInitial={jsonSchemaInitial}
+                  />
                 </>
               )}
               {!hiddenFixedParams && (
@@ -190,7 +197,14 @@ interface ExtraParamsNodeByTypeProps extends JsonFormSchemaListWrapper {
   wrapperClassName?: string
 }
 export const ExtraParamsNodeByType: React.FC<ExtraParamsNodeByTypeProps> = React.memo((props) => {
-  const { extraParamsGroup, pluginType, jsonSchemaListRef, isDefaultActiveKey = true, wrapperClassName } = props
+  const {
+    extraParamsGroup,
+    pluginType,
+    jsonSchemaListRef,
+    jsonSchemaInitial,
+    isDefaultActiveKey = true,
+    wrapperClassName,
+  } = props
   const defaultActiveKey = useMemo(() => {
     if (!isDefaultActiveKey) return undefined
     return extraParamsGroup.map((ele) => ele.group)
@@ -204,7 +218,12 @@ export const ExtraParamsNodeByType: React.FC<ExtraParamsNodeByTypeProps> = React
         <YakitPanel key={`${item.group}`} header={`参数组：${item.group}`}>
           {item.data?.map((formItem) => (
             <React.Fragment key={formItem.Field + formItem.FieldVerbose}>
-              <FormContentItemByType item={formItem} pluginType={pluginType} jsonSchemaListRef={jsonSchemaListRef} />
+              <FormContentItemByType
+                item={formItem}
+                pluginType={pluginType}
+                jsonSchemaListRef={jsonSchemaListRef}
+                jsonSchemaInitial={jsonSchemaInitial}
+              />
             </React.Fragment>
           ))}
         </YakitPanel>

--- a/app/renderer/src/main/src/pages/plugins/pluginExecutionHistory.ts
+++ b/app/renderer/src/main/src/pages/plugins/pluginExecutionHistory.ts
@@ -1,0 +1,126 @@
+import { HTTPRequestBuilderParams } from '@/models/HTTPRequestBuilder'
+import { HybridScanPluginConfig } from '@/models/HybridScan'
+import { YakExecutorParam } from '@/pages/invoker/YakExecutorParams'
+import { RemotePluginGV } from '@/enums/plugin'
+import { getRemoteValue, setRemoteValue } from '@/utils/kv'
+import emiter from '@/utils/eventBus/eventBus'
+import type { PluginOpPageInfoProps } from '@/store/pageInfo'
+import type { HoldGRPCStreamInfo } from '@/hook/useHoldGRPCStream/useHoldGRPCStreamType'
+import type {
+  PluginExecuteExtraFormValue,
+  CustomPluginExecuteFormValue,
+} from './operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeardType'
+
+export type PluginExecutionHistorySource = 'plugin-op' | 'plugin-hub'
+export type PluginExecutionHistoryStatus = 'finished' | 'stopped'
+
+export interface PluginExecutionHistoryItem {
+  id: string
+  pluginId: number
+  pluginName: string
+  pluginUUID?: string
+  pluginType: string
+  headImg?: string
+  source: PluginExecutionHistorySource
+  executedAt: number
+  input?: string
+  execParams: YakExecutorParam[]
+  formValue: CustomPluginExecuteFormValue
+  extraParamsValue: PluginExecuteExtraFormValue
+  httpRequestTemplate?: HTTPRequestBuilderParams
+  linkPluginConfig?: HybridScanPluginConfig
+  code?: string
+  noHTTPRequestTemplate?: boolean
+  /** 本次插件执行的运行时 ID，用于恢复已落库的 HTTP、风险、端口等结果 */
+  runtimeId?: string
+  /** 自定义表格、文本、日志等仅存在于执行流中的前端结果快照 */
+  streamInfo?: HoldGRPCStreamInfo
+  /** 标识该记录已经在执行流结束后写入过结果，旧版仅参数记录不会作为可找回历史展示 */
+  resultRecorded?: boolean
+  /** 本次历史是正常执行完成，还是由用户主动停止 */
+  resultStatus?: PluginExecutionHistoryStatus
+}
+
+export const PLUGIN_EXECUTION_HISTORY_LIMIT = 10
+
+export const getPluginExecutionHistoryPageInfo = (item: PluginExecutionHistoryItem): PluginOpPageInfoProps => ({
+  pluginId: String(item.pluginId),
+  pluginName: item.pluginName,
+  Input: item.input || '',
+  ExecParams: item.execParams || [],
+  Code: item.code || '',
+  PluginType: item.pluginType,
+  autoExecute: false,
+  noHTTPRequestTemplate: !!item.noHTTPRequestTemplate,
+  FormValue: item.formValue,
+  ExtraParamsValue: item.extraParamsValue,
+  HistoryId: item.id,
+  RuntimeId: item.runtimeId,
+})
+
+const binaryReplacer = (_key: string, value: unknown) => {
+  if (value instanceof Uint8Array) {
+    return { __yakitBinary: true, data: Array.from(value) }
+  }
+  if (
+    value &&
+    typeof value === 'object' &&
+    (value as { type?: string }).type === 'Buffer' &&
+    Array.isArray((value as { data?: unknown }).data)
+  ) {
+    return { __yakitBinary: true, data: (value as { data: number[] }).data }
+  }
+  return value
+}
+
+const binaryReviver = (_key: string, value: unknown) => {
+  if (
+    value &&
+    typeof value === 'object' &&
+    (value as { __yakitBinary?: boolean }).__yakitBinary &&
+    Array.isArray((value as { data?: unknown }).data)
+  ) {
+    return new Uint8Array((value as { data: number[] }).data)
+  }
+  return value
+}
+
+const isHistoryItem = (item: unknown): item is PluginExecutionHistoryItem => {
+  if (!item || typeof item !== 'object') return false
+  const value = item as Partial<PluginExecutionHistoryItem>
+  return (
+    !!value.pluginName &&
+    Number.isFinite(Number(value.pluginId)) &&
+    Number.isFinite(Number(value.executedAt)) &&
+    value.resultRecorded === true
+  )
+}
+
+export const queryPluginExecutionHistory = async (): Promise<PluginExecutionHistoryItem[]> => {
+  const value = await getRemoteValue(RemotePluginGV.SinglePluginExecutionHistory)
+  if (!value) return []
+  try {
+    const list = JSON.parse(value, binaryReviver)
+    if (!Array.isArray(list)) return []
+    return list.filter(isHistoryItem).slice(0, PLUGIN_EXECUTION_HISTORY_LIMIT)
+  } catch (error) {
+    return []
+  }
+}
+
+const getPluginIdentity = (item: Pick<PluginExecutionHistoryItem, 'pluginId' | 'pluginUUID' | 'pluginName'>) => {
+  if (item.pluginUUID) return `uuid:${item.pluginUUID}`
+  if (item.pluginId) return `id:${item.pluginId}`
+  return `name:${item.pluginName}`
+}
+
+export const savePluginExecutionHistory = async (item: PluginExecutionHistoryItem): Promise<void> => {
+  const history = await queryPluginExecutionHistory()
+  const identity = getPluginIdentity(item)
+  const nextHistory = [item, ...history.filter((record) => getPluginIdentity(record) !== identity)].slice(
+    0,
+    PLUGIN_EXECUTION_HISTORY_LIMIT,
+  )
+  await setRemoteValue(RemotePluginGV.SinglePluginExecutionHistory, JSON.stringify(nextHistory, binaryReplacer))
+  emiter.emit('refreshPluginExecutionHistory')
+}

--- a/app/renderer/src/main/src/pages/plugins/singlePluginExecution/SinglePluginExecution.tsx
+++ b/app/renderer/src/main/src/pages/plugins/singlePluginExecution/SinglePluginExecution.tsx
@@ -28,6 +28,8 @@ import { PageNodeItemProps, PluginOpPageInfoProps, usePageInfo } from '@/store/p
 import { shallow } from 'zustand/shallow'
 import { YakitRoute } from '@/enums/yakitRoute'
 import { CustomPluginExecuteFormValue } from '../operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeardType'
+import { queryPluginExecutionHistory } from '../pluginExecutionHistory'
+import type { PluginExecutionHistoryItem } from '../pluginExecutionHistory'
 
 export const getLinkPluginConfig = (selectList, pluginListSearchInfo, allCheck?: boolean) => {
   // allCheck只有为false的时候才走该判断，undefined和true不走
@@ -68,6 +70,8 @@ export const SinglePluginExecution: React.FC<SinglePluginExecutionProps> = React
     return undefined
   })
   const [pageInfo, setPageInfo] = useState<PluginOpPageInfoProps | undefined>(initPageInfo())
+  const [historyResult, setHistoryResult] = useState<PluginExecutionHistoryItem>()
+  const [historyLoading, setHistoryLoading] = useState<boolean>(!!pageInfo?.HistoryId)
   const [yakScriptId, setYakScriptId] = useState<number>(props.yakScriptId)
   const [refreshList, setRefreshList] = useState<boolean>(false)
 
@@ -86,6 +90,31 @@ export const SinglePluginExecution: React.FC<SinglePluginExecutionProps> = React
   useEffect(() => {
     getPluginById()
   }, [yakScriptId])
+  useEffect(() => {
+    const historyId = pageInfo?.HistoryId
+    if (!historyId) {
+      setHistoryResult(undefined)
+      setHistoryLoading(false)
+      return
+    }
+
+    let active = true
+    setHistoryLoading(true)
+    queryPluginExecutionHistory()
+      .then((history) => {
+        if (!active) return
+        setHistoryResult(history.find((item) => item.id === historyId))
+      })
+      .catch(() => {
+        if (active) setHistoryResult(undefined)
+      })
+      .finally(() => {
+        if (active) setHistoryLoading(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [pageInfo?.HistoryId])
   useEffect(() => {
     if (inViewport) emiter.on('onRefSinglePluginExecution', getYakScriptByOnlineID)
     return () => {
@@ -260,7 +289,7 @@ export const SinglePluginExecution: React.FC<SinglePluginExecutionProps> = React
         pluginGroupExcludeType={pluginGroupExcludeType}
       >
         <PluginDetailsTab
-          executorShow={!pluginLoading}
+          executorShow={!pluginLoading && !historyLoading}
           plugin={plugin}
           headExtraNode={headExtraNode}
           linkPluginConfig={linkPluginConfig}
@@ -269,6 +298,11 @@ export const SinglePluginExecution: React.FC<SinglePluginExecutionProps> = React
           input={pageInfo?.Input || ''}
           noHTTPRequestTemplate={pageInfo?.noHTTPRequestTemplate}
           autoExecute={pageInfo?.autoExecute}
+          historySource="plugin-op"
+          initFormValue={pageInfo?.FormValue}
+          initExtraParamsValue={pageInfo?.ExtraParamsValue}
+          initRuntimeId={historyResult?.runtimeId || pageInfo?.RuntimeId}
+          initStreamInfo={historyResult?.streamInfo}
         />
       </PluginLocalListDetails>
 

--- a/app/renderer/src/main/src/store/pageInfo.ts
+++ b/app/renderer/src/main/src/store/pageInfo.ts
@@ -21,6 +21,10 @@ import { AIMentionCommandParams } from '@/pages/ai-agent/components/aiMilkdownIn
 import { IrifyAiCodeAuditStyle } from '@/pages/irifyAiCodeAudit/irifyAiCodeAuditStyle'
 import i18n from '@/i18n/i18n'
 import { YakExecutorParam } from '@/pages/invoker/YakExecutorParams'
+import type {
+  CustomPluginExecuteFormValue,
+  PluginExecuteExtraFormValue,
+} from '@/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeardType'
 const tOriginal = i18n.getFixedT(null, 'store')
 
 /**
@@ -342,6 +346,12 @@ export interface PluginOpPageInfoProps {
   PluginType: string
   autoExecute: boolean
   noHTTPRequestTemplate: boolean
+  FormValue?: CustomPluginExecuteFormValue
+  ExtraParamsValue?: PluginExecuteExtraFormValue
+  /** 从插件执行历史找回时对应的历史记录 ID */
+  HistoryId?: string
+  /** 历史执行的运行时 ID */
+  RuntimeId?: string
 }
 interface PageInfoStoreProps {
   pages: Map<string, PageProps>

--- a/app/renderer/src/main/src/utils/eventBus/events/plugins.ts
+++ b/app/renderer/src/main/src/utils/eventBus/events/plugins.ts
@@ -5,6 +5,8 @@ export type PluginsEventProps = {
   onRefSinglePluginExecution?: string
   /** 刷新Codec相关菜单 */
   onRefPluginCodecMenu?: string
+  /** 最近使用插件执行记录发生变化 */
+  refreshPluginExecutionHistory?: string
 
   // ---------- 插件列表相关通信 ----------
   /** 刷新插件商店列表(传 true 则同步刷新高级筛选条件) */


### PR DESCRIPTION
- 在插件枚举中添加最近使用的单插件执行记录
- 更新 useHoldGRPCStream 钩子以支持执行历史的快照功能
- 在 MenuPlugin 组件中实现插件执行历史的查询和展示
- 新增 pluginExecutionHistory.ts 文件，包含执行历史的查询和保存逻辑
- 更新相关组件以支持执行历史的恢复功能
- 添加插件执行历史的单元测试