### PR TITLE
feat(ai-agent): delete/query IM sessions by platform

### DIFF
--- a/app/renderer/src/main/src/pages/ai-agent/historyChat/HistoryChat.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/historyChat/HistoryChat.tsx
@@ -26,7 +26,12 @@ import { JSONParseLog } from '@/utils/tool'
 import { usePageInfo } from '@/store/pageInfo'
 import { shallow } from 'zustand/shallow'
 import classNames from 'classnames'
-import { filterHistorySessionsBySource, getHistorySourceQuerySources, type HistorySourceFilter } from './source'
+import {
+  filterHistorySessionsBySource,
+  getHistorySourceQueryPlatform,
+  getHistorySourceQuerySources,
+  type HistorySourceFilter,
+} from './source'
 
 const clearLocalChats = (sessions: AISession[]) =>
   emiter.emit('onDelChats', JSON.stringify(sessions.map((item) => item.SessionID)))
@@ -103,7 +108,11 @@ const HistoryChat = memo(({ aiSource, embedded }: HistoryChatProps) => {
     if (!enableHistorySourceFilter) return aiSource
     return getHistorySourceQuerySources(aiSource, historySourceFilter)
   }, [aiSource, enableHistorySourceFilter, historySourceFilter])
-  const [{ sessions }, dispatcher] = useSessionList(historyQuerySources)
+  const historyQueryPlatform = useMemo(() => {
+    if (!enableHistorySourceFilter) return []
+    return getHistorySourceQueryPlatform(historySourceFilter)
+  }, [enableHistorySourceFilter, historySourceFilter])
+  const [{ sessions }, dispatcher] = useSessionList(historyQuerySources, historyQueryPlatform)
   const { activeChat } = useAIAgentStore()
   const { setActiveChat } = useAIAgentDispatcher()
   const currentRouteKey = usePageInfo((state) => state.getCurrentPageTabRouteKey(), shallow)
@@ -138,10 +147,15 @@ const HistoryChat = memo(({ aiSource, embedded }: HistoryChatProps) => {
 
     setClearLoading(true)
     try {
-      if (isGlobalAIAgentHistory) {
+      if (isGlobalAIAgentHistory && historySourceFilter === 'local') {
+        // Global AI Agent 侧栏 + local 分组：清空全部来源的会话。
         await grpcDeleteAISession({ DeleteAll: true }, true)
+      } else if (isGlobalAIAgentHistory && enableHistorySourceFilter) {
+        // Global AI Agent 侧栏 + IM 平台分组：只删该平台，不波及其它来源/平台。
+        await grpcDeleteAISession({ Filter: { Source: ['im'], Platform: historyQueryPlatform } }, true)
       } else {
-        await grpcDeleteAISession({ Filter: { Source: historyQuerySources } }, true)
+        // 业务页嵌入：按当前分组的 source + platform 删除。
+        await grpcDeleteAISession({ Filter: { Source: historyQuerySources, Platform: historyQueryPlatform } }, true)
       }
       clearLocalChats(visibleSessions)
       onNewChat()
@@ -175,6 +189,7 @@ const HistoryChat = memo(({ aiSource, embedded }: HistoryChatProps) => {
           ? {
               SessionID: deletedChats.map((item) => item.SessionID),
               Source: historyQuerySources,
+              Platform: historyQueryPlatform,
             }
           : {
               BeforeTimestamp: beforeTimestamp,

--- a/app/renderer/src/main/src/pages/ai-agent/historyChat/HistoryChatList/hook/useSessionList.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/historyChat/HistoryChatList/hook/useSessionList.ts
@@ -34,7 +34,7 @@ const mergeUniqueChats = (prev: AISession[], next: AISession[]) => {
   return uniqueNext.length ? [...prev, ...uniqueNext] : prev
 }
 
-const useSessionList = (aiSource: AISource[]) => {
+const useSessionList = (aiSource: AISource[], platform: string[] = []) => {
   const [_, setPagination, getPagination] = useGetSetState(cloneDeep(initialHistoryPagination))
   const [sessions, setSessions, getSessions] = useGetSetState<AISession[]>([])
   const historyLoadingRef = useRef(false)
@@ -48,6 +48,7 @@ const useSessionList = (aiSource: AISource[]) => {
         Filter: {
           Source: aiSource,
           SessionID: [sessionId],
+          Platform: platform,
         },
       })
       setSessions((prev) => {
@@ -77,6 +78,7 @@ const useSessionList = (aiSource: AISource[]) => {
         Pagination: currentPagination,
         Filter: {
           Source: aiSource,
+          Platform: platform,
         },
       })
       if (isRefresh) {

--- a/app/renderer/src/main/src/pages/ai-agent/historyChat/__test__/source.test.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/historyChat/__test__/source.test.ts
@@ -4,6 +4,7 @@ import {
   filterHistorySessionsBySource,
   getHistorySessionIconMeta,
   getHistorySourceFilterCounts,
+  getHistorySourceQueryPlatform,
   getHistorySourceQuerySources,
   getSessionDisplayTitle,
 } from '../source'
@@ -178,5 +179,11 @@ describe('history source filters', () => {
     expect(getHistorySourceQuerySources(['ai', 'im', ''], 'local')).toEqual(['ai', ''])
     expect(getHistorySourceQuerySources(['ai', 'im', ''], 'feishu')).toEqual(['im'])
     expect(getHistorySourceQuerySources(['ai'], 'feishu')).toEqual([])
+  })
+
+  it('maps visible history source filters to grpc query platforms', () => {
+    expect(getHistorySourceQueryPlatform('local')).toEqual([])
+    expect(getHistorySourceQueryPlatform('feishu')).toEqual(['feishu'])
+    expect(getHistorySourceQueryPlatform('dingtalk')).toEqual(['dingtalk'])
   })
 })

--- a/app/renderer/src/main/src/pages/ai-agent/historyChat/source.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/historyChat/source.ts
@@ -157,6 +157,21 @@ export const getHistorySourceQuerySources = (sources: AISource[], filter: Histor
   return expectedSources.filter((source) => sources.includes(source))
 }
 
+// getHistorySourceQueryPlatform maps a history source filter tab to the IM
+// platform string sent to the backend. 'local' yields no platform filter;
+// feishu / dingtalk map to their platform values. The backend combines this
+// with Source=['im'] to narrow deletion/query to a single IM platform.
+export const getHistorySourceQueryPlatform = (filter: HistorySourceFilter): string[] => {
+  switch (filter) {
+    case 'feishu':
+      return ['feishu']
+    case 'dingtalk':
+      return ['dingtalk']
+    default:
+      return []
+  }
+}
+
 export const getIMSourceDetailText = (item?: AISession): string => {
   const badge = getIMSourceBadge(item)
   if (!badge || !item) return ''

--- a/app/renderer/src/main/src/pages/ai-agent/type/aiChat.d.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/type/aiChat.d.ts
@@ -142,6 +142,10 @@ export interface DeleteAISessionFilter {
    * 删除来源于该来源的数据
    */
   Source?: AISource[]
+  /**
+   * 按 IM 平台删除（feishu / dingtalk），仅当 Source 含 im 时有意义
+   */
+  Platform?: string[]
 }
 
 export interface DeleteAISessionRequest {
@@ -162,5 +166,9 @@ export interface QueryAISessionRequest {
     SessionID?: string[]
     Keyword?: string
     Source?: AISource[]
+    /**
+     * 按 IM 平台筛选（feishu / dingtalk），仅当 Source 含 im 时有意义
+     */
+    Platform?: string[]
   }
 }


### PR DESCRIPTION
关联后端分支:https://github.com/yaklang/yaklang/pull/4824
选中飞书分组点删除全部会误删钉钉等全部 IM 会话：前端分组按
IMSourceMeta.Platform 做的，但删除只传 Source:['im']，后端 WHERE source='im' 删光所有 IM。配合后端新增的 Platform 过滤维度修复。

- type: DeleteAISessionFilter / QueryAISessionRequest.Filter 加 Platform
- source.ts: 新增 getHistorySourceQueryPlatform (local→[], feishu/dingtalk→对应平台)
- HistoryChat: 删除全部改为尊重分组(global+local→DeleteAll; global+IM平台→只删该平台; 业务页→source+platform); 按天删除补 platform
- useSessionList: 列表查询带 Platform，按平台精确分页
- 测试: source.test.ts 加 platform 映射用例 (11/11 通过)