### PR TITLE
refactor(ai-agent): uiExpandMap 写操作迁移到 ChatMultiSessionController

### DIFF
--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/ChatMultiSessionController.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/ChatMultiSessionController.ts
@@ -1455,6 +1455,25 @@ export class ChatMultiSessionController {
     persistToolResultIfTerminal(sessionId, chatDetail)
   }
 
+  /** 设置指定 token 的卡片展开态（纯 UI，不触发渲染树落库） */
+  public setUiExpand(sessionId: string, token: string, expand: boolean) {
+    if (!sessionId || !token) return
+    const { store } = this.ensureSession(sessionId)
+    store.setState((state) => {
+      state.uiExpandMap[token] = expand
+    })
+  }
+
+  /** 切换指定 token 的展开态；map 中无记录时以 defaultExpand 为当前值再取反 */
+  public toggleUiExpand(sessionId: string, token: string, defaultExpand: boolean) {
+    if (!sessionId || !token) return
+    const { store } = this.ensureSession(sessionId)
+    store.setState((state) => {
+      const prev = state.uiExpandMap[token]
+      state.uiExpandMap[token] = prev === undefined ? !defaultExpand : !prev
+    })
+  }
+
   /**
    * 停流并卸池（deleteSessions / onPageUnload）
    * - 仍 ready：pendingDispose + forceClose，等 end/fallback 后 teardown

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/aiRender.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/aiRender.ts
@@ -672,11 +672,7 @@ export interface ChatStoreState {
     >,
   ) => void
 
-  /** 设置指定 token 的展开态（不触发渲染树落库） */
-  setUiExpand: (token: string, expand: boolean) => void
-  /** 切换指定 token 的展开态；map 中无记录时以 defaultExpand 为当前值再取反 */
-  toggleUiExpand: (token: string, defaultExpand: boolean) => void
-  /** 清除指定 token 的展开态记录 */
+  /** 清除指定 token 的展开态记录（仅 store 内部删除节点时用；对外写操作走 ChatMultiSessionController） */
   clearUiExpand: (token: string) => void
 
   /**

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/aiRender.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/aiRender.ts
@@ -672,9 +672,6 @@ export interface ChatStoreState {
     >,
   ) => void
 
-  /** 清除指定 token 的展开态记录（仅 store 内部删除节点时用；对外写操作走 ChatMultiSessionController） */
-  clearUiExpand: (token: string) => void
-
   /**
    * 用持久化渲染树快照整体替换 items/groups/tasks/elements
    * 供 ChatMultiSessionController 从 IDB 恢复会话使用

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/chatStore.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/chatStore.ts
@@ -73,17 +73,6 @@ export const createChatStore = (options?: CreateChatStoreOptions) => {
       cancelChatLoading: false,
       timelinesLoading: false,
 
-      setUiExpand: (token, expand) =>
-        set((state) => {
-          if (!token) return
-          state.uiExpandMap[token] = expand
-        }),
-      toggleUiExpand: (token, defaultExpand) =>
-        set((state) => {
-          if (!token) return
-          const prev = state.uiExpandMap[token]
-          state.uiExpandMap[token] = prev === undefined ? !defaultExpand : !prev
-        }),
       clearUiExpand: (token) =>
         set((state) => {
           if (!token) return

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/chatStore.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/chatStore.ts
@@ -73,12 +73,6 @@ export const createChatStore = (options?: CreateChatStoreOptions) => {
       cancelChatLoading: false,
       timelinesLoading: false,
 
-      clearUiExpand: (token) =>
-        set((state) => {
-          if (!token) return
-          delete state.uiExpandMap[token]
-        }),
-
       updateStateCount: (type) =>
         set((state) => {
           state[type] += 1

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/useUiExpand.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/useUiExpand.ts
@@ -2,16 +2,19 @@ import { useMemoizedFn } from 'ahooks'
 import { useStore, type StoreApi } from 'zustand'
 import type { ChatStoreState } from './aiRender'
 import { useCurrentStore } from './useCurrentDataBySession'
+import useCurrentSessionId from './useCurrentSessionId'
 import { useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { isAuxOrChildWindow } from '@/utils/isAuxOrChildWindow'
+import { globalSessionEngine } from './ChatMultiSessionController'
 
 type UiExpandTuple = [boolean, Dispatch<SetStateAction<boolean>>, () => void]
 
 /**
- * 从指定 chatStore 读写卡片展开态。
+ * 从指定 chatStore 订阅展开态，写操作统一走 ChatMultiSessionController。
  * 订阅粒度仅为 uiExpandMap[token]，其它 token 变更不会触发本组件重渲染。
  */
 export function useUiExpandFromStore(
+  sessionId: string,
   store: StoreApi<ChatStoreState>,
   token: string,
   defaultExpand: boolean,
@@ -21,16 +24,16 @@ export function useUiExpandFromStore(
   const expand = stored === undefined ? defaultExpand : stored
 
   const setExpand = useMemoizedFn<Dispatch<SetStateAction<boolean>>>((next) => {
-    if (!token) return
+    if (!sessionId || !token) return
     const prev = store.getState().uiExpandMap[token]
     const prevResolved = prev === undefined ? defaultExpand : prev
     const value = typeof next === 'function' ? next(prevResolved) : next
-    store.getState().setUiExpand(token, value)
+    globalSessionEngine.setUiExpand(sessionId, token, value)
   })
 
   const toggleExpand = useMemoizedFn(() => {
-    if (!token) return
-    store.getState().toggleUiExpand(token, defaultExpand)
+    if (!sessionId || !token) return
+    globalSessionEngine.toggleUiExpand(sessionId, token, defaultExpand)
   })
 
   return [expand, setExpand, toggleExpand]
@@ -43,9 +46,10 @@ export function useUiExpandFromStore(
 export function useUiExpand(token: string, defaultExpand: boolean): UiExpandTuple {
   const isChildWindow = useRef(isAuxOrChildWindow()).current
   const useLocal = isChildWindow || !token
+  const sessionId = useCurrentSessionId()
   const store = useCurrentStore()
-  // 子窗口/无 token 仍调用 useCurrentStore（hooks 规则），但用空 token 跳过 map 读写
-  const storeTuple = useUiExpandFromStore(store, useLocal ? '' : token, defaultExpand)
+  // 子窗口/无 token 仍调用 hooks（规则），但用空 token 跳过 map 读写
+  const storeTuple = useUiExpandFromStore(useLocal ? '' : sessionId, store, useLocal ? '' : token, defaultExpand)
 
   const [localExpand, setLocalExpand] = useState(defaultExpand)
   const setLocal = useMemoizedFn<Dispatch<SetStateAction<boolean>>>((next) => {


### PR DESCRIPTION
- setUiExpand/toggleUiExpand 从 chatStore 内部 action 移到 ChatMultiSessionController，通过 sessionId 路由到正确会话 store
- useUiExpand 新增 useCurrentSessionId 获取当前会话 ID， 写操作改走 globalSessionEngine.setUiExpand/toggleUiExpand
- chatStore 保留 clearUiExpand（内部删除节点时清理用）
- aiRender.ts 类型声明同步更新