### PR TITLE
fix: 历史任务恢复按钮在非进行中状态均可显示

### DIFF
--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/HistoryTaskTree.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/HistoryTaskTree.tsx
@@ -146,7 +146,7 @@ export const AIHistoryContinueTask: React.FC<AIHistoryContinueTaskProps> = React
     let show = true
     if (!chatIPCData.execute) return true
     if (coordinatorId === currentCoordinatorId) {
-      show = taskInfo?.status === AITaskStatus.error && !chatIPCData?.taskStatus?.loading
+      show = taskInfo?.status !== AITaskStatus.inProgress && !chatIPCData?.taskStatus?.loading
     }
     // 如果当前有任务正在等待被恢复
     if (sendRecoverParamsRef.current) {
@@ -155,7 +155,7 @@ export const AIHistoryContinueTask: React.FC<AIHistoryContinueTaskProps> = React
         sendRecoverParamsRef.current.coordinatorId === coordinatorId && sendRecoverParamsRef.current.taskId === taskId
       )
     }
-    const isStopping = taskInfo?.status === AITaskStatus.error && taskStatus.loading
+    const isStopping = taskInfo?.status !== AITaskStatus.inProgress && taskStatus.loading
 
     // 如果系统正处于正在停止/取消任务的全局 Loading 状态，或当前任务本身正处于停止进行中的状态
     if (chatIPCData.cancelTaskLoading || isStopping) {

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActTaskChat/AIReActTaskChat.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActTaskChat/AIReActTaskChat.tsx
@@ -636,6 +636,8 @@ export const AIRenderTaskFooterExtra: React.FC<AIRenderTaskFooterExtraProps> = R
           </YakitPopconfirm>
         )
       case AITaskStatus.error:
+      case AITaskStatus.skipped:
+      case AITaskStatus.cancel:
         return !taskStatus.loading ? (
           <YakitButton
             type="primary"


### PR DESCRIPTION
扩展恢复按钮显示条件，支持 error、skipped、cancel 等非进行中任务状态。
关联后端：https://github.com/yaklang/yaklang/pull/4771