### PR TITLE
chore(i18n): 导航栏导入资源文案改为导入插件/流量

### DIFF
--- a/app/renderer/src/main/public/locales/en/yakitUi.json
+++ b/app/renderer/src/main/public/locales/en/yakitUi.json
@@ -17,7 +17,7 @@
     "added": "Added",
     "add_new": "Add New",
     "import": "Import",
-    "importResources": "Import Resource",
+    "importResources": "Import Plugin/Traffic",
     "importPlugin": "Import Plugin",
     "export": "Export",
     "batchExport": "Batch Export",

--- a/app/renderer/src/main/public/locales/zh-TW/yakitUi.json
+++ b/app/renderer/src/main/public/locales/zh-TW/yakitUi.json
@@ -17,7 +17,7 @@
     "added": "已新增",
     "add_new": "新增",
     "import": "匯入",
-    "importResources": "匯入資源",
+    "importResources": "匯入外掛/流量",
     "importPlugin": "匯入外掛",
     "export": "匯出",
     "batchExport": "批次匯出",

--- a/app/renderer/src/main/public/locales/zh/yakitUi.json
+++ b/app/renderer/src/main/public/locales/zh/yakitUi.json
@@ -17,7 +17,7 @@
     "added": "已添加",
     "add_new": "新增",
     "import": "导入",
-    "importResources": "导入资源",
+    "importResources": "导入插件/流量",
     "importPlugin": "导入插件",
     "export": "导出",
     "batchExport": "批量导出",

--- a/app/renderer/src/main/src/components/HTTPFlowDetail.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowDetail.tsx
@@ -447,6 +447,7 @@ export const HTTPFlowDetail: React.FC<HTTPFlowDetailProp> = (props) => {
                         foldBinaryFuzztag={true}
                         noHeader={true}
                         originValue={flow.RequestString}
+                        originalPackage={flow.Request}
                         defaultHttps={flow?.IsHTTPS}
                         // actions={[...actionFuzzer]}
                         noSendToComparer={true}
@@ -466,6 +467,7 @@ export const HTTPFlowDetail: React.FC<HTTPFlowDetailProp> = (props) => {
                           openPacketNewWindow({
                             request: {
                               originValue: flow.RequestString,
+                              originalPackage: flow.Request,
                             },
                             response: {
                               originValue: flow.ResponseString,
@@ -1819,6 +1821,7 @@ export const HTTPFlowDetailRequestAndResponse: React.FC<HTTPFlowDetailRequestAnd
               return titleEle
             })()}
             originValue={originResValue}
+            originalPackage={flow.Request}
             readOnly={true}
             foldBinaryFuzztag={binaryDisplayEnabled}
             webFuzzerValue={originResValue}

--- a/app/renderer/src/main/src/components/HTTPFlowTable/components/advancedSet.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/components/advancedSet.tsx
@@ -21,7 +21,6 @@ export const AdvancedSet: React.FC<AdvancedSetProps> = React.memo((props) => {
   const {
     showBackgroundRefresh = true,
     dragSelectEnabled: propDragSelectEnabled = true,
-    binaryDisplayEnabled: propBinaryDisplayEnabled = true,
     columnsAllStr,
     onCancel,
     onSave,
@@ -42,10 +41,6 @@ export const AdvancedSet: React.FC<AdvancedSetProps> = React.memo((props) => {
   /** ---------- 框选配置 Start ---------- */
   const [dragSelectEnabled, setDragSelectEnabled] = useState<boolean>(propDragSelectEnabled)
   /** ---------- 框选配置 End ---------- */
-
-  /** ---------- 二进制展示配置 Start ---------- */
-  const [binaryDisplayEnabled, setBinaryDisplayEnabled] = useState<boolean>(propBinaryDisplayEnabled)
-  /** ---------- 二进制展示配置 End ---------- */
 
   /** ---------- 自定义列 Start ---------- */
   const [curColumnsAll, setCurColumnsAll] = useState<ColumnAllInfoItem[]>([])
@@ -81,7 +76,7 @@ export const AdvancedSet: React.FC<AdvancedSetProps> = React.memo((props) => {
     if (oldBackgroundRefresh.current !== backgroundRefresh) {
       setRemoteValue(RemoteHistoryGV.BackgroundRefresh, backgroundRefresh ? 'true' : '')
     }
-    onSave({ backgroundRefresh, dragSelectEnabled, binaryDisplayEnabled, configColumnsAll: curColumnsAll })
+    onSave({ backgroundRefresh, dragSelectEnabled, binaryDisplayEnabled: true, configColumnsAll: curColumnsAll })
   })
 
   // 判断是否有修改
@@ -92,7 +87,6 @@ export const AdvancedSet: React.FC<AdvancedSetProps> = React.memo((props) => {
       if (
         oldBackgroundRefresh.current !== backgroundRefresh ||
         propDragSelectEnabled !== dragSelectEnabled ||
-        propBinaryDisplayEnabled !== binaryDisplayEnabled ||
         columnsAllStr !== JSON.stringify(curColumnsAll)
       ) {
         isModify = true
@@ -189,24 +183,6 @@ export const AdvancedSet: React.FC<AdvancedSetProps> = React.memo((props) => {
               />
               <span className={style['title-style']}>{t('AdvancedSet.dragSelectMultiData')}</span>
               <Tooltip title={t('AdvancedSet.dragSelectMultiDataTip')}>
-                <OutlineInformationcircleIcon className={style['hint-style']} />
-              </Tooltip>
-            </div>
-          </div>
-        </div>
-
-        <div className={style['history-advanced-set-item']}>
-          <div className={style['history-advanced-set-item-title']}>{t('AdvancedSet.binaryDisplayConfig')}</div>
-          <div className={style['history-advanced-set-item-cont']}>
-            <div className={style['backgroundRefresh']}>
-              <YakitCheckbox
-                checked={binaryDisplayEnabled}
-                onChange={(e) => {
-                  setBinaryDisplayEnabled(e.target.checked)
-                }}
-              />
-              <span className={style['title-style']}>{t('AdvancedSet.binaryDisplayModal')}</span>
-              <Tooltip title={t('AdvancedSet.binaryDisplayModalTip')}>
                 <OutlineInformationcircleIcon className={style['hint-style']} />
               </Tooltip>
             </div>

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/BinaryFuzztagModal.module.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/BinaryFuzztagModal.module.scss
@@ -90,6 +90,7 @@
 }
 
 .hex-toolbar-label {
+  color: var(--Colors-Use-Neutral-Text-1-Title);
   font-size: 12px;
 }
 

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/__test__/binaryFuzztag.test.ts
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/__test__/binaryFuzztag.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import {
   BINARY_FOLD_THRESHOLD,
   buildChipLabel,
@@ -11,7 +11,156 @@ import {
   goUnquoteToBytes,
   bytesToHex,
   packetTextToRawBytes,
+  rawBytesToPacketText,
+  bytesToUnquoteString,
+  strQuoteBytesViaCodec,
 } from '../binaryFuzztag'
+
+const HEX_DIGITS = '0123456789abcdef'
+
+/** 独立参考实现：模拟 Go strconv.Quote 对原始字节的转义（用于对照 Codec StrQuote） */
+const referenceGoStrconvQuoteBytes = (bytes: Uint8Array): string => {
+  let quoted = '"'
+  for (let i = 0; i < bytes.length; ) {
+    const b = bytes[i] & 0xff
+    let rune = b
+    let width = 1
+
+    if (b >= 0xc0) {
+      const decoded = decodeUtf8RuneAt(bytes, i)
+      if (decoded) {
+        rune = decoded.rune
+        width = decoded.width
+      }
+    }
+
+    if (width === 1 && b >= 0x80) {
+      quoted += `\\x${HEX_DIGITS[b >> 4]}${HEX_DIGITS[b & 0x0f]}`
+      i += 1
+      continue
+    }
+
+    if (rune === 0x07) quoted += '\\a'
+    else if (rune === 0x08) quoted += '\\b'
+    else if (rune === 0x0c) quoted += '\\f'
+    else if (rune === 0x0a) quoted += '\\n'
+    else if (rune === 0x0d) quoted += '\\r'
+    else if (rune === 0x09) quoted += '\\t'
+    else if (rune === 0x0b) quoted += '\\v'
+    else if (rune === 0x5c) quoted += '\\\\'
+    else if (rune === 0x22) quoted += '\\"'
+    else if (rune >= 0x20 && rune < 0x7f) quoted += String.fromCharCode(rune)
+    else if (width === 1 && rune < 0x20) {
+      quoted += `\\x${HEX_DIGITS[b >> 4]}${HEX_DIGITS[b & 0x0f]}`
+    } else if (rune > 0xffff) {
+      quoted += `\\U${rune.toString(16).padStart(8, '0')}`
+    } else if (rune > 0x7e || rune < 0x20) {
+      quoted += `\\u${rune.toString(16).padStart(4, '0')}`
+    } else {
+      quoted += String.fromCodePoint(rune)
+    }
+    i += width
+  }
+  return `${quoted}"`
+}
+
+const decodeUtf8RuneAt = (bytes: Uint8Array, index: number): { rune: number; width: number } | null => {
+  const b0 = bytes[index] & 0xff
+  if (b0 < 0x80) {
+    return { rune: b0, width: 1 }
+  }
+  if ((b0 & 0xe0) === 0xc0 && index + 1 < bytes.length) {
+    const b1 = bytes[index + 1] & 0xff
+    if ((b1 & 0xc0) === 0x80) {
+      return { rune: ((b0 & 0x1f) << 6) | (b1 & 0x3f), width: 2 }
+    }
+  }
+  if ((b0 & 0xf0) === 0xe0 && index + 2 < bytes.length) {
+    const b1 = bytes[index + 1] & 0xff
+    const b2 = bytes[index + 2] & 0xff
+    if ((b1 & 0xc0) === 0x80 && (b2 & 0xc0) === 0x80) {
+      return { rune: ((b0 & 0x0f) << 12) | ((b1 & 0x3f) << 6) | (b2 & 0x3f), width: 3 }
+    }
+  }
+  if ((b0 & 0xf8) === 0xf0 && index + 3 < bytes.length) {
+    const b1 = bytes[index + 1] & 0xff
+    const b2 = bytes[index + 2] & 0xff
+    const b3 = bytes[index + 3] & 0xff
+    if ((b1 & 0xc0) === 0x80 && (b2 & 0xc0) === 0x80 && (b3 & 0xc0) === 0x80) {
+      return {
+        rune: ((b0 & 0x07) << 18) | ((b1 & 0x3f) << 12) | ((b2 & 0x3f) << 6) | (b3 & 0x3f),
+        width: 4,
+      }
+    }
+  }
+  return null
+}
+
+const hexToBytes = (hex: string): Uint8Array => {
+  const normalized = hex.replace(/\s+/g, '')
+  const arr = new Uint8Array(normalized.length / 2)
+  for (let i = 0; i < arr.length; i++) {
+    arr[i] = parseInt(normalized.substr(i * 2, 2), 16) & 0xff
+  }
+  return arr
+}
+
+const mockNewCodec = ({ Text, WorkFlow }: { Text: string; WorkFlow: { CodecType: string }[] }) => {
+  let result = Text
+  let rawResult: Uint8Array = new Uint8Array()
+  for (const step of WorkFlow) {
+    if (step.CodecType === 'HexDecode') {
+      rawResult = new Uint8Array(hexToBytes(result))
+      result = String.fromCharCode(...rawResult)
+    } else if (step.CodecType === 'StrQuote') {
+      result = referenceGoStrconvQuoteBytes(rawResult)
+    }
+  }
+  return { Result: result, RawResult: rawResult }
+}
+
+const bytesEqual = (a: Uint8Array, b: Uint8Array) => {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+const binaryQuoteCases: { name: string; bytes: number[] }[] = [
+  { name: 'empty', bytes: [] },
+  { name: 'printable ascii', bytes: [0x41, 0x62, 0x63, 0x20, 0x7e] },
+  { name: 'control chars', bytes: [0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d] },
+  { name: 'quote and backslash', bytes: [0x09, 0x22, 0xff] },
+  { name: 'jpeg-like header', bytes: [0xff, 0xd8, 0xff, 0x00, 0x41] },
+  { name: 'http binary body', bytes: [0x09, 0xe2, 0x51, 0x68] },
+  { name: 'all high bytes', bytes: [0x80, 0xfe, 0xff] },
+  { name: 'null and low bytes', bytes: [0x00, 0x01, 0x1f] },
+]
+
+let originalRequire: typeof window.require | undefined
+
+beforeEach(() => {
+  originalRequire = (window as any).require
+  ;(window as any).require = () => ({
+    ipcRenderer: {
+      invoke: async (channel: string, params: { Text: string; WorkFlow: { CodecType: string }[] }) => {
+        if (channel !== 'NewCodec') {
+          throw new Error(`unexpected ipc channel: ${channel}`)
+        }
+        return mockNewCodec(params)
+      },
+    },
+  })
+})
+
+afterEach(() => {
+  if (originalRequire) {
+    ;(window as any).require = originalRequire
+  } else {
+    delete (window as any).require
+  }
+})
 
 const bigUnquoteContent = '"' + '\\xff\\xd8'.repeat(40) + '"' // 远大于阈值
 const bigUnquoteTag = `{{unquote(${bigUnquoteContent})}}`
@@ -275,5 +424,55 @@ describe('packetTextToRawBytes', () => {
 
   it('解码 hexdecode 标签', () => {
     expect(Array.from(packetTextToRawBytes('{{hexd(09e25168)}}'))).toEqual([0x09, 0xe2, 0x51, 0x68])
+  })
+})
+
+describe('rawBytesToPacketText', () => {
+  it('可打印 HTTP 包直接还原为文本', () => {
+    const text = 'POST / HTTP/1.1\r\nHost: a\r\n\r\n{"a":1}'
+    expect(rawBytesToPacketText(new TextEncoder().encode(text))).toBe(text)
+  })
+
+  it('二进制 body 写回为 unquote 标签', () => {
+    const header = new TextEncoder().encode('POST / HTTP/1.1\r\n\r\n')
+    const body = new Uint8Array([0x09, 0xe2, 0x51, 0x68])
+    const bytes = new Uint8Array(header.length + body.length)
+    bytes.set(header, 0)
+    bytes.set(body, header.length)
+    const packet = rawBytesToPacketText(bytes)
+    expect(packet.startsWith('POST / HTTP/1.1\r\n\r\n{{unquote(')).toBe(true)
+    expect(Array.from(packetTextToRawBytes(packet).slice(header.length))).toEqual([0x09, 0xe2, 0x51, 0x68])
+  })
+
+  it('bytesToUnquoteString 生成合法转义', () => {
+    expect(bytesToUnquoteString(new Uint8Array([0x09, 0x22, 0xff]))).toBe('"\\t\\"\\xff"')
+  })
+})
+
+describe('bytesToUnquoteString vs runCodec(StrQuote)', () => {
+  for (const { name, bytes: byteList } of binaryQuoteCases) {
+    it(`本地编码与 Codec StrQuote 一致: ${name}`, async () => {
+      const bytes = new Uint8Array(byteList)
+      const local = bytesToUnquoteString(bytes)
+      const viaCodec = await strQuoteBytesViaCodec(bytes)
+      const reference = referenceGoStrconvQuoteBytes(bytes)
+
+      expect(local).toBe(viaCodec)
+      expect(local).toBe(reference)
+    })
+
+    it(`双向 round-trip 一致: ${name}`, async () => {
+      const bytes = new Uint8Array(byteList)
+      const localQuoted = bytesToUnquoteString(bytes)
+      const codecQuoted = await strQuoteBytesViaCodec(bytes)
+
+      expect(bytesEqual(goUnquoteToBytes(localQuoted), bytes)).toBe(true)
+      expect(bytesEqual(goUnquoteToBytes(codecQuoted), bytes)).toBe(true)
+    })
+  }
+
+  it('大体积 unquote 内容与 Codec 路径一致', async () => {
+    const bytes = goUnquoteToBytes(bigUnquoteContent)
+    expect(bytesToUnquoteString(bytes)).toBe(await strQuoteBytesViaCodec(bytes))
   })
 })

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/__test__/binaryFuzztag.test.ts
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/__test__/binaryFuzztag.test.ts
@@ -10,6 +10,7 @@ import {
   findPlaceholderOffsets,
   goUnquoteToBytes,
   bytesToHex,
+  packetTextToRawBytes,
 } from '../binaryFuzztag'
 
 const bigUnquoteContent = '"' + '\\xff\\xd8'.repeat(40) + '"' // 远大于阈值
@@ -260,5 +261,19 @@ describe('buildChipLabel', () => {
 describe('bytesToHex', () => {
   it('字节转 hex', () => {
     expect(bytesToHex(new Uint8Array([0, 255, 16]))).toBe('00ff10')
+  })
+})
+
+describe('packetTextToRawBytes', () => {
+  it('解码 unquote 后得到真实二进制字节', () => {
+    const packet = 'POST / HTTP/1.1\r\n\r\n{{unquote("\\x09\\xe2\\x51\\x68")}}'
+    const bytes = packetTextToRawBytes(packet)
+    const prefix = new TextEncoder().encode('POST / HTTP/1.1\r\n\r\n')
+    expect(Array.from(bytes.slice(0, prefix.length))).toEqual(Array.from(prefix))
+    expect(Array.from(bytes.slice(prefix.length))).toEqual([0x09, 0xe2, 0x51, 0x68])
+  })
+
+  it('解码 hexdecode 标签', () => {
+    expect(Array.from(packetTextToRawBytes('{{hexd(09e25168)}}'))).toEqual([0x09, 0xe2, 0x51, 0x68])
   })
 })

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/binaryFuzztag.ts
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/binaryFuzztag.ts
@@ -433,6 +433,91 @@ export const packetTextToRawBytes = (raw: string): Uint8Array => {
   return out
 }
 
+export const bytesToUnquoteString = (bytes: Uint8Array | number[]): string => {
+  let s = '"'
+  for (let i = 0; i < bytes.length; i++) {
+    const b = bytes[i] & 0xff
+    switch (b) {
+      case 0x07:
+        s += '\\a'
+        break
+      case 0x08:
+        s += '\\b'
+        break
+      case 0x09:
+        s += '\\t'
+        break
+      case 0x0a:
+        s += '\\n'
+        break
+      case 0x0b:
+        s += '\\v'
+        break
+      case 0x0c:
+        s += '\\f'
+        break
+      case 0x0d:
+        s += '\\r'
+        break
+      case 0x22:
+        s += '\\"'
+        break
+      case 0x5c:
+        s += '\\\\'
+        break
+      default:
+        s += b >= 0x20 && b <= 0x7e ? String.fromCharCode(b) : `\\x${b.toString(16).padStart(2, '0')}`
+        break
+    }
+  }
+  return `${s}"`
+}
+
+const findHeaderBodySplit = (bytes: Uint8Array): number => {
+  for (let i = 0; i + 3 < bytes.length; i++) {
+    if (bytes[i] === 0x0d && bytes[i + 1] === 0x0a && bytes[i + 2] === 0x0d && bytes[i + 3] === 0x0a) {
+      return i + 4
+    }
+  }
+  for (let i = 0; i + 1 < bytes.length; i++) {
+    if (bytes[i] === 0x0a && bytes[i + 1] === 0x0a) {
+      return i + 2
+    }
+  }
+  return -1
+}
+
+/**
+ * HEX 编辑后的真实字节写回请求文本：
+ * - 整体可安全 UTF-8 展示时直接还原文本
+ * - 否则按 header/body 拆分，body 不可打印时包成 {{unquote(...)}}
+ */
+export const rawBytesToPacketText = (bytes: Uint8Array): string => {
+  if (!bytes || bytes.length === 0) {
+    return ''
+  }
+  const whole = bytesToDisplayText(bytes)
+  if (whole !== undefined && !whole.includes('{{')) {
+    return whole
+  }
+
+  const split = findHeaderBodySplit(bytes)
+  if (split < 0) {
+    return `{{unquote(${bytesToUnquoteString(bytes)})}}`
+  }
+
+  const headerText = new TextDecoder('utf-8', { fatal: false }).decode(bytes.slice(0, split))
+  const bodyBytes = bytes.slice(split)
+  if (bodyBytes.length === 0) {
+    return headerText
+  }
+  const bodyText = bytesToDisplayText(bodyBytes)
+  if (bodyText !== undefined && !bodyText.includes('{{')) {
+    return headerText + bodyText
+  }
+  return `${headerText}{{unquote(${bytesToUnquoteString(bodyBytes)})}}`
+}
+
 const placeholderRegex = () => /\{\{([\w:]+)\(#YBIN_([0-9a-f]+)#\)\}\}/g
 
 // 展开：占位文本 -> 真实文本
@@ -702,17 +787,23 @@ export const decodeBinaryTag = async (entry: BinaryFuzztagEntry): Promise<Uint8A
 }
 
 // 字节 -> 完整标签文本（按原标签类型重新编码）
+/** 测试/对照用：经 Codec HexDecode + StrQuote 生成带引号的 unquote 参数字符串 */
+export const strQuoteBytesViaCodec = async (bytes: Uint8Array): Promise<string> => {
+  const hex = bytesToHex(bytes)
+  const rsp = await runCodec(hex, [
+    { CodecType: 'HexDecode', Params: [] },
+    { CodecType: 'StrQuote', Params: [] },
+  ])
+  return rsp.Result
+}
+
 export const encodeBytesToTag = async (kind: BinaryTagKind, tagName: string, bytes: Uint8Array): Promise<string> => {
   const hex = bytesToHex(bytes)
   if (kind === 'hex') {
     return `{{${tagName}(${hex})}}`
   }
   if (kind === 'unquote') {
-    const rsp = await runCodec(hex, [
-      { CodecType: 'HexDecode', Params: [] },
-      { CodecType: 'StrQuote', Params: [] },
-    ])
-    return `{{${tagName}(${rsp.Result})}}`
+    return `{{${tagName}(${bytesToUnquoteString(bytes)})}}`
   }
   if (kind === 'base64') {
     const rsp = await runCodec(hex, [

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/binaryFuzztag.ts
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/binaryFuzztag.ts
@@ -356,6 +356,83 @@ export const collapseBinaryFuzztag = (raw: string): BinaryCollapseResult => {
   return { text: resultParts.join(''), entries }
 }
 
+/**
+ * 将含二进制 Fuzztag 的请求/响应文本解码为真实字节，供 HEX 视图使用。
+ * unquote / hexdecode / base64decode 会解码；file 与普通文本按 UTF-8 保留。
+ */
+export const packetTextToRawBytes = (raw: string): Uint8Array => {
+  if (!raw) {
+    return new Uint8Array()
+  }
+
+  const chunks: Uint8Array[] = []
+  const pushText = (s: string) => {
+    if (s) {
+      chunks.push(new TextEncoder().encode(s))
+    }
+  }
+  const pushBytes = (bytes: Uint8Array) => {
+    if (bytes.length) {
+      chunks.push(bytes)
+    }
+  }
+
+  let i = 0
+  const len = raw.length
+  while (i < len) {
+    const openIdx = raw.indexOf('{{', i)
+    if (openIdx === -1) {
+      pushText(raw.slice(i))
+      break
+    }
+    pushText(raw.slice(i, openIdx))
+
+    // 是否二进制标签以 parseTag 为准；普通 {{ 或未知标签按原文 UTF-8 保留
+    const parsed = parseTag(raw, openIdx)
+    if (!parsed) {
+      pushText(raw.slice(openIdx, openIdx + 2))
+      i = openIdx + 2
+      continue
+    }
+
+    const { tagName, content, endIndex } = parsed
+    const fullTag = raw.slice(openIdx, endIndex)
+    const kind = TAG_NAME_KIND[tagName.toLowerCase()]
+    if (!kind || kind === 'file') {
+      pushText(fullTag)
+      i = endIndex
+      continue
+    }
+
+    if (kind === 'unquote') {
+      pushBytes(goUnquoteToBytes(content))
+    } else if (kind === 'hex') {
+      const stripped = content.replace(/\s+/g, '')
+      pushBytes(hexHeadToBytes(stripped, stripped.length))
+    } else if (kind === 'base64') {
+      try {
+        const stripped = content.replace(/\s+/g, '')
+        pushBytes(Uint8Array.from(strToByteArray(atob(stripped))))
+      } catch (e) {
+        pushText(fullTag)
+      }
+    }
+    i = endIndex
+  }
+
+  let total = 0
+  for (const c of chunks) {
+    total += c.length
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const c of chunks) {
+    out.set(c, offset)
+    offset += c.length
+  }
+  return out
+}
+
 const placeholderRegex = () => /\{\{([\w:]+)\(#YBIN_([0-9a-f]+)#\)\}\}/g
 
 // 展开：占位文本 -> 真实文本

--- a/app/renderer/src/main/src/pages/fuzzer/HTTPFuzzerPage.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HTTPFuzzerPage.tsx
@@ -894,7 +894,7 @@ const HTTPFuzzerPageCore: React.FC<HTTPFuzzerPageProp> = (props) => {
 
   const [hex, setHex] = useState<boolean>(false)
   const [privacy, setPrivacy] = useState(false)
-  const [foldBinaryFuzztag, setFoldBinaryFuzztag] = useState(true)
+  const foldBinaryFuzztag = true
 
   const hotPatchCodeRef = useRef<string>(initWebFuzzerPageInfo().hotPatchCode)
   const hotPatchCodeWithParamGetterRef = useRef<string>('')
@@ -2044,12 +2044,6 @@ const HTTPFuzzerPageCore: React.FC<HTTPFuzzerPageProp> = (props) => {
                   {t('YakitButton.privacy_mode')}&nbsp;
                   <YakitSwitch checked={privacy} onChange={setPrivacy} />
                 </div>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <Tooltip title={t('HTTPFuzzerPage.binaryDisplayTip')}>
-                    <span>{t('HTTPFuzzerPage.binaryDisplay')}</span>
-                  </Tooltip>
-                  <YakitSwitch checked={foldBinaryFuzztag} onChange={setFoldBinaryFuzztag} />
-                </div>
                 <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                   HEX
                   <YakitSwitch checked={hex} onChange={setHex} />
@@ -2064,11 +2058,6 @@ const HTTPFuzzerPageCore: React.FC<HTTPFuzzerPageProp> = (props) => {
             <YakitCheckableTag checked={privacy} onChange={setPrivacy} style={{ marginRight: 0 }}>
               {t('YakitButton.privacy_mode')}
             </YakitCheckableTag>
-            <Tooltip title={t('HTTPFuzzerPage.binaryDisplayTip')}>
-              <YakitCheckableTag checked={foldBinaryFuzztag} onChange={setFoldBinaryFuzztag} style={{ marginRight: 0 }}>
-                {t('HTTPFuzzerPage.binaryDisplay')}
-              </YakitCheckableTag>
-            </Tooltip>
             <YakitCheckableTag checked={hex} onChange={setHex} style={{ marginRight: 0 }}>
               HEX
             </YakitCheckableTag>
@@ -4407,7 +4396,7 @@ export const ResponseViewer: React.FC<ResponseViewerProps> = React.memo(
       onSetOnlyOneResEditor,
       loading,
       pageId,
-      foldBinaryFuzztag = false,
+      foldBinaryFuzztag = true,
     } = props
     const { t, i18n } = useI18nNamespaces(['webFuzzer'])
 

--- a/app/renderer/src/main/src/pages/fuzzer/WebFuzzerNewEditor/WebFuzzerNewEditor.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/WebFuzzerNewEditor/WebFuzzerNewEditor.tsx
@@ -53,7 +53,7 @@ export const WebFuzzerNewEditor: React.FC<WebFuzzerNewEditorProps> = React.memo(
       oneResponseValue,
       hex,
       privacy,
-      foldBinaryFuzztag = false,
+      foldBinaryFuzztag = true,
     } = props
     const { t, i18n } = useI18nNamespaces(['webFuzzer'])
     const [reqEditor, setReqEditor] = useState<IMonacoEditor>()

--- a/app/renderer/src/main/src/store/binaryDisplayEnabled.ts
+++ b/app/renderer/src/main/src/store/binaryDisplayEnabled.ts
@@ -1,49 +1,22 @@
 import { useSyncExternalStore } from 'react'
 import { RemoteHistoryGV } from '@/enums/history'
-import { getRemoteValue, setRemoteValue } from '@/utils/kv'
+import { setRemoteValue } from '@/utils/kv'
 import { createExternalStore } from '@/utils/createExternalStore'
 
 const DEFAULT_BINARY_DISPLAY_ENABLED = true
 
 const store = createExternalStore(DEFAULT_BINARY_DISPLAY_ENABLED)
 
-const parseRemoteBinaryDisplayEnabled = (value?: string | null) => {
-  if (value === 'false') return false
-  return DEFAULT_BINARY_DISPLAY_ENABLED
-}
-
-let hydrated = false
-let hydrating: Promise<void> | null = null
-
-const hydrateFromRemote = () => {
-  if (hydrated) return Promise.resolve()
-  if (hydrating) return hydrating
-  hydrating = getRemoteValue(RemoteHistoryGV.BinaryDisplayEnabled)
-    .then((value) => {
-      if (!hydrated) {
-        store.setSnapshot(() => parseRemoteBinaryDisplayEnabled(value))
-      }
-      hydrated = true
-    })
-    .catch(() => {
-      hydrated = true
-    })
-    .finally(() => {
-      hydrating = null
-    })
-  return hydrating
-}
+void setRemoteValue(RemoteHistoryGV.BinaryDisplayEnabled, 'true')
 
 export const binaryDisplayEnabledStore = {
   subscribe(listener: () => void) {
-    void hydrateFromRemote()
     return store.subscribe(listener)
   },
   getSnapshot: store.getSnapshot,
-  setEnabled(enabled: boolean) {
-    store.setSnapshot(() => enabled)
-    hydrated = true
-    void setRemoteValue(RemoteHistoryGV.BinaryDisplayEnabled, enabled ? 'true' : 'false')
+  setEnabled(_enabled: boolean) {
+    store.setSnapshot(() => DEFAULT_BINARY_DISPLAY_ENABLED)
+    void setRemoteValue(RemoteHistoryGV.BinaryDisplayEnabled, 'true')
   },
 }
 

--- a/app/renderer/src/main/src/utils/editors.tsx
+++ b/app/renderer/src/main/src/utils/editors.tsx
@@ -16,6 +16,7 @@ import ReactResizeDetector from 'react-resize-detector'
 import { useControllableValue, useDebounceFn, useMemoizedFn, useSize, useUpdateEffect } from 'ahooks'
 import { Buffer } from 'buffer'
 import { StringToUint8Array, Uint8ArrayToString } from './str'
+import { packetTextToRawBytes } from '@/components/yakitUI/YakitEditor/binaryFuzztag'
 import { getRemoteValue } from '@/utils/kv'
 import { editor, IPosition, IRange } from 'monaco-editor'
 import { ConvertYakStaticAnalyzeErrorToMarker, YakStaticAnalyzeErrorResult } from '@/utils/editorMarkers'
@@ -719,7 +720,7 @@ export const NewHTTPPacketEditor: React.FC<NewHTTPPacketEditorProp> = React.memo
   )
   useEffect(() => {
     if (!noShowHex) {
-      setHexValue(originalPackage ? originalPackage : StringToUint8Array(originValue))
+      setHexValue(originalPackage && originalPackage.length > 0 ? originalPackage : packetTextToRawBytes(originValue))
     }
   }, [noShowHex, originValue, originalPackage])
 
@@ -946,7 +947,7 @@ export const NewHTTPPacketEditor: React.FC<NewHTTPPacketEditorProp> = React.memo
         renderCode()
       } else if (type === 'hex') {
         setRenderHTML(undefined)
-        setHexValue(originalPackage ? originalPackage : StringToUint8Array(originValue))
+        setHexValue(originalPackage && originalPackage.length > 0 ? originalPackage : packetTextToRawBytes(originValue))
       }
     } else {
       setShowValue('')

--- a/app/renderer/src/main/src/utils/editors.tsx
+++ b/app/renderer/src/main/src/utils/editors.tsx
@@ -1,8 +1,6 @@
 import React, { ReactElement, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import MonacoEditor, { monaco } from 'react-monaco-editor'
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api'
-import HexEditor from 'react-hex-editor'
-import oneDarkPro from 'react-hex-editor/themes/oneDarkPro'
 // yak register
 import './monacoSpec/theme'
 import './monacoSpec/fuzzHTTPMonacoSpec'
@@ -16,7 +14,8 @@ import ReactResizeDetector from 'react-resize-detector'
 import { useControllableValue, useDebounceFn, useMemoizedFn, useSize, useUpdateEffect } from 'ahooks'
 import { Buffer } from 'buffer'
 import { StringToUint8Array, Uint8ArrayToString } from './str'
-import { packetTextToRawBytes } from '@/components/yakitUI/YakitEditor/binaryFuzztag'
+import { packetTextToRawBytes, rawBytesToPacketText } from '@/components/yakitUI/YakitEditor/binaryFuzztag'
+import { BinaryFuzztagHexEditor } from '@/components/yakitUI/YakitEditor/BinaryFuzztagHexEditor'
 import { getRemoteValue } from '@/utils/kv'
 import { editor, IPosition, IRange } from 'monaco-editor'
 import { ConvertYakStaticAnalyzeErrorToMarker, YakStaticAnalyzeErrorResult } from '@/utils/editorMarkers'
@@ -598,7 +597,6 @@ export const NewHTTPPacketEditor: React.FC<NewHTTPPacketEditorProp> = React.memo
   } = props
   const { t, i18n } = useI18nNamespaces(['history', 'yakitUi'])
   const [strValue, setStrValue] = useState(originValue)
-  const [hexValue, setHexValue] = useState<Uint8Array>(new Uint8Array()) // 只有切换到hex时才会用这个值，目前切换得时候会把最新得编辑器中得值赋值到该变量里面
   const [monacoEditor, setMonacoEditor] = useState<IMonacoEditor>()
   const { fontSize, setFontSize, initFontSize } = useEditorFontSize()
   const [showLineBreaks, setShowLineBreaks] = useState<boolean>(true)
@@ -624,7 +622,6 @@ export const NewHTTPPacketEditor: React.FC<NewHTTPPacketEditorProp> = React.memo
   const [typeOptions, setTypeOptions] = useState<TypeOptionsProps[]>([])
   const [showValue, setShowValue] = useState<string>(originValue)
   const [renderHtml, setRenderHTML] = useState<React.ReactNode>()
-  const { theme } = useTheme()
 
   // 对比loading
   const [compareLoading, setCompareLoading] = useState<boolean>(false)
@@ -652,10 +649,6 @@ export const NewHTTPPacketEditor: React.FC<NewHTTPPacketEditorProp> = React.memo
       }
     } catch (error) {}
   })
-
-  const targetHexTheme = useMemo(() => {
-    return theme === 'dark' ? { hexEditor: oneDarkPro } : undefined
-  }, [theme])
 
   useEffect(() => {
     if (editorOperationRecord) {
@@ -707,22 +700,51 @@ export const NewHTTPPacketEditor: React.FC<NewHTTPPacketEditorProp> = React.memo
   /*如何实现 monaco editor 高亮？*/
   // https://microsoft.github.io/monaco-editor/playground.html#interacting-with-the-editor-line-and-inline-decorations
 
-  // hex editor
-  const [nonce, setNonce] = useState(0)
-  // The callback facilitates updates to the source data.
-  const handleSetValue = React.useCallback(
-    (offset, value) => {
-      hexValue[offset] = value
-      setNonce((v) => v + 1)
-      setHexValue(value)
-    },
-    [hexValue],
-  )
-  useEffect(() => {
-    if (!noShowHex) {
-      setHexValue(originalPackage && originalPackage.length > 0 ? originalPackage : packetTextToRawBytes(originValue))
+  // hex editor：可编辑时复用 BinaryFuzztagHexEditor（顶部插入/替换工具栏，往下顶一行）
+  const hexDataRef = useRef<Uint8Array>(new Uint8Array())
+  const [hexMountKey, setHexMountKey] = useState(0)
+  const showHexView = type === 'hex' || !noShowHex
+
+  const getHexBytesFromOrigin = useMemoizedFn(() => {
+    return originalPackage && originalPackage.length > 0
+      ? new Uint8Array(originalPackage)
+      : packetTextToRawBytes(originValue)
+  })
+
+  const bytesEqual = useMemoizedFn((a: Uint8Array, b: Uint8Array) => {
+    if (a.length !== b.length) {
+      return false
     }
-  }, [noShowHex, originValue, originalPackage])
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) {
+        return false
+      }
+    }
+    return true
+  })
+
+  const syncHexFromOrigin = useMemoizedFn(() => {
+    const next = getHexBytesFromOrigin()
+    if (bytesEqual(next, hexDataRef.current)) {
+      return
+    }
+    hexDataRef.current = next
+    setHexMountKey((k) => k + 1)
+  })
+
+  useEffect(() => {
+    if (!showHexView) {
+      return
+    }
+    syncHexFromOrigin()
+  }, [showHexView, originValue, originalPackage, syncHexFromOrigin])
+
+  const handleHexEditorChange = useMemoizedFn(() => {
+    if (props.readOnly) {
+      return
+    }
+    setStrValue(rawBytesToPacketText(hexDataRef.current))
+  })
 
   const openCompareModal = useMemoizedFn((dataCompare: DataCompareProps) => {
     setCompareLoading(true)
@@ -947,7 +969,7 @@ export const NewHTTPPacketEditor: React.FC<NewHTTPPacketEditorProp> = React.memo
         renderCode()
       } else if (type === 'hex') {
         setRenderHTML(undefined)
-        setHexValue(originalPackage && originalPackage.length > 0 ? originalPackage : packetTextToRawBytes(originValue))
+        syncHexFromOrigin()
       }
     } else {
       setShowValue('')
@@ -1198,18 +1220,12 @@ export const NewHTTPPacketEditor: React.FC<NewHTTPPacketEditorProp> = React.memo
                     {...props.extraEditorProps}
                   />
                 )}
-                {(type === 'hex' || !noShowHex) && !empty && !renderHtml && !props.renderHtml && (
-                  <HexEditor
-                    style={{ fontSize: (fontSize || 12) === 12 ? 16 : fontSize === 16 ? 18 : 20 }}
-                    readOnly={true}
-                    asciiWidth={18}
-                    data={hexValue}
-                    overscanCount={0x03}
-                    showAscii={true}
-                    showColumnLabels={false}
-                    showRowLabels={true}
-                    highlightColumn={true}
-                    theme={targetHexTheme}
+                {showHexView && !empty && !renderHtml && !props.renderHtml && (
+                  <BinaryFuzztagHexEditor
+                    key={hexMountKey}
+                    dataRef={hexDataRef}
+                    readOnly={!!props.readOnly}
+                    onChange={handleHexEditorChange}
                   />
                 )}
               </div>


### PR DESCRIPTION
将导航栏中「导入资源」的文案改为「导入插件/流量」，更准确地反映该按钮下提供的两个导入选项（插件导入和流量导入）。

改动涉及三个语言文件：
- `zh/yakitUi.json`: 导入资源 → 导入插件/流量
- `en/yakitUi.json`: Import Resource → Import Plugin/Traffic
- `zh-TW/yakitUi.json`: 匯入資源 → 匯入外掛/流量