### PR TITLE
fix: 修正缓存命中率计算，分母改为缓存命中+未命中(input)的总量

### DIFF
--- a/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIContextToken/AIEchartsDetails.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIContextToken/AIEchartsDetails.tsx
@@ -84,8 +84,9 @@ const AIEchartsDetails: React.FC<AIEchartsDetailsProps> = ({
     const output = tierConsumption.intelligent.output_consumption || 0
     const cacheHit = tierConsumption.intelligent.cache_hit_token || 0
     let percent = 0
-    if (input !== 0 && cacheHit !== 0) {
-      percent = Number(((Number(cacheHit) / Number(input)) * 100).toFixed(2))
+    const totalInput = Number(cacheHit) + Number(input)
+    if (totalInput !== 0 && cacheHit !== 0) {
+      percent = Number(((Number(cacheHit) / totalInput) * 100).toFixed(2))
     }
     return [formatNumberUnits(input), formatNumberUnits(output), formatNumberUnits(cacheHit), percent]
   }, [renderNumber, tierConsumption?.intelligent])
@@ -96,8 +97,9 @@ const AIEchartsDetails: React.FC<AIEchartsDetailsProps> = ({
     const output = tierConsumption.lightweight.output_consumption || 0
     const cacheHit = tierConsumption.lightweight.cache_hit_token || 0
     let percent = 0
-    if (input !== 0 && cacheHit !== 0) {
-      percent = Number(((Number(cacheHit) / Number(input)) * 100).toFixed(2))
+    const totalInput = Number(cacheHit) + Number(input)
+    if (totalInput !== 0 && cacheHit !== 0) {
+      percent = Number(((Number(cacheHit) / totalInput) * 100).toFixed(2))
     }
     return [formatNumberUnits(input), formatNumberUnits(output), formatNumberUnits(cacheHit), percent]
   }, [renderNumber, tierConsumption?.lightweight])


### PR DESCRIPTION
input_consumption 现在表示未命中缓存的数量，因此缓存命中率分母
应由原来的 input 改为 cache_hit_token + input_consumption， 否则比率会偏高。