### PR TITLE
fix: 修复 handleReactTaskDequeue 改写 token 后 UI 用旧 token 取不到数据的隐藏问题

### DIFF
--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcAIMessageHandlers.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcAIMessageHandlers.ts
@@ -387,15 +387,15 @@ const handleReactTaskDequeue: AIMessageHandler = (request) => {
   if (data.react_task_user_input_uuid) {
     const qsDetail = getContentMap(data.react_task_user_input_uuid)
     if (qsDetail && qsDetail.type === AIChatQSDataTypeEnum.QUESTION) {
-      getChatDataStore()?.casualChat.contents.delete(data.react_task_user_input_uuid)
-      setElements((old) =>
-        old.map((item) => {
-          if (item.token === data.react_task_user_input_uuid) {
-            return { ...item, token: data.react_task_id }
-          }
-          return item
-        }),
-      )
+      // getChatDataStore()?.casualChat.contents.delete(data.react_task_user_input_uuid)
+      // setElements((old) =>
+      //   old.map((item) => {
+      //     if (item.token === data.react_task_user_input_uuid) {
+      //       return { ...item, token: data.react_task_id }
+      //     }
+      //     return item
+      //   }),
+      // )
       return
     }
   }


### PR DESCRIPTION
原逻辑在任务出队时会删除 casualChat.contents 中以 react_task_user_input_uuid 为 key 的内容， 并将 element 的 token 由 react_task_user_input_uuid 改写为 react_task_id。 该数据改写会导致 UI 层仍持有旧 token 时无法从 store 取到对应数据，
先注释掉删除内容与 token 改写逻辑以规避该隐藏问题。