### PR TITLE
perf(aiAgent): 移除高频 useSize/scrollTo 引起的全量重渲染并合并任务规划布局

### DIFF
--- a/app/renderer/src/main/src/pages/ai-agent/AIAgent.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/AIAgent.tsx
@@ -7,7 +7,7 @@ import { getRemoteValue, setRemoteValue } from '@/utils/kv'
 import { RemoteAIAgentGV } from '@/enums/aiAgent'
 import useGetSetState from '../pluginHub/hooks/useGetSetState'
 import type { AISession } from './type/aiChat'
-import { useDebounceFn, useInViewport, useMemoizedFn, useRequest, useSize, useUpdateEffect } from 'ahooks'
+import { useDebounceFn, useInViewport, useMemoizedFn, useRequest, useUpdateEffect } from 'ahooks'
 import { AIAgentSettingDefault, SwitchAIAgentTabEventEnum, YakitAIAgentPageID } from './defaultConstant'
 import cloneDeep from 'lodash/cloneDeep'
 import { AIAgentChat } from './aiAgentChat/AIAgentChat'
@@ -49,13 +49,24 @@ export const AIAgent: React.FC<AIAgentProps> = (props) => {
   const { initialize, knowledgeBases } = useKnowledgeBase()
   const agentRef = useRef<HTMLDivElement>(null)
   const [inViewPort = true] = useInViewport(agentRef)
-  const agentSize = useSize(agentRef)
 
-  useUpdateEffect(() => {
-    if (agentSize?.width && agentSize?.width < 1230) {
-      setShow(false)
-    }
-  }, [agentSize?.width])
+  // 只在宽度跌破阈值时收起侧栏，避免 useSize 每帧 setState 把整页（含会话列表）打满重渲染
+  useEffect(() => {
+    const el = agentRef.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    let skipFirst = true
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect?.width
+      if (!width) return
+      if (skipFirst) {
+        skipFirst = false
+        return
+      }
+      if (width < 1230) setShow((prev) => (prev ? false : prev))
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
 
   // 缓存全局配置数据
   useUpdateEffect(() => {
@@ -193,6 +204,28 @@ export const AIAgent: React.FC<AIAgentProps> = (props) => {
 
   const [isShowAIBottomDetails, setShowAIBottomDetails] = useState(false)
 
+  const splitDefaultSizes = useMemo(() => (isShowAIBottomDetails ? [undefined, 220] : []), [isShowAIBottomDetails])
+  const splitElements = useMemo(
+    () => [
+      {
+        element: (
+          <div className={classNames(styles['ai-agent-chat'])} onClick={onSendSwitchAIAgentTab}>
+            <AIAgentChat />
+          </div>
+        ),
+      },
+      {
+        element: (
+          <AIBottomDetails
+            isShowAIBottomDetails={isShowAIBottomDetails}
+            setShowAIBottomDetails={setShowAIBottomDetails}
+          />
+        ),
+      },
+    ],
+    [isShowAIBottomDetails, onSendSwitchAIAgentTab],
+  )
+
   return (
     <AIAgentContext.Provider value={{ store, dispatcher }}>
       <div id={YakitAIAgentPageID} className={styles['ai-agent']} ref={agentRef}>
@@ -204,24 +237,8 @@ export const AIAgent: React.FC<AIAgentProps> = (props) => {
             <SplitView
               isVertical={true}
               isLastHidden={!isShowAIBottomDetails}
-              defaultSizes={isShowAIBottomDetails ? [undefined, 220] : []}
-              elements={[
-                {
-                  element: (
-                    <div className={classNames(styles['ai-agent-chat'])} onClick={onSendSwitchAIAgentTab}>
-                      <AIAgentChat />
-                    </div>
-                  ),
-                },
-                {
-                  element: (
-                    <AIBottomDetails
-                      isShowAIBottomDetails={isShowAIBottomDetails}
-                      setShowAIBottomDetails={setShowAIBottomDetails}
-                    />
-                  ),
-                },
-              ]}
+              defaultSizes={splitDefaultSizes}
+              elements={splitElements}
             />
           </div>
         </div>

--- a/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatContent.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatContent.tsx
@@ -58,7 +58,7 @@ export const AIChatContent: React.FC<AIChatContentProps> = React.memo(
     const [showFreeChat, setShowFreeChat] = useState<boolean>(true) //自由对话展开收起
     const [timeLine, setTimeLine] = useState<boolean>(true) //侧边栏展开收起
     /** 任务规划 tabs 是否有内容（无则自由对话变大） */
-    const [hasTaskTabs, setHasTaskTabs] = useState(false)
+    // const [hasTaskTabs, setHasTaskTabs] = useState(false)
     /** 文件系统是否有文件预览（无则自由对话变大） */
     const [hasFilePreview, setHasFilePreview] = useState(false)
     const [runTimeId, setRunTimeId] = useState<string>() // 工具卡片跳转自带runTimeID
@@ -203,7 +203,7 @@ export const AIChatContent: React.FC<AIChatContentProps> = React.memo(
             <AIReActTaskChat
               setTimeLine={setTimeLine}
               setShowFreeChat={setShowFreeChat}
-              onTaskTabsChange={setHasTaskTabs}
+              // onTaskTabsChange={setHasTaskTabs} // 方法未使用，新版可以废弃
             />
           )
         case AITabsEnum.File_System:
@@ -249,7 +249,7 @@ export const AIChatContent: React.FC<AIChatContentProps> = React.memo(
       activeKey,
       showFreeChat,
       timeLine,
-      hasTaskTabs,
+      // hasTaskTabs,
       hasFilePreview,
     })
 

--- a/app/renderer/src/main/src/pages/ai-agent/aiChatContent/hooks/useAIChatResizeBox.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatContent/hooks/useAIChatResizeBox.ts
@@ -12,8 +12,11 @@ interface Params {
   activeKey?: AITabsEnumType
   showFreeChat: boolean
   timeLine: boolean
-  /** 任务规划 tabs 是否有内容 */
-  hasTaskTabs: boolean
+  /**
+   * @deprecated 变量对应的赋值方法未使用，新版可以废弃
+   * 任务规划 tabs 是否有内容
+   */
+  // hasTaskTabs: boolean
   /** 文件系统是否有预览文件 */
   hasFilePreview: boolean
 }
@@ -28,7 +31,7 @@ export function useAIChatResizeBox(params: Params) {
   }
 
   const resizeBoxProps = useCreation<ResizeBoxProps>(() => {
-    const { activeKey, showFreeChat, timeLine, hasTaskTabs, hasFilePreview } = params
+    const { activeKey, showFreeChat, timeLine, hasFilePreview } = params
     const override = overrideRef.current
     // 消费一次就清掉
     overrideRef.current = null
@@ -46,7 +49,7 @@ export function useAIChatResizeBox(params: Params) {
     const isFileSystem = activeKey === AITabsEnum.File_System
     const isOperationLog = activeKey === AITabsEnum.Operation_Log
     // 详情区为空 / 读写日志：左侧只保留列表宽度（与时间线一致），自由对话变大
-    const isDetailEmpty = (isTaskContent && !hasTaskTabs) || (isFileSystem && !hasFilePreview) || isOperationLog
+    const isDetailEmpty = isTaskContent || (isFileSystem && !hasFilePreview) || isOperationLog
 
     let secondRatio: ResizeBoxProps['secondRatio']
     let firstRatio: ResizeBoxProps['firstRatio']
@@ -59,7 +62,7 @@ export function useAIChatResizeBox(params: Params) {
       } else {
         // 有详情 / 其它面板：保持原布局
         secondRatio = '432px'
-        firstRatio = '70%'
+        firstRatio = 'calc(100% - 432px)'
       }
     }
 
@@ -73,19 +76,20 @@ export function useAIChatResizeBox(params: Params) {
       firstNodeStyle: {
         padding: 0,
         ...(!showFreeChat && { width: '100%' }),
-        ...(showFreeChat && isTaskContent && !hasTaskTabs && !timeLine ? { maxWidth: 30, minWidth: 30 } : {}),
+        ...(showFreeChat && isTaskContent && !timeLine ? { maxWidth: 30, minWidth: 30 } : {}),
       },
       secondNodeStyle: {
         padding: 0,
         ...(!showFreeChat && { minWidth: 30, maxWidth: 30 }),
       },
+      isRecalculateWH: false,
     }
 
     return {
       ...computed,
       ...override,
     }
-  }, [params.activeKey, params.showFreeChat, params.timeLine, params.hasTaskTabs, params.hasFilePreview, version])
+  }, [params.activeKey, params.showFreeChat, params.timeLine, params.hasFilePreview, version])
 
   return {
     resizeBoxProps,

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard.module.scss
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard.module.scss
@@ -149,3 +149,7 @@
 .timeline-popover {
   max-width: 500px;
 }
+.timeline-popover-content {
+  max-height: 70vh;
+  overflow-y: auto;
+}

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo, forwardRef, memo, useRef } from 'react'
+import { type FC, useMemo, forwardRef, memo } from 'react'
 import styles from './TimelineCard.module.scss'
 import { YakitTag } from '@/components/yakitUI/YakitTag/YakitTag'
 import classNames from 'classnames'
@@ -8,7 +8,7 @@ import type { AIAgentGrpcApi } from '@/pages/ai-re-act/hooks/grpcApi'
 import useVirtuosoAutoScroll from '@/pages/ai-re-act/hooks/useVirtuosoAutoScroll'
 import { YakitPopover } from '@/components/yakitUI/YakitPopover/YakitPopover'
 import { OutlineInformationcircleIcon } from '@/assets/icon/outline'
-import { useMemoizedFn, useSize } from 'ahooks'
+import { useMemoizedFn } from 'ahooks'
 import { YakitSpin } from '@/components/yakitUI/YakitSpin/YakitSpin'
 import { useCurrentStore } from '@/pages/ai-re-act/hooks/useCurrentDataBySession'
 import useCurrentSessionId from '@/pages/ai-re-act/hooks/useCurrentSessionId'
@@ -24,40 +24,37 @@ const TYPE_COLOR_MAP: Record<string, 'info' | 'white' | 'danger'> = {
   raw: 'danger',
 }
 
-const TimelineRow = memo(
-  ({ item, containerHeight }: { item: AIAgentGrpcApi.TimelineItem; containerHeight?: number }) => {
-    const status = TYPE_COLOR_MAP[item.type] || 'white'
-    const maxHeight = containerHeight ? containerHeight * 0.7 : 300
+const TimelineRow = memo(({ item }: { item: AIAgentGrpcApi.TimelineItem }) => {
+  const status = TYPE_COLOR_MAP[item.type] || 'white'
 
-    return (
-      <div className={classNames(styles['timeline-card'], styles[`timeline-card-${status}`])}>
-        <div className={styles['timeline-card-header']}>
-          <div className={styles['timeline-card-header-left']}>
-            <div className={styles['timeline-card-header-hot']} />
-            <span>{formatTime(item.timestamp)}</span>
+  return (
+    <div className={classNames(styles['timeline-card'], styles[`timeline-card-${status}`])}>
+      <div className={styles['timeline-card-header']}>
+        <div className={styles['timeline-card-header-left']}>
+          <div className={styles['timeline-card-header-hot']} />
+          <span>{formatTime(item.timestamp)}</span>
 
-            <YakitTag size="small" fullRadius color={status} className={styles['timeline-card-header-tag']}>
-              <p className={styles['timeline-card-header-tag-text']}>{item.entry_type ?? item.type}</p>
-            </YakitTag>
-          </div>
-
-          <YakitPopover
-            overlayClassName={styles['timeline-popover']}
-            overlayStyle={{ paddingLeft: 4 }}
-            placement="right"
-            content={<div style={{ maxHeight, overflowY: 'auto' }}>{item.content}</div>}
-          >
-            <div className={styles['icon-wrapper']}>
-              <OutlineInformationcircleIcon />
-            </div>
-          </YakitPopover>
+          <YakitTag size="small" fullRadius color={status} className={styles['timeline-card-header-tag']}>
+            <p className={styles['timeline-card-header-tag-text']}>{item.entry_type ?? item.type}</p>
+          </YakitTag>
         </div>
 
-        <div className={styles['timeline-card-body']}>{item.content || ''}</div>
+        <YakitPopover
+          overlayClassName={styles['timeline-popover']}
+          overlayStyle={{ paddingLeft: 4 }}
+          placement="right"
+          content={<div className={styles['timeline-popover-content']}>{item.content}</div>}
+        >
+          <div className={styles['icon-wrapper']}>
+            <OutlineInformationcircleIcon />
+          </div>
+        </YakitPopover>
       </div>
-    )
-  },
-)
+
+      <div className={styles['timeline-card-body']}>{item.content || ''}</div>
+    </div>
+  )
+})
 
 TimelineRow.displayName = 'TimelineRow'
 
@@ -102,8 +99,6 @@ const TimelineCard: FC = () => {
     total: reActTimelines.length,
     isPrependingRef,
   })
-  const containerRef = useRef<HTMLDivElement>(null)
-  const size = useSize(containerRef)
 
   const components = useMemo<Components<AIAgentGrpcApi.TimelineItem>>(
     () => ({
@@ -114,16 +109,13 @@ const TimelineCard: FC = () => {
     [reActTimelines.length],
   )
 
-  const itemContent = useMemoizedFn((_: number, item: AIAgentGrpcApi.TimelineItem) => (
-    <TimelineRow item={item} containerHeight={size?.height} />
-  ))
+  const itemContent = useMemoizedFn((_: number, item: AIAgentGrpcApi.TimelineItem) => <TimelineRow item={item} />)
 
   return (
     <div
       className={classNames(styles['timeline-card-wrapper'], {
         [styles['timeline-card-empty']]: reActTimelines.length === 0,
       })}
-      ref={containerRef}
     >
       <YakitSpin spinning={timelinesLoading}>
         <Virtuoso

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiGroupStreamCard/aiGroupStreamCardList/AIGroupStreamCardList.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiGroupStreamCard/aiGroupStreamCardList/AIGroupStreamCardList.tsx
@@ -44,14 +44,17 @@ const AIGroupStreamCardList: React.FC<AIGroupStreamCardListProps> = memo((props)
     if (!el || !expand) return
     if (!allowAutoScrollRef.current) return
     requestAnimationFrame(() => {
-      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
+      el.scrollTop = el.scrollHeight
     })
     let rafId = 0
+    let lastScrollHeight = el.scrollHeight
     const observer = new ResizeObserver(() => {
       if (!allowAutoScrollRef.current) return
+      if (el.scrollHeight === lastScrollHeight) return
+      lastScrollHeight = el.scrollHeight
       cancelAnimationFrame(rafId)
       rafId = requestAnimationFrame(() => {
-        el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
+        el.scrollTop = el.scrollHeight
       })
     })
     observer.observe(el)

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiYaklangCode/AIYaklangCode.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiYaklangCode/AIYaklangCode.tsx
@@ -54,6 +54,7 @@ export const AIYaklangCode: React.FC<AIYaklangCodeProps> = React.memo((props) =>
 
   const rawData = useCurrentRawData()
   const codeContainerRef = useRef<HTMLDivElement>(null)
+  const heightRafRef = useRef(0)
   const [streamedContent, setStreamedContent] = useState(() => defContent)
   const isLiveStreaming = streaming === true
   // 流式正文在 rawData 里原地累加，React 感知不到；仅在流式进行中轮询取最新驱动渲染。
@@ -108,18 +109,24 @@ export const AIYaklangCode: React.FC<AIYaklangCodeProps> = React.memo((props) =>
       const lineCount = editor.getModel()?.getLineCount() || 1
       const contentHeight = Math.ceil(editor.getTopForLineNumber(lineCount + 1) + lineHeight)
       const height = Math.min(CODE_BLOCK_MAX_HEIGHT, contentHeight)
+      const nextHeight = `${height}px`
+      if (container.style.height === nextHeight && editorEl.style.height === nextHeight) return
 
-      container.style.height = `${height}px`
-      editorEl.style.height = `${height}px`
+      container.style.height = nextHeight
+      editorEl.style.height = nextHeight
       editor.layout()
+    }
+    const scheduleUpdateHeight = () => {
+      if (heightRafRef.current) return
+      heightRafRef.current = requestAnimationFrame(() => {
+        heightRafRef.current = 0
+        updateHeight()
+      })
     }
 
     updateHeight()
-    editor.onDidChangeModelDecorations(() => {
-      updateHeight()
-      requestAnimationFrame(updateHeight)
-    })
-    editor.onDidContentSizeChange(updateHeight)
+    editor.onDidChangeModelDecorations(scheduleUpdateHeight)
+    editor.onDidContentSizeChange(scheduleUpdateHeight)
   })
 
   const renderCode = useMemoizedFn(() => {

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActTaskChat/AIReActTaskChat.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActTaskChat/AIReActTaskChat.tsx
@@ -12,7 +12,7 @@ import { AIChatLeftSide } from '@/pages/ai-agent/chatTemplate/AIAgentChatTemplat
 import { useControllableValue, useCreation, useMemoizedFn } from 'ahooks'
 import classNames from 'classnames'
 import { ChevrondownButton } from '../aiReActChat/AIReActComponent'
-import { OutlineArrowscollapseIcon, OutlineArrowsexpandIcon, OutlineInformationcircleIcon } from '@/assets/icon/outline'
+import { OutlineInformationcircleIcon } from '@/assets/icon/outline'
 import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
 import { type AIChatQSData, AIChatQSDataTypeEnum } from '../hooks/aiRender'
 import { type AIInputEvent, AIInputEventHotPatchTypeEnum, AIInputEventSyncTypeEnum } from '../hooks/grpcApi'
@@ -20,7 +20,6 @@ import { Form, Tooltip } from 'antd'
 import useAIAgentStore from '@/pages/ai-agent/useContext/useStore'
 import emiter from '@/utils/eventBus/eventBus'
 import { randomString } from '@/utils/randomUtil'
-import { YakitResizeBox } from '@/components/yakitUI/YakitResizeBox/YakitResizeBox'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { YakitPopover } from '@/components/yakitUI/YakitPopover/YakitPopover'
 import useAIGlobalConfig from '../hooks/useAIGlobalConfig'
@@ -29,75 +28,84 @@ import { v4 as uuidv4 } from 'uuid'
 import moment from 'moment'
 import { YakitSwitch } from '@/components/yakitUI/YakitSwitch/YakitSwitch'
 import useAIAgentDispatcher from '@/pages/ai-agent/useContext/useDispatcher'
-import { has } from 'lodash'
-import { AITaskContent } from '../aiTaskContent/AITaskContent'
+import has from 'lodash/has'
 import { useCurrentMeta, useCurrentStore } from '../hooks/useCurrentDataBySession'
 import { useStore } from 'zustand'
 import useCurrentSessionId from '../hooks/useCurrentSessionId'
 import { globalSessionEngine } from '../hooks/ChatMultiSessionController'
 
 const AIReActTaskChat: React.FC<AIReActTaskChatProps> = React.memo((props) => {
-  const { setShowFreeChat, setTimeLine, onTaskTabsChange } = props
+  const { /* setShowFreeChat, */ setTimeLine /* , onTaskTabsChange */ } = props
 
   const [leftExpand, setLeftExpand] = useState(true)
-  const [expand, setExpand] = useState(false)
-  const [hasTabs, setHasTabs] = useState(false)
+  // const [expand, setExpand] = useState(false)
+  // const [hasTabs, setHasTabs] = useState(false)
 
-  const onIsExpand = useMemoizedFn(() => {
-    setLeftExpand(expand)
-    setShowFreeChat(expand)
-    setExpand((v) => !v)
-  })
+  // const onIsExpand = useMemoizedFn(() => {
+  //   setLeftExpand(expand)
+  //   setShowFreeChat(expand)
+  //   setExpand((v) => !v)
+  // })
 
   useEffect(() => {
     setTimeLine(leftExpand)
   }, [leftExpand])
 
-  const onTabsChange = useMemoizedFn((tabsLength: number) => {
-    const next = tabsLength > 0
-    setHasTabs(next)
-    onTaskTabsChange?.(next)
-  })
+  // const onTabsChange = useMemoizedFn((tabsLength: number) => {
+  //   const next = tabsLength > 0
+  //   setHasTabs(next)
+  //   onTaskTabsChange?.(next)
+  // })
 
   // 无 tab：任务规划宽度强制为 0（覆盖 secondMinSize 默认 100px）；有 tab：时间线 30% + 规划区
-  const firstNodeStyle = useCreation(() => {
-    if (!hasTabs) {
-      return {
-        width: '100%',
-        overflow: 'hidden',
-        maxWidth: leftExpand ? '' : '30px',
-        borderRight: leftExpand ? 'none' : '1px solid var(--Colors-Use-Neutral-Border)',
-      }
-    }
-    return {
-      width: leftExpand ? '30%' : undefined,
-      overflow: 'hidden',
-      maxWidth: leftExpand ? '' : '30px',
-      borderRight: leftExpand ? 'none' : '1px solid var(--Colors-Use-Neutral-Border)',
-    }
-  }, [hasTabs, leftExpand])
+  // const firstNodeStyle = useCreation(() => {
+  //   if (!hasTabs) {
+  //     return {
+  //       width: '100%',
+  //       overflow: 'hidden',
+  //       maxWidth: leftExpand ? '' : '30px',
+  //       borderRight: leftExpand ? 'none' : '1px solid var(--Colors-Use-Neutral-Border)',
+  //     }
+  //   }
+  //   return {
+  //     width: leftExpand ? '30%' : undefined,
+  //     overflow: 'hidden',
+  //     maxWidth: leftExpand ? '' : '30px',
+  //     borderRight: leftExpand ? 'none' : '1px solid var(--Colors-Use-Neutral-Border)',
+  //   }
+  // }, [hasTabs, leftExpand])
 
-  const secondNodeStyle = useCreation(() => {
-    if (!hasTabs) {
-      return {
-        width: 0,
-        minWidth: 0,
-        maxWidth: 0,
-        padding: 0,
-        overflow: 'hidden' as const,
-        flex: 'none',
-      }
-    }
-    return {
-      width: leftExpand ? '100%' : 'calc(100% - 30px)',
-      padding: 0,
-      overflow: 'auto hidden' as const,
-    }
-  }, [hasTabs, leftExpand])
+  // const secondNodeStyle = useCreation(() => {
+  //   if (!hasTabs) {
+  //     return {
+  //       width: 0,
+  //       minWidth: 0,
+  //       maxWidth: 0,
+  //       padding: 0,
+  //       overflow: 'hidden' as const,
+  //       flex: 'none',
+  //     }
+  //   }
+  //   return {
+  //     width: leftExpand ? '100%' : 'calc(100% - 30px)',
+  //     padding: 0,
+  //     overflow: 'auto hidden' as const,
+  //   }
+  // }, [hasTabs, leftExpand])
 
   return (
     <div className={styles['ai-re-act-task-chat']}>
-      <YakitResizeBox
+      <div
+        style={{
+          width: leftExpand ? '100%' : 30,
+          height: '100%',
+          overflow: 'hidden',
+          borderRight: leftExpand ? 'none' : '1px solid var(--Colors-Use-Neutral-Border)',
+        }}
+      >
+        <AIReActTaskChatLeftSide leftExpand={leftExpand} setLeftExpand={setLeftExpand} />
+      </div>
+      {/* <YakitResizeBox
         firstRatio={hasTabs ? '30%' : '100%'}
         secondRatio={hasTabs ? undefined : '0%'}
         lineDirection="right"
@@ -121,7 +129,7 @@ const AIReActTaskChat: React.FC<AIReActTaskChatProps> = React.memo((props) => {
             }
           />
         }
-      />
+      /> */}
     </div>
   )
 })

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActTaskChat/AIReActTaskChatType.d.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActTaskChat/AIReActTaskChatType.d.ts
@@ -4,8 +4,8 @@ import type { ChatListRenderType } from '../hooks/aiRender'
 export interface AIReActTaskChatProps {
   setShowFreeChat: (show: boolean) => void
   setTimeLine: (show: boolean) => void
-  /** 任务规划 tabs 是否有内容，用于外层自由对话变大 */
-  onTaskTabsChange?: (hasTabs: boolean) => void
+  /** @deprecated 任务规划 tabs 是否有内容，用于外层自由对话变大 */
+  // onTaskTabsChange?: (hasTabs: boolean) => void
 }
 
 export interface AIReActTaskChatLeftSideProps {


### PR DESCRIPTION
## 背景

AI Agent 页面在部分机器上卡顿明显，根因是渲染端存在多处高频 setState / 高频 DOM 写入，导致整页（含会话列表）被反复重渲染。同时「任务规划列表」已与自由对话区合并，旧布局分支已失效，需要一并清理。

## 改动内容

### 性能优化

| 文件 | 改动 | 说明 |
| --- | --- | --- |
| `AIAgent.tsx` | `useSize` → `ResizeObserver` | 原来 `useSize` 每次 resize 都 setState + `useUpdateEffect` 触发整页重渲染，仅为「宽度 < 1230 收起侧栏」一个单向需求。改为 `ResizeObserver` 只在跌破阈值时收起，不回弹，不再每帧 setState。同时把 `SplitView` 的 props 抽到 `useMemo`，减少无谓重渲染 |
| `TimelineCard.tsx` | 移除 `useSize` + `containerHeight` prop | 原来容器高度变化会让所有 `TimelineRow` 重渲染（`itemContent` 闭包捕获 `size.height`）。popover 的 `maxHeight` 改用 CSS `70vh`，`TimelineRow` 的 `memo` 真正生效 |
| `AIGroupStreamCardList.tsx` | `scrollTo({smooth})` → `scrollTop` 赋值 + `scrollHeight` 去重 | 流式追加时 `smooth scroll` 动画堆积卡顿；改为直接赋值 + 仅在 `scrollHeight` 真正变化时调度 rAF |
| `AIYaklangCode.tsx` | 高度更新 rAF 节流 + 相同高度短路 | 原来 `onDidChangeModelDecorations` 双重调用 `updateHeight` + `requestAnimationFrame(updateHeight)`，`onDidContentSizeChange` 也直接调。改为单一 rAF 调度 + 相同高度跳过，减少 `editor.layout()` 调用 |

### 布局调整

| 文件 | 改动 | 说明 |
| --- | --- | --- |
| `AIReActTaskChat.tsx` | 移除内层 `YakitResizeBox` + `AITaskContent` | 任务规划列表已合并进自由对话区，内层右栏（任务执行详情 tabs）不再需要独立分栏，简化为单栏 `AIReActTaskChatLeftSide` |
| `useAIChatResizeBox.ts` | 移除 `hasTaskTabs` 相关分支 | `hasTaskTabs` 语义已失效（不再对应任务规划列表存在性），`isDetailEmpty` 对 Task_Content 改为恒为 true（任务内容 tab 左侧始终让位给自由对话）。`firstRatio` 由 `70%` 改为 `calc(100% - 432px)` 避免窄屏溢出 |
| `AIChatContent.tsx` / `AIReActTaskChatType.d.ts` | `hasTaskTabs` / `onTaskTabsChange` 标记废弃 | 相关代码暂注释保留，待确认后删除 |

## 待确认

1. **`useAIChatResizeBox.ts` 的 `isRecalculateWH: false`**：目前全局关闭，影响 File_System / HTTP / Risk / Operation_Log tab 在窗口缩放时的重算。需确认这些 tab 是否依赖该行为。
2. **注释保留的废弃代码**：`hasTaskTabs` 相关代码已注释保留，待同事确认后统一删除。

## 合并方式

请使用 **Squash merge**。