### PR TITLE
feat(plugins): Codec 插件执行结果优化、Tab 智能切换与自定义表格排序/复制增强

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.zcode/
 bins/database/*.gzip
 bins/yak.zip
 bins/engine-version.txt

--- a/app/renderer/src/main/public/locales/en/plugin.json
+++ b/app/renderer/src/main/public/locales/en/plugin.json
@@ -151,7 +151,8 @@
     "sourceCodeDesc": "You can define the plugin input principle and write output UI here",
     "escFullScreen": "Press Esc to exit full screen",
     "anonymous": "anonymous",
-    "filterCondition": "Filter Condition"
+    "filterCondition": "Filter Condition",
+    "codecInput": "INPUT"
   },
   "PluginExecResultDefaultTabs": {
     "HTTPtraffic": "HTTP traffic",

--- a/app/renderer/src/main/public/locales/zh-TW/plugin.json
+++ b/app/renderer/src/main/public/locales/zh-TW/plugin.json
@@ -151,7 +151,8 @@
     "sourceCodeDesc": "可在此定義外掛輸入原理，並編寫輸出 UI",
     "escFullScreen": "按 Esc 即可退出全屏",
     "anonymous": "匿名",
-    "filterCondition": "篩選條件"
+    "filterCondition": "篩選條件",
+    "codecInput": "輸入"
   },
   "PluginExecResultDefaultTabs": {
     "HTTPtraffic": "HTTP 流量",

--- a/app/renderer/src/main/public/locales/zh/plugin.json
+++ b/app/renderer/src/main/public/locales/zh/plugin.json
@@ -151,7 +151,8 @@
     "sourceCodeDesc": "可在此定义插件输入原理，并编写输出 UI",
     "escFullScreen": "按 Esc 即可退出全屏",
     "anonymous": "匿名",
-    "filterCondition": "筛选条件"
+    "filterCondition": "筛选条件",
+    "codecInput": "输入"
   },
   "PluginExecResultDefaultTabs": {
     "HTTPtraffic": "HTTP 流量",

--- a/app/renderer/src/main/src/components/yakChat/chatCS.tsx
+++ b/app/renderer/src/main/src/components/yakChat/chatCS.tsx
@@ -3190,7 +3190,8 @@ export const PluginAIComponent: React.FC<PluginAIComponentProps> = (props) => {
                       streamInfo={streamInfo}
                       runtimeId={runtimeId}
                       loading={loading}
-                      defaultActiveKey={'Codec结果'}
+                      pluginType="codec"
+                      defaultActiveKey={'执行结果'}
                       pluginExecuteResultWrapper={styles['plugin-execute-result-wrapper']}
                     />
                   </div>

--- a/app/renderer/src/main/src/components/yakChat/chatCS.tsx
+++ b/app/renderer/src/main/src/components/yakChat/chatCS.tsx
@@ -3191,7 +3191,6 @@ export const PluginAIComponent: React.FC<PluginAIComponentProps> = (props) => {
                       runtimeId={runtimeId}
                       loading={loading}
                       pluginType="codec"
-                      defaultActiveKey={'执行结果'}
                       pluginExecuteResultWrapper={styles['plugin-execute-result-wrapper']}
                     />
                   </div>

--- a/app/renderer/src/main/src/pages/pluginEditor/editorCode/EditorCode.tsx
+++ b/app/renderer/src/main/src/pages/pluginEditor/editorCode/EditorCode.tsx
@@ -211,7 +211,7 @@ export const EditorCode: React.FC<EditorCodeProps> = memo(
             Field: 'Input',
             FieldVerbose: 'Input',
             Required: true,
-            TypeVerbose: 'yak',
+            TypeVerbose: 'text',
             DefaultValue: '',
             Help: 'Input',
           }
@@ -559,7 +559,12 @@ export const EditorCode: React.FC<EditorCodeProps> = memo(
                       </div>
                     )}
                     <div className={styles['result-body']}>
-                      <PluginExecuteResult streamInfo={streamInfo} runtimeId={runtimeId} loading={isExecuting} />
+                      <PluginExecuteResult
+                        streamInfo={streamInfo}
+                        runtimeId={runtimeId}
+                        loading={isExecuting}
+                        pluginType={type}
+                      />
                     </div>
                   </>
                 ) : (

--- a/app/renderer/src/main/src/pages/plugins/local/LocalPluginExecute.tsx
+++ b/app/renderer/src/main/src/pages/plugins/local/LocalPluginExecute.tsx
@@ -106,6 +106,7 @@ export const LocalPluginExecute: React.FC<LocalPluginExecuteProps> = React.memo(
           streamInfo={streamInfo}
           runtimeId={runtimeId}
           loading={isExecuting}
+          pluginType={plugin.Type}
           defaultActiveKey={plugin.Type === 'yak' ? t('PluginExecResultDefaultTabs.log') : undefined}
           pluginExecuteResultWrapper={styles['plugin-execute-result-wrapper']}
           isCrawler={plugin.ScriptName === '基础爬虫'}

--- a/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard.tsx
+++ b/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard.tsx
@@ -686,9 +686,7 @@ export const OutputFormComponentsByType: React.FC<OutputFormComponentsByTypeProp
   const formProps = {
     rules: [{ required: item.Required }],
     label:
-      pluginType === 'codec' && item.Field === 'Input'
-        ? t('PluginDebugBody.codecInput')
-        : item.FieldVerbose || item.Field,
+      pluginType === 'codec' && item.Field === 'Input' ? t('FuncTemplate.codecInput') : item.FieldVerbose || item.Field,
     name: item.Field,
     className: styles['plugin-execute-form-item'],
     tooltip: item.Help

--- a/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard.tsx
+++ b/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard.tsx
@@ -228,7 +228,7 @@ export const LocalPluginExecuteDetailHeard: React.FC<PluginExecuteDetailHeardPro
           Field: 'Input',
           FieldVerbose: 'Input',
           Required: true,
-          TypeVerbose: 'yak',
+          TypeVerbose: 'text',
           DefaultValue: '',
           Help: 'Input',
         }
@@ -680,12 +680,15 @@ export const OutputFormComponentsByType: React.FC<OutputFormComponentsByTypeProp
     refreshValue,
     isInline,
   } = props
-  const { t, i18n } = useI18nNamespaces(['yakitUi'])
+  const { t, i18n } = useI18nNamespaces(['yakitUi', 'plugin'])
   const [validateStatus, setValidateStatus] = useState<'success' | 'error'>('success')
 
   const formProps = {
     rules: [{ required: item.Required }],
-    label: item.FieldVerbose || item.Field,
+    label:
+      pluginType === 'codec' && item.Field === 'Input'
+        ? t('PluginDebugBody.codecInput')
+        : item.FieldVerbose || item.Field,
     name: item.Field,
     className: styles['plugin-execute-form-item'],
     tooltip: item.Help
@@ -748,7 +751,11 @@ export const OutputFormComponentsByType: React.FC<OutputFormComponentsByTypeProp
     case 'text':
       return (
         <Form.Item {...formProps}>
-          <YakitInput.TextArea placeholder={t('YakitInput.please_enter')} disabled={disabled} />
+          <YakitInput.TextArea
+            placeholder={t('YakitInput.please_enter')}
+            disabled={disabled}
+            autoSize={{ minRows: 3, maxRows: 10 }}
+          />
         </Form.Item>
       )
     case 'uint':

--- a/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult.module.scss
+++ b/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult.module.scss
@@ -19,9 +19,9 @@
     display: inline-block;
     margin-left: 4px;
     padding: 0px 8px;
-    background: #f6544a;
+    background: var(--Colors-Use-Red-Primary);
     border-radius: 8px;
-    color: #fff;
+    color: var(--Colors-Use-Neutral-Text-1-Title);
     font-size: 12px;
     font-weight: 400;
     line-height: 16px;
@@ -116,6 +116,13 @@
   color: var(--Colors-Use-Neutral-Disable);
   cursor: pointer;
 
+  span {
+    svg {
+      width: 16px;
+      height: 16px;
+    }
+  }
+
   &:hover {
     color: var(--Colors-Use-Main-Primary);
   }
@@ -178,7 +185,7 @@
   .log-tab-name-active {
     .tab-number {
       background-color: var(--Colors-Use-Main-Primary);
-      color: #fff;
+      color: var(--Colors-Use-Neutral-Text-1-Title);
     }
   }
 }

--- a/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult.module.scss
+++ b/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult.module.scss
@@ -80,8 +80,29 @@
   }
 }
 
+.tab-with-icon {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .plugin-execute-custom-table {
   padding: 0;
+}
+
+.custom-table-copy-column {
+  display: flex;
+  align-items: center;
+  color: var(--Colors-Use-Neutral-Disable);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--Colors-Use-Main-Primary);
+  }
+
+  &:active {
+    color: var(--Colors-Use-Main-Pressed);
+  }
 }
 
 .plugin-execute-port-table-container {

--- a/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult.module.scss
+++ b/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult.module.scss
@@ -1,4 +1,5 @@
 @use '../../plugins.scss';
+
 .plugin-execute-result {
   @extend %display-column-center;
   justify-content: flex-start;
@@ -8,6 +9,7 @@
   padding-top: 12px;
   min-height: 500px;
   height: 100%;
+
   .plugin-execute-result-wrapper {
     @extend %display-column-center;
     gap: 12px;
@@ -34,14 +36,17 @@
     border: 0 !important;
     border-top: 1px solid var(--Colors-Use-Neutral-Border) !important;
   }
+
   .custom-table-container {
     border: 0 !important;
   }
 }
+
 .table-container {
   border: 0 !important;
   border-top: 1px solid var(--Colors-Use-Neutral-Border) !important;
 }
+
 .plugin-execute-result-tab-content {
   @extend %display-column-center;
   justify-content: flex-start;
@@ -49,8 +54,10 @@
   color: var(--Colors-Use-Neutral-Text-1-Title);
   font-size: 12px;
   font-weight: 400;
-  line-height: 16px; /* 133.333% */
+  line-height: 16px;
+  /* 133.333% */
   overflow: hidden;
+
   .plugin-execute-result-tab-content-head {
     @extend %display-flex-center;
     justify-content: space-between;
@@ -58,15 +65,18 @@
     border-bottom: 1px solid var(--Colors-Use-Neutral-Border);
   }
 }
+
 .plugin-execute-result-tab-content-body {
   padding: 12px;
   overflow: overlay;
 }
+
 .plugin-execute-http-flow {
   @extend %display-flex-center;
   align-items: flex-start;
   flex: 1;
   height: 100%;
+
   .plugin-execute-web-tree {
     @extend %display-column-center;
     justify-content: flex-start;
@@ -74,6 +84,7 @@
     padding: 12px;
     padding-right: 0;
   }
+
   .current-http-table-container {
     border: 0 !important;
     border-top: 1px solid var(--Colors-Use-Neutral-Border) !important;
@@ -84,6 +95,15 @@
   display: flex;
   align-items: center;
   gap: 4px;
+
+  span {
+    margin-right: 0 !important;
+
+    svg {
+      width: 18px;
+      height: 18px;
+    }
+  }
 }
 
 .plugin-execute-custom-table {
@@ -108,6 +128,7 @@
 .plugin-execute-port-table-container {
   border: 0 !important;
 }
+
 .plugin-execute-port-table-detail-body {
   border-left: 0;
   border-right: 0;
@@ -119,7 +140,9 @@
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
-  line-height: 16px; /* 133.333% */
+  line-height: 16px;
+
+  /* 133.333% */
   &-number {
     color: var(--Colors-Use-Main-Primary);
     margin-left: 4px;
@@ -135,6 +158,7 @@
 .plugin-execute-log {
   .log-tab-name {
     @extend %display-flex-center;
+
     .tab-number {
       @extend %display-flex-center;
       padding: 2px 6px;
@@ -150,6 +174,7 @@
       text-align: center;
     }
   }
+
   .log-tab-name-active {
     .tab-number {
       background-color: var(--Colors-Use-Main-Primary);
@@ -162,6 +187,7 @@
   @extend %display-column-center;
   overflow: hidden;
   height: 100%;
+
   .risks-table-wrapper {
     padding: 0;
   }
@@ -175,7 +201,9 @@
   color: var(--Colors-Use-Neutral-Text-1-Title);
   font-size: 12px;
   font-weight: 400;
-  line-height: 16px; /* 133.333% */
+  line-height: 16px;
+
+  /* 133.333% */
   .table-renderTitle-left {
     @extend %display-flex-center;
     gap: 8px;

--- a/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult.tsx
+++ b/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult.tsx
@@ -50,7 +50,14 @@ import { QueryRisksRequest } from '@/pages/risks/YakitRiskTable/YakitRiskTableTy
 import { defQueryRisksRequest } from '@/pages/risks/YakitRiskTable/constants'
 import { TableTotalAndSelectNumber } from '@/components/TableTotalAndSelectNumber/TableTotalAndSelectNumber'
 import { apiQueryRisksTotalByRuntimeId } from '@/pages/risks/YakitRiskTable/utils'
-import { OutlineChartpieIcon, OutlineLogIcon, OutlineTerminalIcon } from '@/assets/icon/outline'
+import {
+  OutlineChartpieIcon,
+  OutlineDocumenttextIcon,
+  OutlineLogIcon,
+  OutlineTableIcon,
+  OutlineTerminalIcon,
+} from '@/assets/icon/outline'
+import { DocumentDuplicateSvgIcon } from '@/assets/newIcon'
 import { LocalList, LocalPluginLog, LocalText } from './LocalPluginLog'
 import { CodeScanResult } from '@/pages/yakRunnerCodeScan/CodeScanResultTable/CodeScanResultTable'
 import { YakitAuditHoleTable } from '@/pages/yakRunnerAuditHole/YakitAuditHoleTable/YakitAuditHoleTable'
@@ -59,6 +66,9 @@ import { ErrorBoundary } from 'react-error-boundary'
 import moment from 'moment'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { JSONParseLog } from '@/utils/tool'
+import { setClipboardText } from '@/utils/clipboard'
+
+const { ipcRenderer } = window.require('electron')
 
 const { TabPane } = PluginTabs
 
@@ -71,9 +81,12 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
     pluginExecuteResultWrapper = '',
     PluginTabsRightNode,
     isCrawler = false,
+    pluginType,
   } = props
   const { t, i18n } = useI18nNamespaces(['yakitRoute'])
 
+  const [activeKey, setActiveKey] = useState<string | undefined>(undefined)
+  const prevLoadingRef = useRef<boolean>(false)
   const [allTotal, setAllTotal] = useState<number>(0)
   const [tempTotal, setTempTotal] = useState<number>(0) // 在risk表没有展示之前得临时显示在tab上得小红点计数
   const [interval, setInterval] = useState<number | undefined>(1000)
@@ -162,11 +175,16 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
   })
 
   const showTabs = useMemo(() => {
-    if (!tempTotal && !streamInfo.tabsState.find((item) => item.type === 'ssa-risk')) {
-      return streamInfo.tabsState.filter((item) => item.tabName !== t('YakitRoute.vulnerabilityAndrisk'))
+    let tabs = streamInfo.tabsState
+    // Codec 插件不展示 HTTP 流量 tab
+    if (pluginType === 'codec') {
+      tabs = tabs.filter((item) => item.type !== 'http')
     }
-    return streamInfo.tabsState
-  }, [streamInfo.tabsState, tempTotal])
+    if (!tempTotal && !tabs.find((item) => item.type === 'ssa-risk')) {
+      return tabs.filter((item) => item.tabName !== t('YakitRoute.vulnerabilityAndrisk'))
+    }
+    return tabs
+  }, [streamInfo.tabsState, tempTotal, pluginType])
 
   const tabBarRender = useMemoizedFn((tab: HoldGRPCStreamProps.InfoTab, length: number) => {
     if (tab.type === 'risk') {
@@ -175,6 +193,22 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
           {tab.tabName}
           <span className={styles['plugin-execute-result-tabBar']}>{length}</span>
         </>
+      )
+    }
+    if (tab.type === 'table') {
+      return (
+        <span className={styles['tab-with-icon']}>
+          <OutlineTableIcon />
+          {tab.tabName}
+        </span>
+      )
+    }
+    if (tab.type === 'text') {
+      return (
+        <span className={styles['tab-with-icon']}>
+          <OutlineDocumenttextIcon />
+          {tab.tabName}
+        </span>
       )
     }
 
@@ -199,6 +233,55 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
     if (allTotal > 0) return allTotal
     return tempTotal
   }, [allTotal, tempTotal])
+  // 初始化 activeKey：兼容外部传入 defaultActiveKey 和 codec 插件逻辑
+  useEffect(() => {
+    if (defaultActiveKey) {
+      setActiveKey(defaultActiveKey)
+    } else if (pluginType === 'codec') {
+      setActiveKey('执行结果')
+    } else {
+      const logTab = showTabs.find((tab) => tab.type === 'log')
+      if (logTab) setActiveKey(logTab.tabName)
+    }
+  }, [defaultActiveKey, pluginType])
+
+  // 插件执行结束后（loading: true -> false），自动切换到最合适的 Tab
+  useEffect(() => {
+    if (prevLoadingRef.current && !loading) {
+      const builtinTypes = new Set(['http', 'log', 'console'])
+      const customTabs = showTabs.filter((tab) => !builtinTypes.has(tab.type))
+
+      if (customTabs.length > 0) {
+        setActiveKey(customTabs[0].tabName)
+      } else {
+        const httpTab = showTabs.find((tab) => tab.type === 'http')
+        if (httpTab && runtimeId) {
+          ipcRenderer
+            .invoke('QueryHTTPFlows', {
+              RuntimeId: runtimeId,
+              Pagination: { Page: 1, Limit: 1, Order: 'desc', OrderBy: 'Id' },
+            })
+            .then((rsp: { Total: number }) => {
+              if (rsp.Total > 0) {
+                setActiveKey(httpTab.tabName)
+              } else {
+                const logTab = showTabs.find((tab) => tab.type === 'log')
+                setActiveKey(logTab?.tabName || showTabs[0]?.tabName)
+              }
+            })
+            .catch(() => {
+              const logTab = showTabs.find((tab) => tab.type === 'log')
+              setActiveKey(logTab?.tabName || showTabs[0]?.tabName)
+            })
+        } else {
+          const logTab = showTabs.find((tab) => tab.type === 'log')
+          setActiveKey(logTab?.tabName || showTabs[0]?.tabName)
+        }
+      }
+    }
+    prevLoadingRef.current = loading
+  }, [loading])
+
   return (
     <div className={classNames(styles['plugin-execute-result'], pluginExecuteResultWrapper)}>
       {cardState.length > 0 && (
@@ -207,7 +290,7 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
         </div>
       )}
       {showTabs.length > 0 && (
-        <PluginTabs defaultActiveKey={defaultActiveKey} tabBarExtraContent={{ right: PluginTabsRightNode }}>
+        <PluginTabs activeKey={activeKey} onChange={setActiveKey} tabBarExtraContent={{ right: PluginTabsRightNode }}>
           {showTabs.map((ele) => (
             <TabPane
               tab={tabBarRender(ele, showRiskTotal)}
@@ -614,12 +697,26 @@ const PluginExecuteCustomTable: React.FC<PluginExecuteCustomTableProps> = React.
     if (!item) return
     const newColumns = columns.map((ele) => ({
       ...ele,
+      // 所有列均启用排序，数字列按数值排序，字符串列按字符序排序
       sorterProps: {
-        sorter: !Number.isNaN(Number(item[ele.dataKey])),
+        sorter: true,
       },
       filterProps: {
         filtersType: 'input',
       },
+      // 每列筛选旁增加复制按钮，点击复制该列数据到剪贴板
+      afterIconExtra: (
+        <div
+          className={styles['custom-table-copy-column']}
+          onClick={(e) => {
+            e.stopPropagation()
+            const colData = data.map((row) => row[ele.dataKey]).join('\n')
+            setClipboardText(colData)
+          }}
+        >
+          <DocumentDuplicateSvgIcon />
+        </div>
+      ),
     }))
     setColumnsData(newColumns)
   })

--- a/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult.tsx
+++ b/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult.tsx
@@ -85,7 +85,7 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
     pluginType,
   } = props
   const { t, i18n } = useI18nNamespaces(['yakitRoute'])
-
+  const handleChangeActiveKeyRef = useRef<boolean>(false)
   const [activeKey, setActiveKey] = useState<string | undefined>(undefined)
   const prevLoadingRef = useRef<boolean>(false)
   const [allTotal, setAllTotal] = useState<number>(0)
@@ -250,13 +250,18 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
 
   // 插件执行结束后（loading: true -> false），自动切换到最合适的 Tab
   useEffect(() => {
-    if (prevLoadingRef.current && !loading) {
+    if (prevLoadingRef.current && !loading && !handleChangeActiveKeyRef.current) {
       const tabs = showTabsRef.current
       const builtinTypes = new Set(['http', 'log', 'console', 'risk'])
       const customTabs = tabs.filter((tab) => !builtinTypes.has(tab.type))
 
+      // 统一收口：只有未手动切换过 Tab 时，才执行 setActiveKey
+      const safeSetActiveKey = (key: string | undefined) => {
+        if (!handleChangeActiveKeyRef.current) setActiveKey(key)
+      }
+
       if (customTabs.length > 0) {
-        setActiveKey(customTabs[0].tabName)
+        safeSetActiveKey(customTabs[0].tabName)
       } else {
         const httpTab = tabs.find((tab) => tab.type === 'http')
         if (httpTab && runtimeId) {
@@ -267,19 +272,19 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
             })
             .then((rsp: { Total: number }) => {
               if (rsp.Total > 0) {
-                setActiveKey(httpTab.tabName)
+                safeSetActiveKey(httpTab.tabName)
               } else {
                 const logTab = tabs.find((tab) => tab.type === 'log')
-                setActiveKey(logTab?.tabName || tabs[0]?.tabName)
+                safeSetActiveKey(logTab?.tabName || tabs[0]?.tabName)
               }
             })
             .catch(() => {
               const logTab = tabs.find((tab) => tab.type === 'log')
-              setActiveKey(logTab?.tabName || tabs[0]?.tabName)
+              safeSetActiveKey(logTab?.tabName || tabs[0]?.tabName)
             })
         } else {
           const logTab = tabs.find((tab) => tab.type === 'log')
-          setActiveKey(logTab?.tabName || tabs[0]?.tabName)
+          safeSetActiveKey(logTab?.tabName || tabs[0]?.tabName)
         }
       }
     }
@@ -294,7 +299,14 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
         </div>
       )}
       {showTabs.length > 0 && (
-        <PluginTabs activeKey={activeKey} onChange={setActiveKey} tabBarExtraContent={{ right: PluginTabsRightNode }}>
+        <PluginTabs
+          activeKey={activeKey}
+          onChange={(key) => {
+            handleChangeActiveKeyRef.current = true
+            setActiveKey(key)
+          }}
+          tabBarExtraContent={{ right: PluginTabsRightNode }}
+        >
           {showTabs.map((ele) => (
             <TabPane
               tab={tabBarRender(ele, showRiskTotal)}

--- a/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult.tsx
+++ b/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult.tsx
@@ -67,6 +67,7 @@ import moment from 'moment'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { JSONParseLog } from '@/utils/tool'
 import { setClipboardText } from '@/utils/clipboard'
+import useGetSetState from '@/pages/pluginHub/hooks/useGetSetState'
 
 const { ipcRenderer } = window.require('electron')
 
@@ -184,7 +185,9 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
       return tabs.filter((item) => item.tabName !== t('YakitRoute.vulnerabilityAndrisk'))
     }
     return tabs
-  }, [streamInfo.tabsState, tempTotal, pluginType])
+  }, [streamInfo.tabsState, tempTotal, pluginType, i18n.language])
+  const showTabsRef = useRef(showTabs)
+  showTabsRef.current = showTabs
 
   const tabBarRender = useMemoizedFn((tab: HoldGRPCStreamProps.InfoTab, length: number) => {
     if (tab.type === 'risk') {
@@ -240,7 +243,7 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
     } else if (pluginType === 'codec') {
       setActiveKey('执行结果')
     } else {
-      const logTab = showTabs.find((tab) => tab.type === 'log')
+      const logTab = showTabsRef.current.find((tab) => tab.type === 'log')
       if (logTab) setActiveKey(logTab.tabName)
     }
   }, [defaultActiveKey, pluginType])
@@ -248,13 +251,14 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
   // 插件执行结束后（loading: true -> false），自动切换到最合适的 Tab
   useEffect(() => {
     if (prevLoadingRef.current && !loading) {
-      const builtinTypes = new Set(['http', 'log', 'console'])
-      const customTabs = showTabs.filter((tab) => !builtinTypes.has(tab.type))
+      const tabs = showTabsRef.current
+      const builtinTypes = new Set(['http', 'log', 'console', 'risk'])
+      const customTabs = tabs.filter((tab) => !builtinTypes.has(tab.type))
 
       if (customTabs.length > 0) {
         setActiveKey(customTabs[0].tabName)
       } else {
-        const httpTab = showTabs.find((tab) => tab.type === 'http')
+        const httpTab = tabs.find((tab) => tab.type === 'http')
         if (httpTab && runtimeId) {
           ipcRenderer
             .invoke('QueryHTTPFlows', {
@@ -265,17 +269,17 @@ export const PluginExecuteResult: React.FC<PluginExecuteResultProps> = React.mem
               if (rsp.Total > 0) {
                 setActiveKey(httpTab.tabName)
               } else {
-                const logTab = showTabs.find((tab) => tab.type === 'log')
-                setActiveKey(logTab?.tabName || showTabs[0]?.tabName)
+                const logTab = tabs.find((tab) => tab.type === 'log')
+                setActiveKey(logTab?.tabName || tabs[0]?.tabName)
               }
             })
             .catch(() => {
-              const logTab = showTabs.find((tab) => tab.type === 'log')
-              setActiveKey(logTab?.tabName || showTabs[0]?.tabName)
+              const logTab = tabs.find((tab) => tab.type === 'log')
+              setActiveKey(logTab?.tabName || tabs[0]?.tabName)
             })
         } else {
-          const logTab = showTabs.find((tab) => tab.type === 'log')
-          setActiveKey(logTab?.tabName || showTabs[0]?.tabName)
+          const logTab = tabs.find((tab) => tab.type === 'log')
+          setActiveKey(logTab?.tabName || tabs[0]?.tabName)
         }
       }
     }
@@ -662,7 +666,7 @@ const PluginExecuteCustomTable: React.FC<PluginExecuteCustomTableProps> = React.
     tableInfo: { columns = [], data = [], name = '' },
   } = props
   const { t } = useI18nNamespaces(['plugin', 'yakitUi'])
-  const [tableData, setTableData] = useState(data)
+  const [tableData, setTableData, getTableData] = useGetSetState(data)
   const [columnsData, setColumnsData] = useState(columns)
 
   const [sorterTable, setSorterTable] = useState<SortProps>()
@@ -710,7 +714,9 @@ const PluginExecuteCustomTable: React.FC<PluginExecuteCustomTableProps> = React.
           className={styles['custom-table-copy-column']}
           onClick={(e) => {
             e.stopPropagation()
-            const colData = data.map((row) => row[ele.dataKey]).join('\n')
+            const colData = getTableData()
+              .map((row) => row[ele.dataKey])
+              .join('\n')
             setClipboardText(colData)
           }}
         >

--- a/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResultType.d.ts
+++ b/app/renderer/src/main/src/pages/plugins/operator/pluginExecuteResult/PluginExecuteResultType.d.ts
@@ -10,6 +10,8 @@ export interface PluginExecuteResultProps {
   pluginExecuteResultWrapper?: string
   PluginTabsRightNode?: React.ReactNode
   isCrawler?: boolean
+  /** 插件类型，codec 类型时不展示 HTTP 流量 tab 并默认切换到执行结果 */
+  pluginType?: string
 }
 
 export interface VulnerabilitiesRisksTableProps {

--- a/app/renderer/src/main/src/pages/plugins/pluginDebug/PluginDebug.tsx
+++ b/app/renderer/src/main/src/pages/plugins/pluginDebug/PluginDebug.tsx
@@ -292,7 +292,7 @@ export const PluginDebugBody: React.FC<PluginDebugBodyProps> = memo((props) => {
           Field: 'Input',
           FieldVerbose: 'Input',
           Required: true,
-          TypeVerbose: 'yak',
+          TypeVerbose: 'text',
           DefaultValue: '',
           Help: 'Input',
         }
@@ -647,7 +647,12 @@ export const PluginDebugBody: React.FC<PluginDebugBodyProps> = memo((props) => {
                       </div>
                     )}
                     <div className={styles['result-body']}>
-                      <PluginExecuteResult streamInfo={streamInfo} runtimeId={runtimeId} loading={isExecuting} />
+                      <PluginExecuteResult
+                        streamInfo={streamInfo}
+                        runtimeId={runtimeId}
+                        loading={isExecuting}
+                        pluginType={pluginType}
+                      />
                     </div>
                   </>
                 ) : (


### PR DESCRIPTION
## 改动内容

### 1. Codec 插件执行结果 TAB 行为优化
- Codec 插件执行后不再自动展示 HTTP 流量 tab，自动切换到「执行结果」tab
- `PluginExecuteResult` 新增 `pluginType` prop，当为 `codec` 时过滤 `http` 类型 tab 并默认激活「执行结果」
- 各调用点（chatCS / LocalPluginExecute / PluginDebug / EditorCode）传入 `pluginType`
- chatCS 中 `defaultActiveKey` 从 'Codec结果' 同步改为 '执行结果'

### 2. 插件执行结果 Tab 智能切换
- Tab 从 `defaultActiveKey`（非受控）改为 `activeKey` + `onChange`（受控模式）
- 插件执行结束后（loading: true → false）自动切换到最合适的 Tab：
  - 优先切换到自定义 tab（table / text 等插件产出的结果）
  - 无自定义 tab 时查询 HTTP 流量是否有数据，有则切到 HTTP 流量 tab，无则切到日志 tab
- 初始化逻辑：兼容外部传入 `defaultActiveKey` 和 codec 插件默认「执行结果」
- 自定义 tab（table / text）在 tab 标题前增加对应 icon

### 3. Codec 插件 Input 输入框改为 TextArea
- Codec Input 从 YakitEditor（Monaco 编辑器）改为 YakitInput.TextArea，更符合纯文本输入场景
- `TypeVerbose` 从 'yak' 改为 'text'，三个调用点统一修改
- TextArea 设置 `autoSize={{ minRows: 3, maxRows: 10 }}`：默认 3 行，随内容自适应高度，到 10 行后内部滚动
- Input label 国际化：中文「输入」、英文「INPUT」（大写），新增 `PluginDebugBody.codecInput` i18n key

### 4. 自定义表格排序与复制增强
- 所有列启用排序（原仅数字列可排序），字符串列按字符序（localeCompare）排序
- 每列筛选旁新增复制按钮，点击复制该列数据到剪贴板
- 复制按钮使用 16x16 的 DocumentDuplicateSvgIcon，与表头 filter/sorter icon 尺寸一致

## 影响范围

- **所有插件执行结果**：Tab 切换逻辑改为受控模式，执行结束后智能选择最合适的 tab
- **Codec 插件**：执行结果不再展示 HTTP 流量 tab；Input 输入框变为 TextArea 自适应高度
- **自定义表格**（所有插件类型）：所有列可排序；每列可复制
- **非 Codec 插件**：行为不变（pluginType 非 codec 不过滤 tab）
- **TextArea**（所有 text 类型参数）：获得 autoSize 能力，默认 3 行

## 关联改动

> ⚠️ 本 PR 需与 yaklang 仓库的改动同步发布。后端 `common/yak/yakscript/exec_param.go` 中 codec 插件下发的 tab_name 已从 `Codec结果` 改为 `执行结果`，前端 `defaultActiveKey` 需与此名称一致。
> - yaklang PR: https://github.com/yaklang/yaklang/pull/4756

## Review 提示

1. **Tab 受控模式改造**：`PluginTabs` 从 `defaultActiveKey` 改为 `activeKey` + `onChange`，确认用户手动切换 tab 后不会被执行结束逻辑覆盖
2. **执行结束自动切换逻辑**：`loading: true → false` 时触发，优先自定义 tab → HTTP 流量（查询有数据才切）→ 日志；确认异步 `QueryHTTPFlows` 查询的竞态安全性
3. **Codec tab 过滤逻辑**：`showTabs` 中 `pluginType === 'codec'` 过滤 `http` tab，确认不影响其他插件类型的 HTTP 流量展示
4. **defaultActiveKey 一致性**：codec 默认指向 '执行结果'，需与后端 yaklang 下发的 tab_name 一致
5. **TextArea autoSize**：`case 'text'` 统一加了 `autoSize`，确认其他使用 text 类型参数的插件场景不受负面影响
6. **排序改动**：`sorter: true` 让所有列可排序，字符串列走 `localeCompare`，确认排序行为符合预期
7. **复制按钮**：`afterIconExtra` 中的复制按钮 `stopPropagation` 避免触发表头事件，确认不影响排序/筛选交互
8. **自定义 tab icon**：table 类型用 `OutlineTableIcon`，text 类型用 `OutlineDocumenttextIcon`，确认 icon 渲染正确
9. **i18n**：新增 `PluginDebugBody.codecInput` key（zh/en/zh-TW），确认翻译正确