### PR TITLE
fix: 修复 YakitCheckbox 透传 wrapperClassName、AI 消息处理条件判断逻辑及 FilterPopoverBtn 表单初始化时机

### DIFF
--- a/app/renderer/engine-link-startup/src/components/yakitUI/YakitCheckbox/YakitCheckbox.tsx
+++ b/app/renderer/engine-link-startup/src/components/yakitUI/YakitCheckbox/YakitCheckbox.tsx
@@ -17,7 +17,7 @@ import './yakitCheckBoxAnimation.scss'
  * @param {string} wrapperClassName
  */
 export const YakitCheckbox: React.FC<YakitCheckboxProps> = (props) => {
-  const { wrapperClassName } = props
+  const { wrapperClassName, ...restProps } = props
   return props.children ? (
     <span
       className={classNames(
@@ -26,11 +26,11 @@ export const YakitCheckbox: React.FC<YakitCheckboxProps> = (props) => {
         wrapperClassName,
       )}
     >
-      <Checkbox {...props}>{props.children}</Checkbox>
+      <Checkbox {...restProps}>{props.children}</Checkbox>
     </span>
   ) : (
     <span className={classNames(styles['yakit-checkbox-wrapper'], wrapperClassName)}>
-      <Checkbox {...props} />
+      <Checkbox {...restProps} />
     </span>
   )
 }

--- a/app/renderer/src/main/src/components/yakitUI/YakitCheckbox/YakitCheckbox.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitCheckbox/YakitCheckbox.tsx
@@ -17,7 +17,7 @@ import './yakitCheckBoxAnimation.scss'
  * @param {string} wrapperClassName
  */
 export const YakitCheckbox: React.FC<YakitCheckboxProps> = (props) => {
-  const { wrapperClassName } = props
+  const { wrapperClassName, ...restProps } = props
   return props.children ? (
     <span
       className={classNames(
@@ -26,11 +26,11 @@ export const YakitCheckbox: React.FC<YakitCheckboxProps> = (props) => {
         wrapperClassName,
       )}
     >
-      <Checkbox {...props}>{props.children}</Checkbox>
+      <Checkbox {...restProps}>{props.children}</Checkbox>
     </span>
   ) : (
     <span className={classNames(styles['yakit-checkbox-wrapper'], wrapperClassName)}>
-      <Checkbox {...props} />
+      <Checkbox {...restProps} />
     </span>
   )
 }

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcAIMessageHandlers.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcAIMessageHandlers.ts
@@ -571,7 +571,7 @@ const handleCurrentTaskTodoListUpdate: AIMessageHandler = (request) => {
 const handleCapabilityInventory: AIMessageHandler = (request) => {
   const { res, info, getChatDataStore, getTaskId } = request
   if (!res.TaskId) return
-  if (res.Type !== 'structured' && res.NodeId !== 'capability_inventory') return
+  if (res.Type !== 'structured' || res.NodeId !== 'capability_inventory') return
 
   const chatStore = getChatDataStore?.()
   if (!chatStore) return
@@ -695,7 +695,7 @@ const handleCapabilityInventory: AIMessageHandler = (request) => {
 const handlePerception: AIMessageHandler = (request) => {
   const { res, info, getChatDataStore, getTaskId } = request
   if (!res.TaskId) return
-  if (res.Type !== 'perception' && res.NodeId !== 'perception') return
+  if (res.Type !== 'perception' || res.NodeId !== 'perception') return
   const chatStore = getChatDataStore?.()
   if (!chatStore) return
   const ipcContent = Uint8ArrayToString(res.Content) || ''

--- a/app/renderer/src/main/src/pages/plugins/funcTemplate.tsx
+++ b/app/renderer/src/main/src/pages/plugins/funcTemplate.tsx
@@ -1424,9 +1424,12 @@ export const FilterPopoverBtn: React.FC<FilterPopoverBtnProps> = memo((props) =>
 
   const [form] = Form.useForm()
   useEffect(() => {
-    form.setFieldsValue({ ...defaultFilter })
     onSetIsActive(defaultFilter)
   }, [defaultFilter])
+  useEffect(() => {
+    if (!visible) return
+    form.setFieldsValue({ ...defaultFilter })
+  }, [defaultFilter, visible])
   /**需求：详情的搜索会清除tag，插件组因为已经移出到外面，所以插件组不会被清除 */
   const onFinish = useMemoizedFn((value) => {
     for (let name of excludeFilterName) {


### PR DESCRIPTION
## 修复内容

本 PR 修复了以下问题：

### 1. YakitCheckbox 透传 wrapperClassName
- **文件**：`app/renderer/engine-link-startup/src/components/yakitUI/YakitCheckbox/YakitCheckbox.tsx`、`app/renderer/src/main/src/components/yakitUI/YakitCheckbox/YakitCheckbox.tsx`
- **问题**：`wrapperClassName` 是用于外层 `span` 的自定义属性，但之前通过 `{...props}` 直接透传给了底层 antd `Checkbox` 组件，导致向 DOM 元素传递非标准属性。
- **修复**：解构出 `wrapperClassName`，仅透传 `restProps` 给底层 `Checkbox`。

### 2. AI 消息处理条件判断逻辑错误
- **文件**：`app/renderer/src/main/src/pages/ai-re-act/hooks/grpcAIMessageHandlers.ts`
- **问题**：`handleCapabilityInventory` 与 `handlePerception` 中的早退判断使用了 `&&`：
  ```ts
  if (res.Type !== 'structured' && res.NodeId !== 'capability_inventory') return
  ```
  这表示「两者都不满足才跳过」，与预期（「任一不满足即跳过」）相反，导致逻辑分支被错误进入。
- **修复**：将 `&&` 改为 `||`，使 Type 与 NodeId 必须同时匹配才继续处理。

### 3. FilterPopoverBtn 表单初始化时机
- **文件**：`app/renderer/src/main/src/pages/plugins/funcTemplate.tsx`
- **问题**：`useEffect` 中只要 `defaultFilter` 变化就执行 `form.setFieldsValue`，即便弹层不可见也会覆盖用户在表单中已输入的值。
- **修复**：拆分为两个 `useEffect`，仅在弹层 `visible` 时才执行 `setFieldsValue`，避免不可见时覆盖表单值。

## 合并方式

**请使用 Squash and merge（压缩合并）方式合并。**