### PR TITLE
feat: codec页面支持复制标签页

### DIFF
--- a/app/renderer/src/main/src/defaultConstants/Codec.ts
+++ b/app/renderer/src/main/src/defaultConstants/Codec.ts
@@ -1,5 +1,6 @@
 import type { RightItemsProps } from '@/pages/codec/NewCodec'
 import type { CodecPageInfoProps } from '@/store/pageInfo'
+import cloneDeep from 'lodash/cloneDeep'
 
 export const initialRightItems: RightItemsProps[] = [
   // {
@@ -17,7 +18,7 @@ export const initialRightItems: RightItemsProps[] = [
 ]
 
 export const defaultCodecPageInfo: CodecPageInfoProps = {
-  rightItems: initialRightItems,
+  rightItems: cloneDeep(initialRightItems),
   inputEditor: '',
   outputResponse: undefined,
 }

--- a/app/renderer/src/main/src/defaultConstants/Codec.ts
+++ b/app/renderer/src/main/src/defaultConstants/Codec.ts
@@ -1,6 +1,5 @@
 import type { RightItemsProps } from '@/pages/codec/NewCodec'
 import type { CodecPageInfoProps } from '@/store/pageInfo'
-import cloneDeep from 'lodash/cloneDeep'
 
 export const initialRightItems: RightItemsProps[] = [
   // {
@@ -18,7 +17,7 @@ export const initialRightItems: RightItemsProps[] = [
 ]
 
 export const defaultCodecPageInfo: CodecPageInfoProps = {
-  rightItems: cloneDeep(initialRightItems),
+  rightItems: initialRightItems,
   inputEditor: '',
   outputResponse: undefined,
 }

--- a/app/renderer/src/main/src/defaultConstants/Codec.ts
+++ b/app/renderer/src/main/src/defaultConstants/Codec.ts
@@ -1,0 +1,23 @@
+import type { RightItemsProps } from '@/pages/codec/NewCodec'
+import type { CodecPageInfoProps } from '@/store/pageInfo'
+
+export const initialRightItems: RightItemsProps[] = [
+  // {
+  //     title: "Item A",
+  //     codecType:"55",
+  //     key:"QQ",
+  //     node: [
+  //         {
+  //             leftNode: {name:"DD",type: "input", title: "IV"},
+  //             rightNode: {name:"BB",selectArr: [{label:"B",value:"B"}, {label:"K",value:"K"},{label:"M",value:"M"}], type: "select"},
+  //             type: "flex"
+  //         },
+  //     ]
+  // },
+]
+
+export const defaultCodecPageInfo: CodecPageInfoProps = {
+  rightItems: initialRightItems,
+  inputEditor: '',
+  outputResponse: undefined,
+}

--- a/app/renderer/src/main/src/pages/codec/NewCodec.tsx
+++ b/app/renderer/src/main/src/pages/codec/NewCodec.tsx
@@ -89,6 +89,7 @@ import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { type CodecPageInfoProps, type PageNodeItemProps, usePageInfo } from '@/store/pageInfo'
 import { shallow } from 'zustand/shallow'
 import { defaultCodecPageInfo, initialRightItems } from '@/defaultConstants/Codec'
+import cloneDeep from 'lodash/cloneDeep'
 const { ipcRenderer } = window.require('electron')
 const { YakitPanel } = YakitCollapse
 
@@ -2066,13 +2067,15 @@ export const NewCodec: React.FC<NewCodecProps> = (props) => {
     if (currentItem && currentItem.pageParamsInfo.codecPageInfo) {
       return currentItem.pageParamsInfo.codecPageInfo
     }
-    return { ...defaultCodecPageInfo }
+    return cloneDeep(defaultCodecPageInfo)
   })
   // codec分类展开收起
   const [fold, setFold] = useState<boolean>(true)
   // 是否全部展开
   const [isExpand, setExpand] = useState<boolean>(false)
-  const [rightItems, setRightItems] = useState<RightItemsProps[]>(cachedPageInfo.rightItems || initialRightItems)
+  const [rightItems, setRightItems] = useState<RightItemsProps[]>(
+    cachedPageInfo.rightItems || cloneDeep(initialRightItems),
+  )
   const [leftData, setLeftData] = useState<LeftDataProps[]>([])
   // 我的收藏
   const [leftCollectData, setLeftCollectData] = useState<LeftDataProps[]>([])

--- a/app/renderer/src/main/src/pages/codec/NewCodec.tsx
+++ b/app/renderer/src/main/src/pages/codec/NewCodec.tsx
@@ -2072,9 +2072,7 @@ export const NewCodec: React.FC<NewCodecProps> = (props) => {
   const [fold, setFold] = useState<boolean>(true)
   // 是否全部展开
   const [isExpand, setExpand] = useState<boolean>(false)
-  const [rightItems, setRightItems] = useState<RightItemsProps[]>(
-    (cachedPageInfo.rightItems as RightItemsProps[]) || initialRightItems,
-  )
+  const [rightItems, setRightItems] = useState<RightItemsProps[]>(cachedPageInfo.rightItems || initialRightItems)
   const [leftData, setLeftData] = useState<LeftDataProps[]>([])
   // 我的收藏
   const [leftCollectData, setLeftCollectData] = useState<LeftDataProps[]>([])
@@ -2087,9 +2085,7 @@ export const NewCodec: React.FC<NewCodecProps> = (props) => {
   const cacheCodecRef = useRef<CodecMethod[]>([])
   // Input/Output编辑器内容
   const [inputEditor, setInputEditor] = useState<string>(cachedPageInfo.inputEditor || '')
-  const [outputResponse, setOutputResponse] = useState<CodecResponseProps>(
-    cachedPageInfo.outputResponse as CodecResponseProps,
-  )
+  const [outputResponse, setOutputResponse] = useState<CodecResponseProps | undefined>(cachedPageInfo.outputResponse)
 
   // 编辑后回写 pageInfo store：rightItems / inputEditor / outputResponse
   const { run: syncCodecPageInfo } = useDebounceFn(

--- a/app/renderer/src/main/src/pages/codec/NewCodec.tsx
+++ b/app/renderer/src/main/src/pages/codec/NewCodec.tsx
@@ -1,6 +1,14 @@
 import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { Divider, Tooltip, Upload } from 'antd'
-import { useMemoizedFn, useThrottleFn, useUpdateEffect, useDebounceEffect, useSize, useControllableValue } from 'ahooks'
+import {
+  useMemoizedFn,
+  useThrottleFn,
+  useUpdateEffect,
+  useDebounceFn,
+  useDebounceEffect,
+  useSize,
+  useControllableValue,
+} from 'ahooks'
 import styles from './NewCodec.module.scss'
 import { failed, success, warn, info } from '@/utils/notification'
 import classNames from 'classnames'
@@ -78,6 +86,9 @@ import { useTheme } from '@/hook/useTheme'
 import { handleOpenFileSystemDialog } from '@/utils/fileSystemDialog'
 import { YakitPopconfirm } from '@/components/yakitUI/YakitPopconfirm/YakitPopconfirm'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import { type CodecPageInfoProps, type PageNodeItemProps, usePageInfo } from '@/store/pageInfo'
+import { shallow } from 'zustand/shallow'
+import { defaultCodecPageInfo, initialRightItems } from '@/defaultConstants/Codec'
 const { ipcRenderer } = window.require('electron')
 const { YakitPanel } = YakitCollapse
 
@@ -2008,7 +2019,7 @@ interface RightItemsFlexProps {
   // 控件类型
   type: 'flex'
 }
-interface RightItemsProps {
+export interface RightItemsProps {
   title: string
   codecType: string
   key: string
@@ -2016,20 +2027,6 @@ interface RightItemsProps {
   // 屏蔽/中止
   status?: 'shield' | 'suspend' | 'run'
 }
-const initialRightItems: RightItemsProps[] = [
-  // {
-  //     title: "Item A",
-  //     codecType:"55",
-  //     key:"QQ",
-  //     node: [
-  //         {
-  //             leftNode: {name:"DD",type: "input", title: "IV"},
-  //             rightNode: {name:"BB",selectArr: [{label:"B",value:"B"}, {label:"K",value:"K"},{label:"M",value:"M"}], type: "select"},
-  //             type: "flex"
-  //         },
-  //     ]
-  // },
-]
 export interface CodecParam {
   Name: string
   Type: string
@@ -2057,11 +2054,27 @@ export interface NewCodecProps {
 export const NewCodec: React.FC<NewCodecProps> = (props) => {
   const { t, i18nRefresh } = useI18nNamespaces(['codec', 'yakitUi'])
   const { id } = props
+  const { queryPagesDataById, updatePagesDataCacheById } = usePageInfo(
+    (s) => ({
+      queryPagesDataById: s.queryPagesDataById,
+      updatePagesDataCacheById: s.updatePagesDataCacheById,
+    }),
+    shallow,
+  )
+  const [cachedPageInfo] = useState<CodecPageInfoProps>(() => {
+    const currentItem = queryPagesDataById(YakitRoute.Codec, id)
+    if (currentItem && currentItem.pageParamsInfo.codecPageInfo) {
+      return currentItem.pageParamsInfo.codecPageInfo
+    }
+    return { ...defaultCodecPageInfo }
+  })
   // codec分类展开收起
   const [fold, setFold] = useState<boolean>(true)
   // 是否全部展开
   const [isExpand, setExpand] = useState<boolean>(false)
-  const [rightItems, setRightItems] = useState<RightItemsProps[]>(initialRightItems)
+  const [rightItems, setRightItems] = useState<RightItemsProps[]>(
+    (cachedPageInfo.rightItems as RightItemsProps[]) || initialRightItems,
+  )
   const [leftData, setLeftData] = useState<LeftDataProps[]>([])
   // 我的收藏
   const [leftCollectData, setLeftCollectData] = useState<LeftDataProps[]>([])
@@ -2073,8 +2086,34 @@ export const NewCodec: React.FC<NewCodecProps> = (props) => {
   const [isShowSearchList, setShowSearchList] = useState<boolean>(false)
   const cacheCodecRef = useRef<CodecMethod[]>([])
   // Input/Output编辑器内容
-  const [inputEditor, setInputEditor] = useState<string>('')
-  const [outputResponse, setOutputResponse] = useState<CodecResponseProps>()
+  const [inputEditor, setInputEditor] = useState<string>(cachedPageInfo.inputEditor || '')
+  const [outputResponse, setOutputResponse] = useState<CodecResponseProps>(
+    cachedPageInfo.outputResponse as CodecResponseProps,
+  )
+
+  // 编辑后回写 pageInfo store：rightItems / inputEditor / outputResponse
+  const { run: syncCodecPageInfo } = useDebounceFn(
+    () => {
+      const currentItem: PageNodeItemProps | undefined = queryPagesDataById(YakitRoute.Codec, id)
+      if (!currentItem) return
+      updatePagesDataCacheById(YakitRoute.Codec, {
+        ...currentItem,
+        pageParamsInfo: {
+          ...currentItem.pageParamsInfo,
+          codecPageInfo: {
+            rightItems,
+            inputEditor,
+            outputResponse,
+          },
+        },
+      })
+    },
+    { wait: 300 },
+  )
+  useUpdateEffect(() => {
+    syncCodecPageInfo()
+  }, [rightItems, inputEditor, outputResponse])
+
   // 是否正在执行
   const [runLoading, setRunLoading] = useState<boolean>(false)
   // 是否为点击添加至执行列表

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -3315,7 +3315,7 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
       pageName: node.verbose,
       pageParamsInfo: {
         codecPageInfo: {
-          ...(node?.pageParams?.codecPageInfo || defaultCodecPageInfo),
+          ...(node?.pageParams?.codecPageInfo || cloneDeep(defaultCodecPageInfo)),
         },
       },
       sortFieId: order,

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -147,6 +147,7 @@ import { defaultAddYakitScriptPageInfo } from '@/defaultConstants/AddYakitScript
 import { useMenuHeight } from '@/store/menuHeight'
 import type { HybridScanInputTarget } from '@/models/HybridScan'
 import { defaultWebsocketFuzzerPageInfo } from '@/defaultConstants/WebsocketFuzzer'
+import { defaultCodecPageInfo } from '@/defaultConstants/Codec'
 import { DuplicateTabContent, type RecoveryModel, RestoreTabContent } from './TabRenameModalContent'
 import {
   type FuzzerConfig,
@@ -207,7 +208,8 @@ const Close_Group_Tip = 'close-group_tip'
 const colorList = ['purple', 'blue', 'lakeBlue', 'green', 'red', 'orange', 'bluePurple', 'grey']
 const droppable = 'droppable'
 const droppableGroup = 'droppableGroup'
-const duplicateWebFuzzerTabsEvent = 'onDuplicateWebFuzzerTabs'
+// 支持「复制标签页」的路由列表（仅组内 tab 显示菜单项）。
+const duplicateTabRoutes: YakitRoute[] = [YakitRoute.HTTPFuzzer, YakitRoute.Codec]
 const pageTabItemRightOperation: (t: TFunction) => YakitMenuItemType[] = (t) => {
   return [
     {
@@ -1729,74 +1731,105 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
     }
   })
 
-  const onDuplicateWebFuzzerTabs = useMemoizedFn(({ item, count }: { item: MultipleNodeInfo; count: number }) => {
-    const currentItem = queryPagesDataById(YakitRoute.HTTPFuzzer, item.id)
-    const webFuzzerPageInfo = currentItem?.pageParamsInfo?.webFuzzerPageInfo
-    if (!webFuzzerPageInfo) return
+  // 通用「复制标签页」：从 pageInfo store 读原 tab 内容，克隆 N 个新 tab 到原 tab 所在组（或顶层）
+  const onDuplicateTabs = useMemoizedFn(
+    ({ item, count, route }: { item: MultipleNodeInfo; count: number; route: YakitRoute }) => {
+      const newPageCache = cloneDeep(getPageCache())
+      const currentPageCache = newPageCache.find((ele) => ele.route === route)
+      if (!currentPageCache) return
 
-    const { request = defaultPostTemplate, advancedConfigValue, advancedConfigShow, hotPatchCode } = webFuzzerPageInfo
+      const { index, subIndex } = getPageItemById(currentPageCache.multipleNode || [], item.id)
+      const targetGroupId = subIndex !== -1 && index !== -1 ? currentPageCache.multipleNode[index].id : '0'
+      const groupChildrenLength =
+        targetGroupId !== '0' && index !== -1 ? currentPageCache.multipleNode[index].groupChildren?.length || 0 : 0
 
-    const pageParams: ComponentParams = {
-      request,
-      system: item.pageParams?.system,
-      advancedConfigValue,
-      advancedConfigShow,
-      hotPatchCode,
-    }
+      const currentItem = queryPagesDataById(route, item.id)
+      const baseName = item.verbose || currentItem?.pageName
+      const key = routeConvertKey(route, '')
 
-    const baseName = item.verbose || currentItem?.pageName
-    const key = routeConvertKey(YakitRoute.HTTPFuzzer, '')
-
-    const newPageCache = cloneDeep(getPageCache())
-    const currentPageCache = newPageCache.find((ele) => ele.route === YakitRoute.HTTPFuzzer)
-    if (!currentPageCache) return
-
-    const { index, subIndex } = getPageItemById(currentPageCache.multipleNode || [], item.id)
-    const targetGroupId = subIndex !== -1 && index !== -1 ? currentPageCache.multipleNode[index].id : '0'
-    const groupChildrenLength =
-      targetGroupId !== '0' && index !== -1 ? currentPageCache.multipleNode[index].groupChildren?.length || 0 : 0
-
-    const baseSortId =
-      targetGroupId !== '0' ? groupChildrenLength + 1 : (currentPageCache.multipleNode?.length || 0) + 1
-    const createdNodes: MultipleNodeInfo[] = Array.from({ length: count }, (_, index) => {
-      const { time, tabId } = generateTabIdentity(key, index)
-      return {
-        id: tabId,
-        verbose: `${baseName}(${index + 1})`,
-        time,
-        pageParams: {
-          ...pageParams,
-          id: tabId,
-          groupId: targetGroupId,
-        },
-        groupId: targetGroupId,
-        sortFieId: baseSortId + index,
+      // 按 route 构造新节点的 pageParams（含克隆内容）。返回 undefined 表示该路由不支持复制。
+      const buildPageParams: (route: YakitRoute) => ComponentParams | undefined = (route) => {
+        switch (route) {
+          case YakitRoute.HTTPFuzzer: {
+            const info = currentItem?.pageParamsInfo?.webFuzzerPageInfo
+            if (!info) return undefined
+            return {
+              request: info.request || defaultPostTemplate,
+              system: item.pageParams?.system,
+              advancedConfigValue: info.advancedConfigValue,
+              advancedConfigShow: info.advancedConfigShow,
+              hotPatchCode: info.hotPatchCode,
+            }
+          }
+          case YakitRoute.Codec: {
+            const info = currentItem?.pageParamsInfo?.codecPageInfo
+            if (!info) return undefined
+            return {
+              codecPageInfo: {
+                rightItems: cloneDeep(info.rightItems),
+                inputEditor: info.inputEditor,
+                outputResponse: cloneDeep(info.outputResponse),
+              },
+            }
+          }
+          default:
+            return undefined
+        }
       }
-    })
+      const pageParams = buildPageParams(route)
+      if (!pageParams) return
 
-    if (targetGroupId !== '0' && index !== -1) {
-      currentPageCache.multipleNode[index].groupChildren = [
-        ...(currentPageCache.multipleNode[index].groupChildren || []),
-        ...createdNodes,
-      ]
-    } else {
-      currentPageCache.multipleNode.push(...createdNodes)
-    }
-    currentPageCache.multipleLength = (currentPageCache.multipleLength || 0) + createdNodes.length
-    currentPageCache.openFlag = false
-    currentPageCache.selectSubItem = false
+      const baseSortId =
+        targetGroupId !== '0' ? groupChildrenLength + 1 : (currentPageCache.multipleNode?.length || 0) + 1
+      const createdNodes: MultipleNodeInfo[] = Array.from({ length: count }, (_, index) => {
+        const { time, tabId } = generateTabIdentity(key, index)
+        return {
+          id: tabId,
+          verbose: `${baseName}(${index + 1})`,
+          time,
+          pageParams: {
+            ...pageParams,
+            id: tabId,
+            groupId: targetGroupId,
+          },
+          groupId: targetGroupId,
+          sortFieId: baseSortId + index,
+        }
+      })
 
-    createdNodes.forEach((node) => {
-      addFuzzerList(node.id, node, node.sortFieId)
-    })
+      if (targetGroupId !== '0' && index !== -1) {
+        currentPageCache.multipleNode[index].groupChildren = [
+          ...(currentPageCache.multipleNode[index].groupChildren || []),
+          ...createdNodes,
+        ]
+      } else {
+        currentPageCache.multipleNode.push(...createdNodes)
+      }
+      currentPageCache.multipleLength = (currentPageCache.multipleLength || 0) + createdNodes.length
+      currentPageCache.openFlag = false
+      currentPageCache.selectSubItem = false
 
-    setPageCache(newPageCache)
-  })
+      // 按 route 调对应注册函数，把新节点写入 pageInfo store
+      createdNodes.forEach((node) => {
+        switch (route) {
+          case YakitRoute.HTTPFuzzer:
+            addFuzzerList(node.id, node, node.sortFieId)
+            break
+          case YakitRoute.Codec:
+            onCodec(node, node.sortFieId)
+            break
+          default:
+            break
+        }
+      })
 
+      setPageCache(newPageCache)
+    },
+  )
   useEffect(() => {
-    emiter.on(duplicateWebFuzzerTabsEvent, onDuplicateWebFuzzerTabs)
+    emiter.on('onDuplicateTabs', onDuplicateTabs)
     return () => {
-      emiter.off(duplicateWebFuzzerTabsEvent, onDuplicateWebFuzzerTabs)
+      emiter.off('onDuplicateTabs', onDuplicateTabs)
     }
   }, [])
 
@@ -2245,6 +2278,9 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
         break
       case YakitRoute.DataCompare:
         onDataCompare(node, order)
+        break
+      case YakitRoute.Codec:
+        onCodec(node, order)
         break
       default:
         break
@@ -3239,7 +3275,6 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
     }
     addPagesDataCache(YakitRoute.WebsocketFuzzer, newPageNode)
   })
-
   /**记事本编辑 */
   const onSetModifyNotepadData = useMemoizedFn((node: MultipleNodeInfo, order: number) => {
     const newPageNode: PageNodeItemProps = {
@@ -3268,6 +3303,24 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
       sortFieId: order,
     }
     addPagesDataCache(YakitRoute.DataCompare, newPageNode)
+  })
+
+  /** Codec */
+  const onCodec = useMemoizedFn((node: MultipleNodeInfo, order: number) => {
+    const newPageNode: PageNodeItemProps = {
+      id: `${randomString(8)}-${order}`,
+      routeKey: YakitRoute.Codec,
+      pageGroupId: node.groupId,
+      pageId: node.id,
+      pageName: node.verbose,
+      pageParamsInfo: {
+        codecPageInfo: {
+          ...(node?.pageParams?.codecPageInfo || defaultCodecPageInfo),
+        },
+      },
+      sortFieId: order,
+    }
+    addPagesDataCache(YakitRoute.Codec, newPageNode)
   })
 
   /**
@@ -5094,7 +5147,7 @@ const SubTabs: React.FC<SubTabsProps> = React.memo(
       } catch (error) {}
     })
 
-    const onShowDuplicateModal = useMemoizedFn((item: MultipleNodeInfo) => {
+    const onShowDuplicateModal = useMemoizedFn((item: MultipleNodeInfo, route: YakitRoute) => {
       const m = showYakitModal({
         title: (modalT) => modalT('TabRenameModalContent.duplicateTabs'),
         footer: null,
@@ -5103,7 +5156,7 @@ const SubTabs: React.FC<SubTabsProps> = React.memo(
             maxCount={secondaryTabsNumRef.current}
             subPageCount={getSubPageTotal(subPage)}
             onClose={() => m.destroy()}
-            onDuplicate={(count) => emiter.emit(duplicateWebFuzzerTabsEvent, { item, count })}
+            onDuplicate={(count) => emiter.emit('onDuplicateTabs', { item, count, route })}
           />
         ),
       })
@@ -5149,16 +5202,18 @@ const SubTabs: React.FC<SubTabsProps> = React.memo(
           key: 'removeFromGroup',
         })
       }
+      // 复制标签页：对 duplicateTabRoutes 中的路由、且组内 tab 显示
+      if (duplicateTabRoutes.includes(pageItem.route) && subIndex !== -1) {
+        menuData = [
+          ...menuData,
+          {
+            label: t('TabRenameModalContent.duplicateTabs'),
+            key: 'duplicateTab',
+          },
+        ]
+      }
+      // 恢复标签页：目前仅 WebFuzzer 有历史恢复机制
       if (pageItem.route === YakitRoute.HTTPFuzzer) {
-        if (subIndex !== -1) {
-          menuData = [
-            ...menuData,
-            {
-              label: t('TabRenameModalContent.duplicateTabs'),
-              key: 'duplicateTab',
-            },
-          ]
-        }
         menuData = [
           ...menuData,
           {
@@ -5208,7 +5263,7 @@ const SubTabs: React.FC<SubTabsProps> = React.memo(
                 onNewGroup(item)
                 break
               case 'duplicateTab':
-                onShowDuplicateModal(item)
+                onShowDuplicateModal(item, pageItem.route)
                 break
               case 'restoreTab':
                 onRestoreHistory(pageRouteKey)

--- a/app/renderer/src/main/src/routes/newRoute.tsx
+++ b/app/renderer/src/main/src/routes/newRoute.tsx
@@ -146,6 +146,7 @@ import type {
   AuditHoleInfoProps,
   AIRepositoryProps,
   PluginOpPageInfoProps,
+  CodecPageInfoProps,
 } from '@/store/pageInfo'
 import { SpaceEnginePage } from '@/pages/spaceEngine/SpaceEnginePage'
 import { SinglePluginExecution } from '@/pages/plugins/singlePluginExecution/SinglePluginExecution'
@@ -663,6 +664,8 @@ export interface ComponentParams {
   simpleDetectPageInfo?: SimpleDetectPageInfoProps
   /**webSocket页面 */
   websocketFuzzerPageInfo?: WebsocketFuzzerPageInfoProps
+  /**Codec 编解码页面 */
+  codecPageInfo?: CodecPageInfoProps
   /**流量分析器页面 */
   hTTPHistoryAnalysisPageInfo?: HTTPHistoryAnalysisPageInfo
   /**新建插件页面 */

--- a/app/renderer/src/main/src/store/pageInfo.ts
+++ b/app/renderer/src/main/src/store/pageInfo.ts
@@ -107,6 +107,8 @@ interface PageParamsInfoProps {
   }
   /** 插件执行页（Plugin_OP） */
   pluginOpPageInfo?: PluginOpPageInfoProps
+  /** Codec 编解码页面 */
+  codecPageInfo?: CodecPageInfoProps
 }
 
 export interface AIForgeEditorPageInfoProps {
@@ -158,6 +160,20 @@ export interface WebsocketFuzzerPageInfoProps {
   wsTls?: boolean
   wsRequest?: Uint8Array
   wsToServer?: Uint8Array
+}
+
+export interface CodecPageInfoProps {
+  /** 编解码运行顺序，对应 NewCodec 的 RightItemsProps[] */
+  rightItems?: any[]
+  /** 输入框内容 */
+  inputEditor?: string
+  /** 执行输出，结构同 Codec 的 CodecResponseProps */
+  outputResponse?: {
+    Result: string
+    RawResult?: Uint8Array
+    ResultVerbose: string
+    IsFalseAppearance: boolean
+  }
 }
 
 export interface HTTPHistoryAnalysisPageInfo {

--- a/app/renderer/src/main/src/store/pageInfo.ts
+++ b/app/renderer/src/main/src/store/pageInfo.ts
@@ -21,6 +21,7 @@ import type { AIMentionCommandParams } from '@/pages/ai-agent/components/aiMilkd
 import type { IrifyAiCodeAuditStyle } from '@/pages/irifyAiCodeAudit/irifyAiCodeAuditStyle'
 import i18n from '@/i18n/i18n'
 import type { YakExecutorParam } from '@/pages/invoker/YakExecutorParams'
+import type { CodecResponseProps, RightItemsProps } from '@/pages/codec/NewCodec'
 const tOriginal = i18n.getFixedT(null, 'store')
 
 /**
@@ -164,16 +165,11 @@ export interface WebsocketFuzzerPageInfoProps {
 
 export interface CodecPageInfoProps {
   /** 编解码运行顺序，对应 NewCodec 的 RightItemsProps[] */
-  rightItems?: any[]
+  rightItems?: RightItemsProps[]
   /** 输入框内容 */
   inputEditor?: string
   /** 执行输出，结构同 Codec 的 CodecResponseProps */
-  outputResponse?: {
-    Result: string
-    RawResult?: Uint8Array
-    ResultVerbose: string
-    IsFalseAppearance: boolean
-  }
+  outputResponse?: CodecResponseProps
 }
 
 export interface HTTPHistoryAnalysisPageInfo {

--- a/app/renderer/src/main/src/utils/eventBus/events/main.ts
+++ b/app/renderer/src/main/src/utils/eventBus/events/main.ts
@@ -1,4 +1,5 @@
 import type { MultipleNodeInfo } from '@/pages/layout/mainOperatorContent/MainOperatorContentType'
+import type { YakitRoute } from '@/enums/yakitRoute'
 
 export type MainOperatorEventProps = {
   /** 远程打开一个页面 */
@@ -16,6 +17,6 @@ export type MainOperatorEventProps = {
 
   /**二级路由Tab数据变化 */
   secondMenuTabDataChange: string
-  /**复制 webfuzzer 标签页 */
-  onDuplicateWebFuzzerTabs: { item: MultipleNodeInfo; count: number }
+  /**复制标签页（通用，按 route switch 分发到各页面的复制逻辑） */
+  onDuplicateTabs: { item: MultipleNodeInfo; count: number; route: YakitRoute }
 }


### PR DESCRIPTION
## PR 说明

### 标题
`feat: Codec 页面支持状态缓存与复制标签页`

### 概述
为 Codec 编解码页面接入 `pageInfo` store 状态缓存，并支持「复制标签页」。Codec 页面的执行顺序（`rightItems`）、输入内容、输出结果现在会随标签页持久化，复制标签页时可完整克隆这些状态。

### 改动文件（6 个）

| 文件 | 改动 |
| --- | --- |
| `store/pageInfo.ts` | 新增 `CodecPageInfoProps`（`rightItems` / `inputEditor` / `outputResponse`），挂到 `PageParamsInfoProps` |
| `defaultConstants/Codec.ts`（新增） | 抽取 `initialRightItems` 与 `defaultCodecPageInfo` 默认值 |
| `pages/codec/NewCodec.tsx` | 挂载时从 store 读缓存恢复三项状态；编辑后用 `useDebounceFn`(300ms) 防抖回写 store |
| `layout/.../MainOperatorContent.tsx` | 将 WebFuzzer 专用的 `onDuplicateWebFuzzerTabs` 重构为通用 `onDuplicateTabs`（按 `route` 分发）；为 `HTTPFuzzer` 与 `Codec` 分别构造克隆内容，Codec 深拷贝三项状态 |
| `utils/eventBus/events/main.ts` | 事件名 `onDuplicateWebFuzzerTabs` → `onDuplicateTabs`（带 `route` 字段） |
| `routes/newRoute.tsx` | `ComponentParams` 增加 `codecPageInfo` 字段 |

### 行为变化
- **复制标签页**：右键 Codec tab 可复制（含内容），新 tab 自动放入原 tab 所在组并带序号命名。
- **通用化重构**：「复制标签页」机制从 WebFuzzer 专用改为按路由分发的通用方案，后续新增支持路由只需在 `duplicateTabRoutes`、`buildPageParams`、节点注册 switch 三处补充即可。

### 注意点
- 此前「复制标签页」仅 WebFuzzer tab 右键菜单可见，现 Codec tab 亦可见（由 `duplicateTabRoutes` 控制）。

### 合并方式二