### PR TITLE
fix: 修复标题栏拖拽区域挡住右键菜单点击 禁用橡皮筋回弹效果 避免列表滚动时滚动条占位导致布局抖动

### DIFF
--- a/app/renderer/src/main/src/components/TableVirtualResize/TableVirtualResize.module.scss
+++ b/app/renderer/src/main/src/components/TableVirtualResize/TableVirtualResize.module.scss
@@ -207,6 +207,7 @@
       overflow-y: overlay;
       overflow-x: overlay;
       overflow-anchor: none;
+      outline: none;
       position: relative;
       padding-bottom: 34px;
       border: 1px solid var(--Colors-Use-Neutral-Border);

--- a/app/renderer/src/main/src/components/TableVirtualResize/TableVirtualResize.tsx
+++ b/app/renderer/src/main/src/components/TableVirtualResize/TableVirtualResize.tsx
@@ -1030,7 +1030,9 @@ const Table = <T extends any>(props: TableVirtualResizeProps<T>) => {
   const onMouseDownDragSelection = useMemoizedFn((event: React.MouseEvent<HTMLDivElement>) => {
     if (!enableDragSelection) return
 
-    shortcutFocusRef.current?.focus()
+    // 聚焦真实滚动容器，避免焦点在包装层时滚轮边界落到外层
+    const focusTarget = (containerRef.current || shortcutFocusRef.current) as HTMLElement | null
+    focusTarget?.focus({ preventScroll: true })
     if (!canStartDragSelection(event)) return
 
     const container = containerRef.current
@@ -1598,6 +1600,7 @@ const Table = <T extends any>(props: TableVirtualResizeProps<T>) => {
               )}
               <div
                 ref={containerRef}
+                tabIndex={-1}
                 className={classNames(
                   styles['virtual-table-list-container'],
                   {

--- a/app/renderer/src/main/src/components/layout/UILayout.tsx
+++ b/app/renderer/src/main/src/components/layout/UILayout.tsx
@@ -1709,7 +1709,7 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
                   className={styles['header-border-yakit-mask']}
                 ></div>
 
-                <div className={classNames(styles['yakit-header-title'])} onDoubleClick={maxScreen}>
+                <div className={classNames(styles['yakit-header-title'], dropClassName)} onDoubleClick={maxScreen}>
                   {getAppTitleName}-{`${EngineModeVerbose(engineMode || 'local', dynamicStatus)}`}
                 </div>
 
@@ -1792,7 +1792,7 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
                   className={styles['header-border-yakit-mask']}
                 ></div>
 
-                <div className={classNames(styles['yakit-header-title'])} onDoubleClick={maxScreen}>
+                <div className={classNames(styles['yakit-header-title'], dropClassName)} onDoubleClick={maxScreen}>
                   <>
                     {getAppTitleName}-{`${EngineModeVerbose(engineMode || 'local', dynamicStatus)}`}
                   </>

--- a/app/renderer/src/main/src/components/layout/uiLayout.module.scss
+++ b/app/renderer/src/main/src/components/layout/uiLayout.module.scss
@@ -73,7 +73,6 @@
           font-weight: 600;
           color: var(--Colors-Use-Neutral-Text-1-Title);
           text-align: center;
-          -webkit-app-region: drag;
         }
 
         .header-left {

--- a/app/renderer/src/main/src/components/yakitUI/YakitMenu/showByRightContext.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitMenu/showByRightContext.tsx
@@ -1,6 +1,7 @@
 import ReactDOM from 'react-dom'
 import React, { memo, ReactNode, useEffect, useRef } from 'react'
 import { coordinate } from '@/pages/globalVariable'
+import emiter from '@/utils/eventBus/eventBus'
 import { YakitMenu, YakitMenuProp } from './YakitMenu'
 import styles from './showByRightContext.module.scss'
 
@@ -73,6 +74,8 @@ export const showByRightContext = (props: YakitMenuProp | ReactNode, x?: number,
   div.id = ContextMenuId
   div.className = 'popup'
   document.body.appendChild(div)
+  // 与 Drawer/Modal 一致：菜单打开时关闭标题栏拖拽，避免挡住菜单点击
+  emiter.emit('setYakitHeaderDraggable', false)
 
   const destory = () => {
     // if (rightContextRootDiv) {
@@ -82,6 +85,7 @@ export const showByRightContext = (props: YakitMenuProp | ReactNode, x?: number,
     if (unmountResult && div.parentNode) {
       div.parentNode.removeChild(div)
     }
+    emiter.emit('setYakitHeaderDraggable', true)
   }
 
   const offsetPosition = (width: number, height: number) => {

--- a/app/renderer/src/main/src/index.css
+++ b/app/renderer/src/main/src/index.css
@@ -1,9 +1,14 @@
 @import '~antd/dist/antd.css';
 
+html,
 body {
-  overflow-x: hidden;
-  overflow-y: auto;
+  height: 100%;
   margin: 0;
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+body {
   font-family:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
     'Helvetica Neue', sans-serif;

--- a/app/renderer/src/main/src/utils/globalShortcutKey/shortcutKeyFocusHook/ShortcutKeyFocusHook.module.scss
+++ b/app/renderer/src/main/src/utils/globalShortcutKey/shortcutKeyFocusHook/ShortcutKeyFocusHook.module.scss
@@ -1,4 +1,8 @@
 .shortcut-key-focus-hook {
+  // 聚焦在此非滚动包装时，滚轮边界会落到祖先可滚层；锁住以阻断链式滚动
+  overflow: hidden;
+  overscroll-behavior: none;
+  outline: none;
 }
 
 .shortcut-key-focus-hook-hint {


### PR DESCRIPTION
第二个合并方式