### PR TITLE
perf(aiAgent): 会话正文视窗外淘汰与按需回灌，降低长会话内存占用

### DIFF
--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
@@ -241,7 +241,7 @@ export const AIReActChatContents: React.FC<AIReActChatContentsPProps> = React.me
           key={activeChat?.SessionID}
           ref={virtuosoRef}
           scrollerRef={setScrollerRef}
-          defaultItemHeight={26}
+          defaultItemHeight={80}
           atBottomStateChange={handleAtBottomStateChange}
           data={casualChatElements}
           totalListHeightChanged={handleTotalListHeightChanged}
@@ -249,7 +249,7 @@ export const AIReActChatContents: React.FC<AIReActChatContentsPProps> = React.me
           firstItemIndex={firstItemIndex}
           initialTopMostItemIndex={chatLength > 1 ? { index: 'LAST' } : 0}
           components={components}
-          // increaseViewportBy={{ top: 1200, bottom: 0 }}
+          increaseViewportBy={{ top: 600, bottom: 200 }}
           atBottomThreshold={50}
           skipAnimationFrameInResizeObserver
           startReached={handleLoadMore}

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/ChatMultiSessionController.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/ChatMultiSessionController.ts
@@ -46,6 +46,7 @@ import {
   drainSessionContentWrites,
   persistIndependentItem,
   persistToolResultIfTerminal,
+  applyHydratedStageSettled,
 } from './persist/contentPersistHelper'
 import type { DeleteSessionsAISourceType } from '@/pages/ai-agent/historyChat/utils'
 
@@ -518,16 +519,8 @@ export class ChatMultiSessionController {
     }
   }
 
-  /** 按 token 获取会话消息内容 */
-  private async persistGetSessionContent(sessionId: string, token: string) {
-    try {
-      return await aiChatPersistStore.getSessionContent(sessionId, token)
-    } catch {
-      return undefined
-    }
-  }
   /** 按 token 列表批量获取会话消息内容 */
-  async persistGetSessionContents(sessionId: string, tokens: string[]) {
+  public async persistGetSessionContents(sessionId: string, tokens: string[]) {
     try {
       return await aiChatPersistStore.getSessionContents(sessionId, tokens)
     } catch {
@@ -585,6 +578,7 @@ export class ChatMultiSessionController {
     if (tokens.length) {
       const rows = await this.persistGetSessionContents(sessionId, tokens)
       for (const row of rows) {
+        applyHydratedStageSettled(row.content)
         rawData.contents.set(row.token, row.content)
       }
     }
@@ -593,12 +587,17 @@ export class ChatMultiSessionController {
     return true
   }
 
-  /** 仅删除内存 contents 中的条目，不删渲染树 / IDB */
-  public removeContentsFromMemory(sessionId: string, tokens: string[]) {
-    // const { rawData } = this.ensureSession(sessionId)
-    // for (const token of tokens) {
-    //   rawData.contents.delete(token)
-    // }
+  /** 仅删除内存 contents 中的条目，不删渲染树 / IDB。未传 tokens 或空数组则清空该 session 全部 contents。池不存在时 no-op（不 ensureSession）。 */
+  public removeContentsFromMemory(sessionId: string, tokens?: string[]) {
+    const rawData = this.rawDataPool.get(sessionId)
+    if (!rawData) return
+    if (!tokens || tokens.length === 0) {
+      rawData.contents.clear()
+      return
+    }
+    for (const token of tokens) {
+      rawData.contents.delete(token)
+    }
   }
   // #endregion
 
@@ -1386,7 +1385,7 @@ export class ChatMultiSessionController {
       // mirrorToLogWindow()
 
       if (handleFunc) {
-        handleFunc({
+        const result = handleFunc({
           sessionId,
           res,
           chatType: store.getState().currentChatStatus.coordinatorId === res.CoordinatorId ? 'task' : 'reAct',
@@ -1400,6 +1399,11 @@ export class ChatMultiSessionController {
             pushLogToOtherWindow({ sessionId: sessionId, Timestamp: res.Timestamp, ...log })
           },
         })
+        if (result && typeof result.then === 'function') {
+          void result.catch((error) => {
+            console.error('handleGrpcOutputEvent error', error)
+          })
+        }
       }
     } catch (error) {
       console.error('handleGrpcOutputEvent error', error)

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/ChatMultiSessionController.pageIndex.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/ChatMultiSessionController.pageIndex.test.ts
@@ -15,6 +15,10 @@ vi.mock('../persist/contentPersistHelper', () => ({
   persistIndependentItem: vi.fn(),
   persistToolResultIfTerminal: vi.fn(),
   drainSessionContentWrites: vi.fn().mockResolvedValue([]),
+  applyHydratedStageSettled: (content: any) => {
+    if (content && content.stageSettled !== false) content.stageSettled = true
+    return content
+  },
 }))
 vi.mock('../persist/aiChatPersistStore', () => ({
   default: {
@@ -88,8 +92,16 @@ describe('ChatMultiSessionController page index / ensureSession', () => {
     expect(request.Source).toBe('ai')
 
     rawData.contents.set('t1', { id: 't1' } as any)
-    // 当前实现体已注释，调用应不抛；恢复删除逻辑后再断言 has===false
-    expect(() => ctrl.removeContentsFromMemory('s-cfg', ['t1'])).not.toThrow()
+    ctrl.removeContentsFromMemory('s-cfg', ['t1'])
+    expect(rawData.contents.has('t1')).toBe(false)
+    expect(() => ctrl.removeContentsFromMemory('ghost')).not.toThrow()
+    rawData.contents.set('a', { id: 'a' } as any)
+    rawData.contents.set('b', { id: 'b' } as any)
+    ctrl.removeContentsFromMemory('s-cfg')
+    expect(rawData.contents.size).toBe(0)
+    rawData.contents.set('c', { id: 'c' } as any)
+    ctrl.removeContentsFromMemory('s-cfg', [])
+    expect(rawData.contents.size).toBe(0)
   })
 
   it('A22: getSessionExecute is read-only and does not create empty pool', () => {

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/aiStream.handlers.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/aiStream.handlers.test.ts
@@ -8,6 +8,7 @@ vi.mock('../persist/contentPersistHelper', () => ({
   persistToolResultIfTerminal: vi.fn(),
   upsertSessionContent: vi.fn(),
   setSessionReferencePersist: vi.fn(),
+  persistGetSessionContent: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('../AIAgentLogEmitter', () => ({
@@ -16,7 +17,7 @@ vi.mock('../AIAgentLogEmitter', () => ({
 }))
 
 describe('aiStream handlers', () => {
-  it('D4: stream_start creates STREAM content', () => {
+  it('D4: stream_start creates STREAM content', async () => {
     const req = makeHandlerRequest({
       res: makeGrpcJsonRes(
         'stream_start',
@@ -24,12 +25,13 @@ describe('aiStream handlers', () => {
         { NodeId: 're-act-loop-thought', EventUUID: 'eu-1' },
       ),
     })
-    aiStreamDataHandlers.stream_start(req)
+    await aiStreamDataHandlers.stream_start(req)
     const found = [...req.rawData.contents.values()].find((c) => c.type === AIChatQSDataTypeEnum.STREAM)
     expect(found).toBeTruthy()
+    expect(found?.stageSettled).toBe(false)
   })
 
-  it('D4: stream-finished ends stream by event_writer_id', () => {
+  it('D4: stream-finished ends stream by event_writer_id', async () => {
     const req = makeHandlerRequest({
       res: makeGrpcJsonRes(
         'structured',
@@ -51,7 +53,7 @@ describe('aiStream handlers', () => {
         content: 'hi',
       },
     } as any)
-    aiStreamDataHandlers['stream-finished'](req)
+    await aiStreamDataHandlers['stream-finished'](req)
     const stream = req.rawData.contents.get('ew-1') as any
     expect(stream.data.status).toBe('end')
   })
@@ -60,7 +62,7 @@ describe('aiStream handlers', () => {
     expect(typeof aiStreamDataHandlers.reference_material).toBe('function')
   })
 
-  it('D4: stream handler is registered', () => {
+  it('D4: stream handler hydrates/rebuilds when contents missing', async () => {
     expect(typeof aiStreamDataHandlers.stream).toBe('function')
     const req = makeHandlerRequest({
       res: makeGrpcRes({
@@ -70,7 +72,10 @@ describe('aiStream handlers', () => {
         Content: new TextEncoder().encode('x'),
       }),
     })
-    // without prior start may no-op; ensure no throw
-    expect(() => aiStreamDataHandlers.stream(req)).not.toThrow()
+    await aiStreamDataHandlers.stream(req)
+    const stream = req.rawData.contents.get('eu-1') as any
+    expect(stream?.type).toBe(AIChatQSDataTypeEnum.STREAM)
+    expect(stream.data.content).toBe('x')
+    expect(stream.stageSettled).toBe(false)
   })
 })

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/aiToolResult.handlers.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/aiToolResult.handlers.test.ts
@@ -7,6 +7,7 @@ vi.mock('../persist/contentPersistHelper', () => ({
   persistIndependentItem: vi.fn(),
   persistToolResultIfTerminal: vi.fn(),
   upsertSessionContent: vi.fn(),
+  persistGetSessionContent: vi.fn().mockResolvedValue(undefined),
 }))
 
 describe('aiToolResult handlers', () => {
@@ -22,9 +23,10 @@ describe('aiToolResult handlers', () => {
     aiToolResultDataHandlers.tool_call_start(req)
     const item = req.rawData.contents.get('call-9')
     expect(item?.type).toBe(AIChatQSDataTypeEnum.TOOL_RESULT)
+    expect(item?.stageSettled).toBe(false)
   })
 
-  it('D6: tool_call_param updates params', () => {
+  it('D6: tool_call_param updates params', async () => {
     const req = makeHandlerRequest({
       res: makeGrpcJsonRes('tool_call_param', {
         call_tool_id: 'call-9',
@@ -40,7 +42,7 @@ describe('aiToolResult handlers', () => {
       AIModelName: '',
       data: { tool: { status: 'default' }, callToolId: 'call-9' },
     } as any)
-    aiToolResultDataHandlers.tool_call_param(req)
+    await aiToolResultDataHandlers.tool_call_param(req)
     expect((req.rawData.contents.get('call-9') as any).data.tool.reviewParams).toEqual({ a: 1 })
   })
 

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/contentPersistHelper.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/contentPersistHelper.test.ts
@@ -8,6 +8,7 @@ import {
   deletePersistedContent,
   setSessionReferencePersist,
   drainSessionContentWrites,
+  applyHydratedStageSettled,
 } from '../persist/contentPersistHelper'
 import { AIChatQSDataTypeEnum } from '../aiRender'
 import aiChatPersistStore from '../persist/aiChatPersistStore'
@@ -49,7 +50,17 @@ describe('contentPersistHelper', () => {
       data: { tool: { status: 'success' } },
     } as any
     await persistToolResultIfTerminal('s1', terminal)
+    expect(terminal.stageSettled).toBe(true)
     expect(aiChatPersistStore.setSessionContent).toHaveBeenCalled()
+  })
+
+  it('marks IDB hydrate missing stageSettled as true', () => {
+    const content = { id: 'old', type: AIChatQSDataTypeEnum.THOUGHT, data: 'x' } as any
+    applyHydratedStageSettled(content)
+    expect(content.stageSettled).toBe(true)
+    const hot = { id: 'hot', stageSettled: false } as any
+    applyHydratedStageSettled(hot)
+    expect(hot.stageSettled).toBe(false)
   })
 
   it('E3: clone / persistIndependent / delete', async () => {
@@ -63,6 +74,7 @@ describe('contentPersistHelper', () => {
     expect(cloned).not.toBe(data)
 
     await persistIndependentItem('s1', data)
+    expect(data.stageSettled).toBe(true)
     expect(aiChatPersistStore.setSessionContent).toHaveBeenCalledWith('s1', 'x1', expect.any(Function))
 
     await deletePersistedContent('s1', 'x1')

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/ensureContentInMemory.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/ensureContentInMemory.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ensureContentInMemory } from '../persist/ensureContentInMemory'
+import { AIChatQSDataTypeEnum } from '../aiRender'
+
+const persistGetSessionContent = vi.hoisted(() => vi.fn())
+
+vi.mock('../persist/contentPersistHelper', () => ({
+  applyHydratedStageSettled: (content: { stageSettled?: boolean }) => {
+    if (content.stageSettled !== false) content.stageSettled = true
+    return content
+  },
+  persistGetSessionContent,
+}))
+
+describe('ensureContentInMemory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns existing without reading IDB', async () => {
+    const contents = new Map<string, any>()
+    const current = { id: 't1', type: AIChatQSDataTypeEnum.THOUGHT, data: 'a' }
+    contents.set('t1', current)
+    const got = await ensureContentInMemory('s1', 't1', contents)
+    expect(got).toBe(current)
+    expect(persistGetSessionContent).not.toHaveBeenCalled()
+  })
+
+  it('hydrates from IDB and treats missing stageSettled as true', async () => {
+    persistGetSessionContent.mockResolvedValue({
+      id: 't1',
+      type: AIChatQSDataTypeEnum.THOUGHT,
+      data: 'from-idb',
+    })
+    const contents = new Map<string, any>()
+    const got = await ensureContentInMemory('s1', 't1', contents)
+    expect(got?.data).toBe('from-idb')
+    expect(got?.stageSettled).toBe(true)
+    expect(contents.get('t1')).toBe(got)
+  })
+
+  it('rebuilds from create when IDB misses', async () => {
+    persistGetSessionContent.mockResolvedValue(undefined)
+    const contents = new Map<string, any>()
+    const created = {
+      id: 'ew-1',
+      type: AIChatQSDataTypeEnum.STREAM,
+      stageSettled: false,
+      data: { status: 'start', content: '' },
+    } as any
+    const got = await ensureContentInMemory('s1', 'ew-1', contents, () => created)
+    expect(got).toBe(created)
+    expect(contents.get('ew-1')).toBe(created)
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/useLoadOlder.evict.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/useLoadOlder.evict.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { collectEvictableContentTokens } from '../contentEvict'
+import { AIChatQSDataTypeEnum } from '../aiRender'
+
+describe('collectEvictableContentTokens', () => {
+  const makeContents = () => {
+    const contents = new Map<string, any>()
+    contents.set('hot-stream', {
+      id: 'hot-stream',
+      type: AIChatQSDataTypeEnum.STREAM,
+      stageSettled: false,
+    })
+    contents.set('settled', {
+      id: 'settled',
+      type: AIChatQSDataTypeEnum.THOUGHT,
+      stageSettled: true,
+    })
+    contents.set('legacy', {
+      id: 'legacy',
+      type: AIChatQSDataTypeEnum.QUESTION,
+    })
+    contents.set('visible', {
+      id: 'visible',
+      type: AIChatQSDataTypeEnum.RESULT,
+      stageSettled: true,
+    })
+    return contents
+  }
+
+  it('skips entire evict when session execute', () => {
+    const keep = new Set<string>()
+    expect(collectEvictableContentTokens(makeContents(), keep, true)).toEqual([])
+  })
+
+  it('keeps stageSettled false and keep-set; evicts settled and legacy missing field', () => {
+    const keep = new Set(['visible'])
+    const toEvict = collectEvictableContentTokens(makeContents(), keep, false)
+    expect(toEvict.sort()).toEqual(['legacy', 'settled'])
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/utils.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/utils.test.ts
@@ -51,6 +51,7 @@ describe('utils core helpers', () => {
     expect(base.AIModelName).toBe('model')
     expect(base.Timestamp).toBe(123)
     expect(base.id).toBeTruthy()
+    expect(base.stageSettled).toBe(false)
   })
 
   it('B4: genExecTasks flattens tree and maps depends_on', () => {

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/aiRender.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/aiRender.ts
@@ -411,6 +411,11 @@ export interface AIChatQSDataBase<T extends string, U> {
   reference?: string[]
   /** 父集合组的key/token(如果被收集到集合组中, 则存在该字段) */
   parentGroupToken?: string
+  /**
+   * 阶段性完成。false=热数据，不可从内存淘汰；true=可按视窗 evict。
+   * 缺字段（IDB 旧行）视为 true。
+   */
+  stageSettled?: boolean
 }
 
 type ChatQuestion = AIChatQSDataBase<AIChatQSDataTypeEnum.QUESTION, string>

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/contentEvict.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/contentEvict.ts
@@ -1,0 +1,20 @@
+import type { AIChatQSData } from './aiRender'
+
+/**
+ * 空闲会话视窗淘汰：keep 内、或 stageSettled===false 的热数据不删。
+ * execute 中整表跳过。
+ */
+export const collectEvictableContentTokens = (
+  contents: Map<string, AIChatQSData>,
+  keep: Set<string>,
+  execute: boolean,
+): string[] => {
+  if (execute) return []
+  const toEvict: string[] = []
+  for (const [token, content] of contents) {
+    if (keep.has(token)) continue
+    if (content.stageSettled === false) continue
+    toEvict.push(token)
+  }
+  return toEvict
+}

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcStreamHandler/aiStream.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcStreamHandler/aiStream.ts
@@ -12,7 +12,41 @@ import {
   setSessionReferencePersist,
   upsertSessionContent,
 } from '../persist/contentPersistHelper'
+import { ensureContentInMemory } from '../persist/ensureContentInMemory'
 import { ensureToolResultOnUI } from './aiToolResult'
+
+/**
+ * 构造 STREAM 正文（id = event_writer_id / EventUUID）。
+ * stream_start 直接写入 Map；stream / stream-finished 在 contents miss 时作为
+ * ensureContentInMemory 的 create：中途未落盘，淘汰后只能按当前事件重建，不写 IDB。
+ */
+const createStreamChatData = (
+  requestInfo: AIMessageHandlerParams,
+  eventWriterId: string,
+): Extract<AIChatQSData, { type: AIChatQSDataTypeEnum.STREAM }> => {
+  const { res, chatType, store, rawData } = requestInfo
+  return {
+    ...genBaseAIChatData(res),
+    id: eventWriterId,
+    chatType,
+    type: AIChatQSDataTypeEnum.STREAM,
+    data: {
+      NodeId: res.NodeId,
+      NodeIdVerbose: res.NodeIdVerbose || convertNodeIdToVerbose(res.NodeId),
+      CallToolID: res.CallToolID,
+      EventUUID: eventWriterId,
+      status: 'start',
+      content: '',
+      ContentType: res.ContentType,
+    },
+    TaskId: generateTaskNodeDataID({
+      chatType,
+      planID: store.getState().currentChatStatus.questionID,
+      taskID: res.TaskId,
+      isExist: (key) => rawData.contents.has(key),
+    }),
+  }
+}
 
 /** 生成stream_group组数据 */
 const genStreamGroupData = (
@@ -63,8 +97,8 @@ const genStreamGroupData = (
   })
 }
 
-const handleStreamStart: AIMessageHandler = (requestInfo) => {
-  const { res, chatType, store, rawData, meta } = requestInfo
+const handleStreamStart: AIMessageHandler = async (requestInfo) => {
+  const { sessionId, res, rawData, meta } = requestInfo
   if (res.Type !== 'stream_start') return
 
   if (res.IsSystem || res.IsReason) return
@@ -101,7 +135,7 @@ const handleStreamStart: AIMessageHandler = (requestInfo) => {
       requestInfo.pushLog({ level: 'error', message: `${res.Type}数据(NodeId: ${NodeId}), CallToolID 为空` })
       return
     }
-    const toolResult = rawData.contents.get(CallToolID)
+    const toolResult = await ensureContentInMemory(sessionId, CallToolID, rawData.contents)
     if (!toolResult || toolResult.type !== AIChatQSDataTypeEnum.TOOL_RESULT) {
       requestInfo.pushLog({
         level: 'error',
@@ -110,27 +144,7 @@ const handleStreamStart: AIMessageHandler = (requestInfo) => {
       return
     }
 
-    rawData.contents.set(event_writer_id, {
-      ...genBaseAIChatData(res),
-      id: event_writer_id,
-      chatType: chatType,
-      type: AIChatQSDataTypeEnum.STREAM,
-      data: {
-        NodeId,
-        NodeIdVerbose: res.NodeIdVerbose || convertNodeIdToVerbose(NodeId),
-        CallToolID,
-        EventUUID: event_writer_id,
-        status: 'start',
-        content: '',
-        ContentType: res.ContentType,
-      },
-      TaskId: generateTaskNodeDataID({
-        chatType,
-        planID: store.getState().currentChatStatus.questionID,
-        taskID: res.TaskId,
-        isExist: (key) => rawData.contents.has(key),
-      }),
-    })
+    rawData.contents.set(event_writer_id, createStreamChatData(requestInfo, event_writer_id))
     toolResult.data.stream.EventUUID = event_writer_id
     toolResult.data.type = 'stream'
     // stdout 流开始：工具卡片首次上树（create 阶段故意不上屏）
@@ -150,31 +164,11 @@ const handleStreamStart: AIMessageHandler = (requestInfo) => {
     return
   }
 
-  rawData.contents.set(event_writer_id, {
-    ...genBaseAIChatData(res),
-    id: event_writer_id,
-    chatType: chatType,
-    type: AIChatQSDataTypeEnum.STREAM,
-    data: {
-      NodeId,
-      NodeIdVerbose: res.NodeIdVerbose || convertNodeIdToVerbose(NodeId),
-      CallToolID,
-      EventUUID: event_writer_id,
-      status: 'start',
-      content: '',
-      ContentType: res.ContentType,
-    },
-    TaskId: generateTaskNodeDataID({
-      chatType,
-      planID: store.getState().currentChatStatus.questionID,
-      taskID: res.TaskId,
-      isExist: (key) => rawData.contents.has(key),
-    }),
-  })
+  rawData.contents.set(event_writer_id, createStreamChatData(requestInfo, event_writer_id))
 }
 
-const handleStream: AIMessageHandler = (requestInfo) => {
-  const { res, chatType, store, rawData, meta } = requestInfo
+const handleStream: AIMessageHandler = async (requestInfo) => {
+  const { sessionId, res, chatType, store, rawData, meta } = requestInfo
   if (res.Type !== 'stream') return
   // 历史数据-(系统信息|推理信息)数据，不处理
   if (res.IsSync && (res.IsSystem || res.IsReason)) return
@@ -237,7 +231,7 @@ const handleStream: AIMessageHandler = (requestInfo) => {
       requestInfo.pushLog({ level: 'error', message: `${res.Type}数据(NodeId: ${NodeId}), CallToolID 为空` })
       return
     }
-    const toolResult = rawData.contents.get(CallToolID)
+    const toolResult = await ensureContentInMemory(sessionId, CallToolID, rawData.contents)
     if (!toolResult || toolResult.type !== AIChatQSDataTypeEnum.TOOL_RESULT || !toolResult.data.stream.EventUUID) {
       requestInfo.pushLog({
         level: 'error',
@@ -245,7 +239,12 @@ const handleStream: AIMessageHandler = (requestInfo) => {
       })
       return
     }
-    const toolForStreamData = rawData.contents.get(toolResult.data.stream.EventUUID)
+    const toolForStreamData = await ensureContentInMemory(
+      sessionId,
+      toolResult.data.stream.EventUUID,
+      rawData.contents,
+      () => createStreamChatData(requestInfo, toolResult.data.stream.EventUUID),
+    )
     if (!toolForStreamData || toolForStreamData.type !== AIChatQSDataTypeEnum.STREAM) {
       requestInfo.pushLog({
         level: 'error',
@@ -264,7 +263,9 @@ const handleStream: AIMessageHandler = (requestInfo) => {
   }
 
   // 数据集合中对应的数据
-  const streamData = rawData.contents.get(EventUUID)
+  const streamData = await ensureContentInMemory(sessionId, EventUUID, rawData.contents, () =>
+    createStreamChatData(requestInfo, EventUUID),
+  )
 
   // 数据不存在
   if (!streamData || streamData.type !== AIChatQSDataTypeEnum.STREAM) {
@@ -296,8 +297,8 @@ const handleStream: AIMessageHandler = (requestInfo) => {
   }
 }
 
-const handleStreamFinished: AIMessageHandler = (requestInfo) => {
-  const { res, store, rawData, meta } = requestInfo
+const handleStreamFinished: AIMessageHandler = async (requestInfo) => {
+  const { sessionId, res, store, rawData, meta } = requestInfo
   if (res.Type !== 'structured' || res.NodeId !== 'stream-finished') return
   // 历史数据-(系统信息|推理信息)数据，不处理
   if (res.IsSync && (res.IsSystem || res.IsReason)) return
@@ -341,7 +342,7 @@ const handleStreamFinished: AIMessageHandler = (requestInfo) => {
       return
     }
 
-    const toolResult = rawData.contents.get(CallToolID)
+    const toolResult = await ensureContentInMemory(sessionId, CallToolID, rawData.contents)
     if (!toolResult || toolResult.type !== AIChatQSDataTypeEnum.TOOL_RESULT) {
       // 工具执行结果卡片UI没有展示时
       toolErrorResult.status = 'end'
@@ -362,11 +363,16 @@ const handleStreamFinished: AIMessageHandler = (requestInfo) => {
       return
     }
 
-    const toolResult = rawData.contents.get(res.CallToolID)
+    const toolResult = await ensureContentInMemory(sessionId, res.CallToolID, rawData.contents)
     if (!toolResult || toolResult.type !== AIChatQSDataTypeEnum.TOOL_RESULT || !toolResult.data.stream.EventUUID) {
       return
     }
-    const toolForStreamData = rawData.contents.get(toolResult.data.stream.EventUUID)
+    const toolForStreamData = await ensureContentInMemory(
+      sessionId,
+      toolResult.data.stream.EventUUID,
+      rawData.contents,
+      () => createStreamChatData(requestInfo, toolResult.data.stream.EventUUID),
+    )
     if (!toolForStreamData || toolForStreamData.type !== AIChatQSDataTypeEnum.STREAM) {
       return
     }
@@ -385,7 +391,12 @@ const handleStreamFinished: AIMessageHandler = (requestInfo) => {
   }
 
   // 数据集合中对应的数据
-  const streamData = rawData.contents.get(event_writer_id)
+  const streamData = await ensureContentInMemory(sessionId, event_writer_id, rawData.contents, () => {
+    const created = createStreamChatData(requestInfo, event_writer_id)
+    created.data.NodeId = node_id
+    created.data.status = 'end'
+    return created
+  })
   // 数据不存在 不输出到日志，因为日志的流数据也有该类型数据
   if (!streamData || streamData.type !== AIChatQSDataTypeEnum.STREAM) return
 
@@ -395,15 +406,17 @@ const handleStreamFinished: AIMessageHandler = (requestInfo) => {
   upsertSessionContent(requestInfo.sessionId, streamData.id, streamData)
 }
 
-const handleReferenceMaterial: AIMessageHandler = (requestInfo) => {
+const handleReferenceMaterial: AIMessageHandler = async (requestInfo) => {
   const { sessionId, res, chatType, store, rawData } = requestInfo
   if (res.Type !== 'reference_material') return
 
   const ipcContent = Uint8ArrayToString(res.Content) || ''
   const data = JSON.parse(ipcContent) as AIAgentGrpcApi.ReferenceMaterialPayload
 
-  const chatData = rawData.contents.get(data.event_uuid)
-  const toolResult = rawData.contents.get(res.CallToolID || '')
+  const chatData = await ensureContentInMemory(sessionId, data.event_uuid, rawData.contents)
+  const toolResult = res.CallToolID
+    ? await ensureContentInMemory(sessionId, res.CallToolID, rawData.contents)
+    : undefined
 
   // 收数时自动生成 refToken，立刻落表3；内存只挂 token，不存完整 payload
   const refToken = uuidv4()

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcStreamHandler/aiToolResult.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcStreamHandler/aiToolResult.ts
@@ -6,6 +6,7 @@ import { AIChatQSDataTypeEnum, type AIChatQSData, type AIToolResult } from '../a
 import cloneDeep from 'lodash/cloneDeep'
 import { DefaultAIToolResult, DefaultToolResultSummary } from '../defaultConstant'
 import { persistToolResultIfTerminal, upsertSessionContent } from '../persist/contentPersistHelper'
+import { ensureContentInMemory } from '../persist/ensureContentInMemory'
 
 /**
  * 工具卡片首次上树用 dispatchStreamingNode；已在 items 里则只 bump renderNum。
@@ -30,6 +31,15 @@ export const ensureToolResultOnUI = (
       isHistory: res.IsSync,
     },
   })
+}
+
+const ensureToolResultContent = async (
+  requestInfo: AIMessageHandlerParams,
+  callToolId: string,
+): Promise<Extract<AIChatQSData, { type: AIChatQSDataTypeEnum.TOOL_RESULT }> | undefined> => {
+  const item = await ensureContentInMemory(requestInfo.sessionId, callToolId, requestInfo.rawData.contents)
+  if (!item || item.type !== AIChatQSDataTypeEnum.TOOL_RESULT) return undefined
+  return item
 }
 
 const handleToolCallStart: AIMessageHandler = (requestInfo) => {
@@ -68,8 +78,8 @@ const handleToolCallStart: AIMessageHandler = (requestInfo) => {
   })
 }
 
-const handleToolCallParam: AIMessageHandler = (requestInfo) => {
-  const { res, rawData } = requestInfo
+const handleToolCallParam: AIMessageHandler = async (requestInfo) => {
+  const { res } = requestInfo
   if (res.Type !== 'tool_call_param') return
 
   const ipcContent = Uint8ArrayToString(res.Content) || ''
@@ -79,8 +89,8 @@ const handleToolCallParam: AIMessageHandler = (requestInfo) => {
     return
   }
 
-  const toolResult = rawData.contents.get(call_tool_id)
-  if (!toolResult || toolResult.type !== AIChatQSDataTypeEnum.TOOL_RESULT) {
+  const toolResult = await ensureToolResultContent(requestInfo, call_tool_id)
+  if (!toolResult) {
     requestInfo.pushLog({
       level: 'error',
       message: `${res.Type}数据(call_tool_id:${call_tool_id}), 没有对应的tool_call_start类型初始化`,
@@ -94,7 +104,7 @@ const handleToolCallParam: AIMessageHandler = (requestInfo) => {
   persistToolResultIfTerminal(requestInfo.sessionId, toolResult)
 }
 
-const handleToolCallWatcher: AIMessageHandler = (requestInfo) => {
+const handleToolCallWatcher: AIMessageHandler = async (requestInfo) => {
   const { res, rawData } = requestInfo
   if (res.Type !== 'tool_call_watcher') return
 
@@ -106,8 +116,8 @@ const handleToolCallWatcher: AIMessageHandler = (requestInfo) => {
   }
 
   // 先获取工具结果数据，从里面拿到stream的EventUUID
-  const toolResult = rawData.contents.get(call_tool_id)
-  if (!toolResult || toolResult.type !== AIChatQSDataTypeEnum.TOOL_RESULT || !toolResult.data.stream.EventUUID) {
+  const toolResult = await ensureToolResultContent(requestInfo, call_tool_id)
+  if (!toolResult || !toolResult.data.stream.EventUUID) {
     requestInfo.pushLog({
       level: 'error',
       message: `${res.Type}数据(call_tool_id:${call_tool_id}), 没有对应的tool_call_start类型初始化`,
@@ -115,7 +125,11 @@ const handleToolCallWatcher: AIMessageHandler = (requestInfo) => {
     return
   }
   // 通过上面获取到的EventUUID，获取stream数据
-  const toolForStreamData = rawData.contents.get(toolResult.data.stream.EventUUID)
+  const toolForStreamData = await ensureContentInMemory(
+    requestInfo.sessionId,
+    toolResult.data.stream.EventUUID,
+    rawData.contents,
+  )
   if (!toolForStreamData || toolForStreamData.type !== AIChatQSDataTypeEnum.STREAM) {
     requestInfo.pushLog({
       level: 'error',
@@ -137,8 +151,8 @@ const handleToolCallWatcher: AIMessageHandler = (requestInfo) => {
   }
 }
 
-const handleToolCallLogDir: AIMessageHandler = (requestInfo) => {
-  const { res, rawData } = requestInfo
+const handleToolCallLogDir: AIMessageHandler = async (requestInfo) => {
+  const { res } = requestInfo
   if (res.Type !== 'tool_call_log_dir') return
 
   const ipcContent = Uint8ArrayToString(res.Content) || ''
@@ -148,8 +162,8 @@ const handleToolCallLogDir: AIMessageHandler = (requestInfo) => {
     return
   }
 
-  const toolResult = rawData.contents.get(call_tool_id)
-  if (!toolResult || toolResult.type !== AIChatQSDataTypeEnum.TOOL_RESULT) {
+  const toolResult = await ensureToolResultContent(requestInfo, call_tool_id)
+  if (!toolResult) {
     requestInfo.pushLog({
       level: 'error',
       message: `${res.Type}数据(call_tool_id:${call_tool_id}), 没有对应的tool_call_start类型初始化`,
@@ -170,8 +184,8 @@ const handleToolCallLogDir: AIMessageHandler = (requestInfo) => {
   persistToolResultIfTerminal(requestInfo.sessionId, toolResult)
 }
 
-const handleToolCallResult: AIMessageHandler = (requestInfo) => {
-  const { res, rawData, meta } = requestInfo
+const handleToolCallResult: AIMessageHandler = async (requestInfo) => {
+  const { res, meta } = requestInfo
   if (!['tool_call_user_cancel', 'tool_call_done', 'tool_call_error'].includes(res.Type)) return
   const status =
     { tool_call_user_cancel: 'user_cancelled', tool_call_done: 'success', tool_call_error: 'failed' }[res.Type] ||
@@ -185,8 +199,8 @@ const handleToolCallResult: AIMessageHandler = (requestInfo) => {
     return
   }
 
-  const toolResult = rawData.contents.get(call_tool_id)
-  if (!toolResult || toolResult.type !== AIChatQSDataTypeEnum.TOOL_RESULT) {
+  const toolResult = await ensureToolResultContent(requestInfo, call_tool_id)
+  if (!toolResult) {
     requestInfo.pushLog({
       level: 'error',
       message: `${res.Type}数据(call_tool_id:${call_tool_id}), 没有对应的tool_call_start类型初始化`,
@@ -221,8 +235,8 @@ const handleToolCallResult: AIMessageHandler = (requestInfo) => {
   upsertSessionContent(requestInfo.sessionId, toolResult.id, toolResult)
 }
 
-const handleToolCallSummary: AIMessageHandler = (requestInfo) => {
-  const { res, rawData, meta } = requestInfo
+const handleToolCallSummary: AIMessageHandler = async (requestInfo) => {
+  const { res, meta } = requestInfo
   if (res.Type !== 'tool_call_summary') return
 
   const ipcContent = Uint8ArrayToString(res.Content) || ''
@@ -232,8 +246,8 @@ const handleToolCallSummary: AIMessageHandler = (requestInfo) => {
     return
   }
 
-  const toolResult = rawData.contents.get(call_tool_id)
-  if (!toolResult || toolResult.type !== AIChatQSDataTypeEnum.TOOL_RESULT) {
+  const toolResult = await ensureToolResultContent(requestInfo, call_tool_id)
+  if (!toolResult) {
     requestInfo.pushLog({
       level: 'error',
       message: `${res.Type}数据(call_tool_id:${call_tool_id}), 没有对应的tool_call_start类型初始化`,
@@ -262,8 +276,8 @@ const handleToolCallSummary: AIMessageHandler = (requestInfo) => {
   persistToolResultIfTerminal(requestInfo.sessionId, toolResult)
 }
 
-const handleToolCallStatus: AIMessageHandler = (requestInfo) => {
-  const { res, rawData } = requestInfo
+const handleToolCallStatus: AIMessageHandler = async (requestInfo) => {
+  const { res } = requestInfo
   if (res.Type !== 'tool_call_status') return
 
   const ipcContent = Uint8ArrayToString(res.Content) || ''
@@ -273,8 +287,8 @@ const handleToolCallStatus: AIMessageHandler = (requestInfo) => {
     return
   }
 
-  const toolResult = rawData.contents.get(call_tool_id)
-  if (!toolResult || toolResult.type !== AIChatQSDataTypeEnum.TOOL_RESULT) {
+  const toolResult = await ensureToolResultContent(requestInfo, call_tool_id)
+  if (!toolResult) {
     requestInfo.pushLog({
       level: 'error',
       message: `${res.Type}数据(call_tool_id:${call_tool_id}), 没有对应的tool_call_start类型初始化`,
@@ -290,8 +304,8 @@ const handleToolCallStatus: AIMessageHandler = (requestInfo) => {
   persistToolResultIfTerminal(requestInfo.sessionId, toolResult)
 }
 
-const handleToolCallReason: AIMessageHandler = (requestInfo) => {
-  const { res, rawData } = requestInfo
+const handleToolCallReason: AIMessageHandler = async (requestInfo) => {
+  const { res } = requestInfo
   if (res.Type !== 'tool_call_reason') return
 
   const ipcContent = Uint8ArrayToString(res.Content) || ''
@@ -301,8 +315,8 @@ const handleToolCallReason: AIMessageHandler = (requestInfo) => {
     return
   }
 
-  const toolResult = rawData.contents.get(call_tool_id)
-  if (!toolResult || toolResult.type !== AIChatQSDataTypeEnum.TOOL_RESULT) {
+  const toolResult = await ensureToolResultContent(requestInfo, call_tool_id)
+  if (!toolResult) {
     requestInfo.pushLog({
       level: 'error',
       message: `${res.Type}数据(call_tool_id:${call_tool_id}), 没有对应的tool_call_start类型初始化`,

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/persist/contentPersistHelper.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/persist/contentPersistHelper.ts
@@ -30,6 +30,21 @@ export const clonePersistableContent = (data: AIChatQSData): AIChatQSData => {
   return cloneDeep(data)
 }
 
+/** IDB 灌回：缺 stageSettled 视为已完成，可淘汰 */
+export const applyHydratedStageSettled = (content: AIChatQSData): AIChatQSData => {
+  if (content.stageSettled !== false) content.stageSettled = true
+  return content
+}
+
+/** 按 token 读取会话正文；读盘失败返回 undefined，不抛 */
+export const persistGetSessionContent = async (sessionId: string, token: string): Promise<AIChatQSData | undefined> => {
+  try {
+    return await aiChatPersistStore.getSessionContent(sessionId, token)
+  } catch {
+    return undefined
+  }
+}
+
 /**
  * 写入/覆盖会话正文（入队串行）。
  * next 为完整对象时直接 put；为 updater 时走同事务 get→update→put。
@@ -42,8 +57,13 @@ export const upsertSessionContent = (
   return enqueueContentWrite(sessionId, token, async () => {
     try {
       if (typeof next === 'function') {
-        await aiChatPersistStore.setSessionContent(sessionId, token, next)
+        await aiChatPersistStore.setSessionContent(sessionId, token, (old) => {
+          const result = next(old)
+          result.stageSettled = true
+          return result
+        })
       } else {
+        next.stageSettled = true
         const snapshot = clonePersistableContent(next)
         await aiChatPersistStore.setSessionContent(sessionId, token, () => snapshot)
       }

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/persist/ensureContentInMemory.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/persist/ensureContentInMemory.ts
@@ -1,0 +1,34 @@
+import type { AIChatQSData } from '../aiRender'
+import { applyHydratedStageSettled, persistGetSessionContent } from './contentPersistHelper'
+
+/**
+ * 内存没有则从 IDB 灌回 Map（旧行缺 stageSettled 视为 true）。
+ * 仍没有则用 create 按事件重建，不写回对抗淘汰的热路径。
+ */
+export const ensureContentInMemory = async (
+  sessionId: string,
+  token: string,
+  contents: Map<string, AIChatQSData>,
+  create?: () => AIChatQSData | undefined,
+): Promise<AIChatQSData | undefined> => {
+  const existing = contents.get(token)
+  if (existing) return existing
+
+  try {
+    const persisted = await persistGetSessionContent(sessionId, token)
+    if (persisted) {
+      applyHydratedStageSettled(persisted)
+      contents.set(token, persisted)
+      return persisted
+    }
+  } catch {
+    // 读盘失败不打断主流程，走 create
+  }
+
+  const created = create?.()
+  if (created) {
+    contents.set(token, created)
+    return created
+  }
+  return undefined
+}

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/type.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/type.ts
@@ -37,5 +37,5 @@ export interface AIMessageHandlerParams extends ReturnType<ChatMultiSessionContr
   sendRequest: (request: AIInputEvent) => void
   pushLog: (log: AIAgentGrpcApi.Log) => void
 }
-export type AIMessageHandler = (params: AIMessageHandlerParams) => void
+export type AIMessageHandler = (params: AIMessageHandlerParams) => void | Promise<void>
 // #endregion

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/useLoadOlder.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/useLoadOlder.ts
@@ -12,8 +12,8 @@ import { collectEvictableContentTokens } from './contentEvict'
 
 /** 向上/向下固定预取条数 */
 const LOAD_AHEAD = 10
-/** 向后保留条数（已滚过的不立即淘汰，保留 5 条缓冲） */
-const KEEP_BEHIND = 5
+/** 向后保留条数（已滚过的不立即淘汰，贴底回看时减少空壳灌内容撑高） */
+const KEEP_BEHIND = 15
 /** 强制保留最新尾部条数（人在中间看历史时，底部流式输出不丢展示） */
 const TAIL_KEEP = 30
 /** firstItemIndex 起始偏移 */

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/useLoadOlder.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/useLoadOlder.ts
@@ -6,7 +6,9 @@ import { globalSessionEngine } from './ChatMultiSessionController'
 import { useCurrentStore, useCurrentRawData } from './useCurrentDataBySession'
 import useCurrentSessionId from './useCurrentSessionId'
 import { AITaskStatus } from './grpcApi'
-import type { ChatListRenderType } from './aiRender'
+import { type ChatListRenderType } from './aiRender'
+import { applyHydratedStageSettled } from './persist/contentPersistHelper'
+import { collectEvictableContentTokens } from './contentEvict'
 
 /** 向上/向下固定预取条数 */
 const LOAD_AHEAD = 10
@@ -143,7 +145,7 @@ const useLoadOlder = (chatType: ChatListRenderType) => {
   }, [processing, handleLoadMore])
   // #endregion
 
-  // 切会话时重置方向跟踪与杂项 Ref + 清空旧 contents（旧 session Map 占内存）
+  // 切会话：cleanup 清旧会话；执行中不清。不要在切进来时清空当前 session。
   useEffect(() => {
     lastStartIndexRef.current = -1
     wasLoadingRef.current = false
@@ -151,10 +153,11 @@ const useLoadOlder = (chatType: ChatListRenderType) => {
     isPrependingRef.current = false
     atTopRef.current = false
     pendingRequestRef.current = false
-    // 清空旧 session 的 contents 视窗（保留 IDB，可恢复）
-    if (sessionId && rawData.contents.size > 0) {
-      const tokens = [...rawData.contents.keys()]
-      globalSessionEngine.removeContentsFromMemory(sessionId, tokens)
+    const leavingId = sessionId
+    return () => {
+      if (!leavingId) return
+      if (globalSessionEngine.getSessionExecute(leavingId)) return
+      globalSessionEngine.removeContentsFromMemory(leavingId)
     }
   }, [sessionId])
 
@@ -211,6 +214,7 @@ const useLoadOlder = (chatType: ChatListRenderType) => {
     const rows = await globalSessionEngine.persistGetSessionContents(sessionId, tokens)
     const state = store.getState()
     for (const row of rows) {
+      applyHydratedStageSettled(row.content)
       rawData.contents.set(row.token, row.content)
       // 按 kind bump renderNum：item→items，group→groups，task→tasks
       if (state.items[row.token]) {
@@ -255,13 +259,13 @@ const useLoadOlder = (chatType: ChatListRenderType) => {
   const evictOutsideViewport = useMemoizedFn((startIndex: number, endIndex: number) => {
     if (!sessionId) return
     const keep = computeKeepTokens(startIndex, endIndex)
-    // 强制保留当前活跃 review 数据，避免视窗淘汰导致提交时取不到
     const currentReviewDetail = store.getState().currentReviewDetail
     if (currentReviewDetail.token) keep.add(currentReviewDetail.token)
-    const toEvict: string[] = []
-    for (const token of rawData.contents.keys()) {
-      if (!keep.has(token)) toEvict.push(token)
-    }
+    const toEvict = collectEvictableContentTokens(
+      rawData.contents,
+      keep,
+      globalSessionEngine.getSessionExecute(sessionId),
+    )
     if (toEvict.length) {
       globalSessionEngine.removeContentsFromMemory(sessionId, toEvict)
     }

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/utils.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/utils.ts
@@ -43,6 +43,7 @@ export const genBaseAIChatData = (info: AIOutputEvent) => {
     AIService: info.AIService,
     AIModelName: info.AIModelName,
     Timestamp: info.Timestamp,
+    stageSettled: false as boolean,
   }
 }
 


### PR DESCRIPTION
## 背景

AI Agent 长会话场景下，`rawData.contents` 会把整段会话正文常驻内存，随轮次增长内存占用持续上升；同时虚拟列表对已滚过视窗的内容不做淘汰，空壳撑高导致回看时频繁撑高抖动。

## 改动

### 1. 视窗外正文淘汰 + 按需回灌（contentEvict / ensureContentInMemory）

- 新增 `stageSettled` 热冷标记：`false` 表示热数据（未落盘 / 流式中），不可淘汰；`true` 表示已落盘可淘汰。IDB 旧行缺该字段视为 `true`。
- 新增 `contentEvict.ts`：视窗外且不在 keep 集合、且非热数据的条目参与淘汰；会话执行中整表跳过淘汰。
- 新增 `ensureContentInMemory.ts`：handler 取 contents miss 时先从 IDB 回灌（旧行补 `stageSettled=true`），仍 miss 则按当前事件重建（不写回 IDB，避免对抗淘汰热路径）。
- `contentPersistHelper` 在 `upsertSessionContent` 落盘时统一置 `stageSettled=true`；新增 `applyHydratedStageSettled` / `persistGetSessionContent`。
- `ChatMultiSessionController.removeContentsFromMemory` 恢复删除逻辑，未传 tokens 或空数组时清空该 session 全部 contents；池不存在时 no-op。
- grpc handler（aiStream / aiToolResult）改为 async，所有 `rawData.contents.get` 替换为 `ensureContentInMemory`；`AIMessageHandler` 类型放宽为 `void | Promise<void>`，`handleGrpcOutputEvent` 对返回的 Promise 做兜底 catch。
- `useLoadOlder` 切会话改为在 cleanup 中清旧会话 contents（执行中不清），加载历史时对回灌行补 `stageSettled`；视窗淘汰改用 `collectEvictableContentTokens`。

### 2. 虚拟列表缓冲调参

- `defaultItemHeight` 26 → 80，更贴近真实条目高度，减少初始空壳撑高。
- 开启 `increaseViewportBy={{ top: 600, bottom: 200 }}`，向上预渲染 600px、向下 200px，平滑滚动并减少回看时空壳撑高。
- `KEEP_BEHIND` 5 → 15，贴底回看时保留更多已滚过条目，减少从 IDB 重新灌内容造成的撑高抖动。

## 测试

- 新增 `ensureContentInMemory.test.ts`、`useLoadOlder.evict.test.ts`。
- 更新 `aiStream.handlers.test.ts`、`aiToolResult.handlers.test.ts`、`contentPersistHelper.test.ts`、`ChatMultiSessionController.pageIndex.test.ts`、`utils.test.ts` 覆盖 async handler、`stageSettled` 标记与淘汰逻辑。

## 合并方式

请使用 **Squash merge** 合并。