### PR TITLE
chore(i18n): 导航栏导入资源文案改为导入插件/流量

### DIFF
--- a/app/renderer/src/main/public/locales/en/yakitUi.json
+++ b/app/renderer/src/main/public/locales/en/yakitUi.json
@@ -17,7 +17,7 @@
     "added": "Added",
     "add_new": "Add New",
     "import": "Import",
-    "importResources": "Import Resource",
+    "importResources": "Import Plugin/Traffic",
     "importPlugin": "Import Plugin",
     "export": "Export",
     "batchExport": "Batch Export",

--- a/app/renderer/src/main/public/locales/zh-TW/yakitUi.json
+++ b/app/renderer/src/main/public/locales/zh-TW/yakitUi.json
@@ -17,7 +17,7 @@
     "added": "已新增",
     "add_new": "新增",
     "import": "匯入",
-    "importResources": "匯入資源",
+    "importResources": "匯入外掛/流量",
     "importPlugin": "匯入外掛",
     "export": "匯出",
     "batchExport": "批次匯出",

--- a/app/renderer/src/main/public/locales/zh/yakitUi.json
+++ b/app/renderer/src/main/public/locales/zh/yakitUi.json
@@ -17,7 +17,7 @@
     "added": "已添加",
     "add_new": "新增",
     "import": "导入",
-    "importResources": "导入资源",
+    "importResources": "导入插件/流量",
     "importPlugin": "导入插件",
     "export": "导出",
     "batchExport": "批量导出",


### PR DESCRIPTION
将导航栏中「导入资源」的文案改为「导入插件/流量」，更准确地反映该按钮下提供的两个导入选项（插件导入和流量导入）。

改动涉及三个语言文件：
- `zh/yakitUi.json`: 导入资源 → 导入插件/流量
- `en/yakitUi.json`: Import Resource → Import Plugin/Traffic
- `zh-TW/yakitUi.json`: 匯入資源 → 匯入外掛/流量