### PR TITLE
refactor(ai-agent): AIMarkdown 移除顶部标题栏，操作按钮改为悬停显示

### DIFF
--- a/app/renderer/src/main/src/pages/ai-agent/components/aiMarkdown/AIMarkdown.module.scss
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiMarkdown/AIMarkdown.module.scss
@@ -2,29 +2,38 @@
   display: flex;
   flex-direction: column;
   font-size: 14px;
-  gap: 4px;
   background-color: var(--Colors-Use-Neutral-Bg-Hover);
   border-radius: 8px;
   padding: 8px;
-
   overflow-wrap: break-word;
 
-  .milkdown-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    .header-name {
-      color: var(--Colors-Use-Neutral-Text-1-Title);
-      font-size: 14px;
-      font-weight: 500;
-    }
+  .ai-milkdown-body {
+    position: relative;
+    width: 100%;
+    min-height: 0;
   }
-  .header-extra {
+
+  .hover-actions {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 2;
     display: flex;
     align-items: center;
     gap: 4px;
+    padding: 2px 4px;
+    border-radius: 4px;
+    background: var(--Colors-Use-Neutral-Bg-Hover);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
   }
+
+  .ai-milkdown-body:hover > .hover-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
   .ai-milkdown {
     font-size: 14px;
     background-color: transparent;

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiMarkdown/AIMarkdown.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiMarkdown/AIMarkdown.tsx
@@ -11,9 +11,7 @@ import {
   OutlineDownloadIcon,
   OutlineNotebookIcon,
 } from '@/assets/icon/outline'
-import ModalInfo from '../ModelInfo'
 import { ColorsPreViewMDIcon, ColorsSourceCodeIcon } from '@/assets/icon/colors'
-import ChatCard from '../ChatCard'
 import { Tooltip } from 'antd'
 import { StreamMarkdown } from '@/pages/assetViewer/reportRenders/markdownRender'
 import { YakitEditor } from '@/components/yakitUI/YakitEditor/YakitEditor'
@@ -25,7 +23,7 @@ import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { isAuxOrChildWindow } from '@/utils/isAuxOrChildWindow'
 
 export const AIMarkdown: React.FC<AIMarkdownProps> = React.memo((props) => {
-  const { content, nodeLabel, className, modalInfo, referenceNode, streaming } = props
+  const { content, nodeLabel, className, referenceNode, streaming } = props
   const { t } = useI18nNamespaces(['aiAgent', 'yakitUi'])
 
   const { goAddNotepad } = useGoEditNotepad()
@@ -87,11 +85,9 @@ export const AIMarkdown: React.FC<AIMarkdownProps> = React.memo((props) => {
   const isChildWindow = useRef(isAuxOrChildWindow())
 
   return (
-    <ChatCard
-      titleText={nodeLabel}
-      titleExtra={<ModalInfo {...modalInfo} />}
-      titleMore={
-        <div className={styles['header-extra']}>
+    <div className={classNames(styles['ai-milkdown-wrapper'], className)}>
+      <div className={styles['ai-milkdown-body']}>
+        <div className={styles['hover-actions']}>
           {!isChildWindow.current && (
             <Tooltip title={t('AIMarkdown.openFromNotepad')}>
               <YakitButton size="small" type="text" icon={<OutlineNotebookIcon />} onClick={onGoToNote} />
@@ -117,11 +113,9 @@ export const AIMarkdown: React.FC<AIMarkdownProps> = React.memo((props) => {
             />
           </Tooltip>
         </div>
-      }
-      className={classNames(styles['ai-milkdown-wrapper'], className)}
-    >
-      {renderContent()}
-      {referenceNode}
-    </ChatCard>
+        {renderContent()}
+        {referenceNode}
+      </div>
+    </div>
   )
 })

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiMarkdown/type.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiMarkdown/type.ts
@@ -1,11 +1,9 @@
-import { ModalInfoProps } from '../ModelInfo'
 import { ReactNode } from 'react'
 
 export interface AIMarkdownProps {
   content: string
   nodeLabel: string
   className?: string
-  modalInfo: ModalInfoProps
   referenceNode: ReactNode
   /** 是否正在流式输出（用于开启流式淡入渲染效果，结束后关闭） */
   streaming?: boolean

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
@@ -88,7 +88,6 @@ export const AIStreamNode: React.FC<AIStreamNodeProps> = React.memo((props) => {
           referenceNode={referenceNode}
           content={content}
           nodeLabel={nodeLabel}
-          modalInfo={modalInfo}
           streaming={streaming}
           {...aiMarkdownProps}
         />

--- a/app/renderer/src/main/src/pages/assetViewer/reportRenders/markdownRender.scss
+++ b/app/renderer/src/main/src/pages/assetViewer/reportRenders/markdownRender.scss
@@ -1466,7 +1466,7 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
   h1 {
     font-size: 1.125rem !important;
     line-height: 1.5 !important;
-    margin-top: 8px !important;
+    margin-top: 2px !important;
     margin-bottom: 2px !important;
   }
 


### PR DESCRIPTION
详情：
去掉 ChatCard 包裹与 ModalInfo 标题区，将下载/预览/展开等操作移至内容区右上角悬停展示，并收紧 markdown h1 顶部间距。

合并方式：2