### PR TITLE
fix: handleSend review 在 task 容器内时正确更新 renderNum，并简化 planDetails 更新逻辑

### DIFF
--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcAIMessageHandlers.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcAIMessageHandlers.ts
@@ -543,26 +543,25 @@ const handleCurrentTaskTodoListUpdate: AIMessageHandler = (request) => {
   if (isEmpty(data)) return
 
   const newData = handleTodoListData(data.items, data.task_id)
+  const applyTodoListFields = (target: PlanItemDetailsData) => {
+    target.uuid = uuidv4()
+    target.taskId = target.taskId || res.TaskId
+    target.todoList = newData
+  }
+
   if (info.chatType === 'task') {
     const oldData = chatStore.taskChat.planDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
-    oldData.uuid = uuidv4()
-    oldData.taskId = oldData.taskId || res.TaskId
-    oldData.todoList = newData
+    applyTodoListFields(oldData)
     chatStore.taskChat.planDetailsMap.set(res.TaskId, oldData)
   } else if (info.chatType === 'reAct') {
     const isSubAgentTask = isCasualSubAgentTask(chatStore, res, getTaskId)
+    const chatDetail = isSubAgentTask
+      ? chatStore.casualChat.planDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
+      : chatStore.casualChat?.planDetails
+    if (!chatDetail) return
+    applyTodoListFields(chatDetail)
     if (isSubAgentTask) {
-      const oldData = chatStore.casualChat.planDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
-      oldData.uuid = uuidv4()
-      oldData.taskId = oldData.taskId || res.TaskId
-      oldData.todoList = newData
-      chatStore.casualChat.planDetailsMap.set(res.TaskId, oldData)
-    } else {
-      const chatDetail = chatStore.casualChat?.planDetails
-      if (!chatDetail) return
-      chatDetail.uuid = uuidv4()
-      chatDetail.taskId = chatDetail.taskId || res.TaskId
-      chatDetail.todoList = newData
+      chatStore.casualChat.planDetailsMap.set(res.TaskId, chatDetail)
     }
     callback?.(res)
   }
@@ -656,37 +655,28 @@ const handleCapabilityInventory: AIMessageHandler = (request) => {
   if (!!dynamic?.forges) {
     itemData.forges.dynamic = dynamic.forges
   }
+  const applyCapabilityFields = (target: PlanItemDetailsData) => {
+    target.uuid = itemData.uuid
+    target.taskId = target.taskId || res.TaskId
+    target.tool = itemData.tool
+    target.forges = itemData.forges
+    target.skills = itemData.skills
+    target.plugins = itemData.plugins
+    target.mcp = itemData.mcp
+  }
   if (info.chatType === 'task') {
     const oldData = chatStore.taskChat.planDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
-    oldData.uuid = itemData.uuid
-    oldData.taskId = oldData?.taskId || res.TaskId
-    oldData.tool = itemData.tool
-    oldData.forges = itemData.forges
-    oldData.skills = itemData.skills
-    oldData.plugins = itemData.plugins
-    oldData.mcp = itemData.mcp
+    applyCapabilityFields(oldData)
     chatStore.taskChat.planDetailsMap.set(res.TaskId, oldData)
   } else if (info.chatType === 'reAct') {
     const isSubAgentTask = isCasualSubAgentTask(chatStore, res, getTaskId)
+    const chatDetail = isSubAgentTask
+      ? chatStore.casualChat.planDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
+      : chatStore.casualChat?.planDetails || cloneDeep(DefaultPlanItemDetailsData)
+    applyCapabilityFields(chatDetail)
     if (isSubAgentTask) {
-      const oldData = chatStore.casualChat.planDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
-      oldData.uuid = itemData.uuid
-      oldData.taskId = oldData?.taskId || res.TaskId
-      oldData.tool = itemData.tool
-      oldData.forges = itemData.forges
-      oldData.skills = itemData.skills
-      oldData.plugins = itemData.plugins
-      oldData.mcp = itemData.mcp
-      chatStore.casualChat.planDetailsMap.set(res.TaskId, oldData)
+      chatStore.casualChat.planDetailsMap.set(res.TaskId, chatDetail)
     } else {
-      const chatDetail = chatStore.casualChat?.planDetails || cloneDeep(DefaultPlanItemDetailsData)
-      chatDetail.uuid = itemData.uuid
-      chatDetail.taskId = chatDetail?.taskId || res.TaskId
-      chatDetail.tool = itemData.tool
-      chatDetail.forges = itemData.forges
-      chatDetail.skills = itemData.skills
-      chatDetail.plugins = itemData.plugins
-      chatDetail.mcp = itemData.mcp
       chatStore.casualChat.planDetails = chatDetail
     }
   }
@@ -702,25 +692,24 @@ const handlePerception: AIMessageHandler = (request) => {
   const perception = (JSON.parse(ipcContent) as AIAgentGrpcApi.PerceptionData) || {}
   if (isEmpty(perception)) return
   perception.summary = isArray(perception.summary) ? perception.summary.join(',') : perception.summary
+  const applyPerceptionFields = (target: PlanItemDetailsData) => {
+    target.uuid = uuidv4()
+    target.taskId = target.taskId || res.TaskId
+    target.perception = perception
+  }
   if (info.chatType === 'task') {
     const oldData = chatStore.taskChat.planDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
-    oldData.taskId = oldData?.taskId || res.TaskId
-    oldData.uuid = uuidv4()
-    oldData.perception = perception
+    applyPerceptionFields(oldData)
     chatStore.taskChat.planDetailsMap.set(res.TaskId, oldData)
   } else if (info.chatType === 'reAct') {
     const isSubAgentTask = isCasualSubAgentTask(chatStore, res, getTaskId)
+    const chatDetail = isSubAgentTask
+      ? chatStore.casualChat.planDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
+      : chatStore.casualChat?.planDetails || cloneDeep(DefaultPlanItemDetailsData)
+    applyPerceptionFields(chatDetail)
     if (isSubAgentTask) {
-      const oldData = chatStore.casualChat.planDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
-      oldData.uuid = uuidv4()
-      oldData.taskId = oldData.taskId || res.TaskId
-      oldData.perception = perception
-      chatStore.casualChat.planDetailsMap.set(res.TaskId, oldData)
+      chatStore.casualChat.planDetailsMap.set(res.TaskId, chatDetail)
     } else {
-      const chatDetail = chatStore.casualChat?.planDetails || cloneDeep(DefaultPlanItemDetailsData)
-      chatDetail.uuid = uuidv4()
-      chatDetail.taskId = chatDetail.taskId || res.TaskId
-      chatDetail.perception = perception
       chatStore.casualChat.planDetails = chatDetail
     }
   }
@@ -737,29 +726,25 @@ const handleSessionSnapshot: AIMessageHandler = (request) => {
   const ipcContent = Uint8ArrayToString(res.Content) || ''
   const snapshot = (JSON.parse(ipcContent) as AIAgentGrpcApi.SessionSnapshot) || {}
   if (isEmpty(snapshot)) return
+  const applySnapshotFields = (target: PlanItemDetailsData) => {
+    target.uuid = uuidv4()
+    target.taskId = target.taskId || res.TaskId
+    target.execution = snapshot.execution
+    target.backgroundProcesses = snapshot.background_processes
+  }
   if (info.chatType === 'task') {
     const oldData = chatStore.taskChat.planDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
-    oldData.taskId = oldData?.taskId || res.TaskId
-    oldData.uuid = uuidv4()
-    oldData.execution = snapshot.execution
-    oldData.backgroundProcesses = snapshot.background_processes
-
+    applySnapshotFields(oldData)
     chatStore.taskChat.planDetailsMap.set(res.TaskId, oldData)
   } else if (info.chatType === 'reAct') {
     const isSubAgentTask = isCasualSubAgentTask(chatStore, res, getTaskId)
+    const chatDetail = isSubAgentTask
+      ? chatStore.casualChat.planDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
+      : chatStore.casualChat?.planDetails || cloneDeep(DefaultPlanItemDetailsData)
+    applySnapshotFields(chatDetail)
     if (isSubAgentTask) {
-      const oldData = chatStore.casualChat.planDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
-      oldData.uuid = uuidv4()
-      oldData.taskId = oldData.taskId || res.TaskId
-      oldData.execution = snapshot.execution
-      oldData.backgroundProcesses = snapshot.background_processes
-      chatStore.casualChat.planDetailsMap.set(res.TaskId, oldData)
+      chatStore.casualChat.planDetailsMap.set(res.TaskId, chatDetail)
     } else {
-      const chatDetail = chatStore.casualChat?.planDetails || cloneDeep(DefaultPlanItemDetailsData)
-      chatDetail.uuid = uuidv4()
-      chatDetail.taskId = chatDetail.taskId || res.TaskId
-      chatDetail.execution = snapshot.execution
-      chatDetail.backgroundProcesses = snapshot.background_processes
       chatStore.casualChat.planDetails = chatDetail
     }
   }

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/useCasualChat.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/useCasualChat.ts
@@ -217,12 +217,22 @@ function useCasualChat(params: UseCasualChatParams) {
         review.current = undefined
         setContentMap(chatData.id, chatData)
         setElements((old) => {
-          return old.map((item) => {
-            if (item.token === chatData.id && item.type === chatData.type) {
+          const newArr = old.map((item) => {
+            if (chatData.taskId && item.token === chatData.taskId && item.kind === 'task') {
+              const newChild = item.children.map((subItem) => {
+                if (subItem.token === chatData.id && subItem.type === chatData.type) {
+                  return { ...subItem, renderNum: subItem.renderNum + 1 }
+                }
+                return subItem
+              })
+              return { ...item, children: newChild, renderNum: item.renderNum + 1 }
+            } else if (item.token === chatData.id && item.type === chatData.type) {
               return { ...item, renderNum: item.renderNum + 1 }
+            } else {
+              return item
             }
-            return item
           })
+          return newArr
         })
       }
       cb && cb()


### PR DESCRIPTION
## 背景
在 AI 会话（casualChat / taskChat）中，`planDetails` 相关数据的更新逻辑存在一处 bug 与较多重复代码，本 PR 一并修复与重构。

## 改动内容

### 1. fix: handleSend 中 review 数据位于 task 容器内时正确更新子节点 renderNum
**文件：`useCasualChat.ts`**

- 原 `setElements` 仅按 `chatData.id` 匹配顶层 element。当 review 数据归属于某个 task 容器（`chatData.taskId` 存在）时，顶层 element 的 token 是 `taskId` 而非 `chatData.id`，导致无法命中、子节点 `renderNum` 不更新。
- 新增 task 容器分支：命中 `item.kind === 'task' && token === chatData.taskId` 时，进入 `children` 中匹配 `chatData.id`，并同时 bump 父容器 `renderNum`。
- 行为与 `grpcAIMessageHandlers.bumpRenderItem` 保持一致；其余场景回退到原顶层匹配逻辑。

### 2. refactor: 简化 planDetails 更新逻辑的重复代码
**文件：`grpcAIMessageHandlers.ts`**

- 对 `handleCurrentTaskTodoListUpdate`、`handleCapabilityInventory`、`handlePerception`、`handleSessionSnapshot` 四个处理器，提取局部 `applyXxxFields(target)` 函数，消除 task / reAct / subAgentTask 分支中重复的字段赋值。
- 统一 reAct 分支的数据获取方式。
- **保持原有行为不变**，纯重构，减少约 66 行重复代码。

## 影响范围
- `app/renderer/src/main/src/pages/ai-re-act/hooks/useCasualChat.ts`
- `app/renderer/src/main/src/pages/ai-re-act/hooks/grpcAIMessageHandlers.ts`

## 合并方式
**请使用 Squash and merge（第二种合并方式）合并。**
由于本 PR 包含两个 commit（fix + refactor），squash 会将它们合并为一个 commit 进入 master；合并前 GitHub 会以本 PR 标题作为 commit message 标题、本描述作为正文，因此合并时请注意确认 squash commit 的标题与描述已更新为最新内容。