### PR TITLE
feat: memfit 发版 CI 增加 GitHub Release 上传步骤

### DIFF
--- a/.github/workflows/build-multi-memfit-prod.yml
+++ b/.github/workflows/build-multi-memfit-prod.yml
@@ -112,7 +112,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # 给 Windows 安装包外壳做 Authenticode 签名(上传 OSS 之前)
+  # 给 Windows 安装包外壳做 Authenticode 签名(上传 Release/OSS 之前)
   # 内置引擎已在 yaklang OSS 源头签名，此处只补安装包外壳这一层
   sign_windows:
     needs: build_memfit
@@ -166,6 +166,14 @@ jobs:
 
       - run: ls
         name: List downloaded artifacts
+
+      - name: Create Release and Upload Assets
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ./*
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Release ${{ github.ref_name }}
+          tag: ${{ github.ref_name }}
 
       - name: Upload Memfit to OSS
         uses: tvrcgo/upload-to-oss@master


### PR DESCRIPTION
## Summary
- 在 `build-multi-memfit-prod.yml` 的 `publish_memfit_to_oss` job 中，于上传 OSS 前增加 GitHub Release 发布步骤
- 与 Yakit / IRify 发版流程对齐，将 Memfit 安装包挂到对应 `v*-memfit` tag 的 Release

## Test plan
- [ ] 推送 `v*-memfit` tag 触发 Build Memfit Prod
- [ ] 确认签名后的安装包已上传到对应 tag 的 GitHub Release
- [ ] 确认 OSS 上传仍正常

请使用第二种合并方式（Squash and merge）