### PR TITLE
fix(aiAgent): 恢复上周误删的任务规划 todolist tab 展示逻辑

### DIFF
--- a/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatContent.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatContent.tsx
@@ -58,7 +58,7 @@ export const AIChatContent: React.FC<AIChatContentProps> = React.memo(
     const [showFreeChat, setShowFreeChat] = useState<boolean>(true) //自由对话展开收起
     const [timeLine, setTimeLine] = useState<boolean>(true) //侧边栏展开收起
     /** 任务规划 tabs 是否有内容（无则自由对话变大） */
-    // const [hasTaskTabs, setHasTaskTabs] = useState(false)
+    const [hasTaskTabs, setHasTaskTabs] = useState(false)
     /** 文件系统是否有文件预览（无则自由对话变大） */
     const [hasFilePreview, setHasFilePreview] = useState(false)
     const [runTimeId, setRunTimeId] = useState<string>() // 工具卡片跳转自带runTimeID
@@ -203,7 +203,7 @@ export const AIChatContent: React.FC<AIChatContentProps> = React.memo(
             <AIReActTaskChat
               setTimeLine={setTimeLine}
               setShowFreeChat={setShowFreeChat}
-              // onTaskTabsChange={setHasTaskTabs} // 方法未使用，新版可以废弃
+              onTaskTabsChange={setHasTaskTabs}
             />
           )
         case AITabsEnum.File_System:
@@ -249,7 +249,7 @@ export const AIChatContent: React.FC<AIChatContentProps> = React.memo(
       activeKey,
       showFreeChat,
       timeLine,
-      // hasTaskTabs,
+      hasTaskTabs,
       hasFilePreview,
     })
 

--- a/app/renderer/src/main/src/pages/ai-agent/aiChatContent/hooks/useAIChatResizeBox.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatContent/hooks/useAIChatResizeBox.ts
@@ -12,11 +12,8 @@ interface Params {
   activeKey?: AITabsEnumType
   showFreeChat: boolean
   timeLine: boolean
-  /**
-   * @deprecated 变量对应的赋值方法未使用，新版可以废弃
-   * 任务规划 tabs 是否有内容
-   */
-  // hasTaskTabs: boolean
+  /** 任务规划 tabs 是否有内容 */
+  hasTaskTabs: boolean
   /** 文件系统是否有预览文件 */
   hasFilePreview: boolean
 }
@@ -31,7 +28,7 @@ export function useAIChatResizeBox(params: Params) {
   }
 
   const resizeBoxProps = useCreation<ResizeBoxProps>(() => {
-    const { activeKey, showFreeChat, timeLine, hasFilePreview } = params
+    const { activeKey, showFreeChat, timeLine, hasTaskTabs, hasFilePreview } = params
     const override = overrideRef.current
     // 消费一次就清掉
     overrideRef.current = null
@@ -49,7 +46,7 @@ export function useAIChatResizeBox(params: Params) {
     const isFileSystem = activeKey === AITabsEnum.File_System
     const isOperationLog = activeKey === AITabsEnum.Operation_Log
     // 详情区为空 / 读写日志：左侧只保留列表宽度（与时间线一致），自由对话变大
-    const isDetailEmpty = isTaskContent || (isFileSystem && !hasFilePreview) || isOperationLog
+    const isDetailEmpty = (isTaskContent && !hasTaskTabs) || (isFileSystem && !hasFilePreview) || isOperationLog
 
     let secondRatio: ResizeBoxProps['secondRatio']
     let firstRatio: ResizeBoxProps['firstRatio']
@@ -76,7 +73,7 @@ export function useAIChatResizeBox(params: Params) {
       firstNodeStyle: {
         padding: 0,
         ...(!showFreeChat && { width: '100%' }),
-        ...(showFreeChat && isTaskContent && !timeLine ? { maxWidth: 30, minWidth: 30 } : {}),
+        ...(showFreeChat && isTaskContent && !hasTaskTabs && !timeLine ? { maxWidth: 30, minWidth: 30 } : {}),
       },
       secondNodeStyle: {
         padding: 0,
@@ -89,7 +86,7 @@ export function useAIChatResizeBox(params: Params) {
       ...computed,
       ...override,
     }
-  }, [params.activeKey, params.showFreeChat, params.timeLine, params.hasFilePreview, version])
+  }, [params.activeKey, params.showFreeChat, params.timeLine, params.hasTaskTabs, params.hasFilePreview, version])
 
   return {
     resizeBoxProps,

--- a/app/renderer/src/main/src/pages/ai-agent/aiChatWelcome/AIChatWelcome.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatWelcome/AIChatWelcome.tsx
@@ -7,7 +7,6 @@ import type {
   SideSettingButtonProps,
 } from './type'
 import styles from './AIChatWelcome.module.scss'
-import DoomFlameBackground from './DoomFlameBackground'
 import { AIChatTextarea } from '../template/template'
 import { useCreation, useDebounceFn, useInViewport, useMemoizedFn, useSize, useUpdateEffect } from 'ahooks'
 import type { AIChatTextareaRefProps, AIChatTextareaSubmit } from '../template/type'
@@ -205,7 +204,7 @@ const AIChatWelcome: React.FC<AIChatWelcomeProps> = React.memo(
     })
     return (
       <div className={styles['ai-chat-welcome-wrapper']} ref={welcomeRef}>
-        <DoomFlameBackground />
+        {/* <DoomFlameBackground /> */}
         <div className={styles['open-file-tree-button']} onClick={() => setOpenDrawer(!openDrawer)}>
           {t('AIChatWelcome.expandResources')}
           <YakitButton type="text2" icon={<OutlineOpenIcon />} />

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActTaskChat/AIReActTaskChat.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActTaskChat/AIReActTaskChat.tsx
@@ -12,7 +12,7 @@ import { AIChatLeftSide } from '@/pages/ai-agent/chatTemplate/AIAgentChatTemplat
 import { useControllableValue, useCreation, useMemoizedFn } from 'ahooks'
 import classNames from 'classnames'
 import { ChevrondownButton } from '../aiReActChat/AIReActComponent'
-import { OutlineInformationcircleIcon } from '@/assets/icon/outline'
+import { OutlineArrowscollapseIcon, OutlineArrowsexpandIcon, OutlineInformationcircleIcon } from '@/assets/icon/outline'
 import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
 import { type AIChatQSData, AIChatQSDataTypeEnum } from '../hooks/aiRender'
 import { type AIInputEvent, AIInputEventHotPatchTypeEnum, AIInputEventSyncTypeEnum } from '../hooks/grpcApi'
@@ -20,6 +20,7 @@ import { Form, Tooltip } from 'antd'
 import useAIAgentStore from '@/pages/ai-agent/useContext/useStore'
 import emiter from '@/utils/eventBus/eventBus'
 import { randomString } from '@/utils/randomUtil'
+import { YakitResizeBox } from '@/components/yakitUI/YakitResizeBox/YakitResizeBox'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { YakitPopover } from '@/components/yakitUI/YakitPopover/YakitPopover'
 import useAIGlobalConfig from '../hooks/useAIGlobalConfig'
@@ -29,83 +30,74 @@ import moment from 'moment'
 import { YakitSwitch } from '@/components/yakitUI/YakitSwitch/YakitSwitch'
 import useAIAgentDispatcher from '@/pages/ai-agent/useContext/useDispatcher'
 import has from 'lodash/has'
+import { AITaskContent } from '../aiTaskContent/AITaskContent'
 import { useCurrentMeta, useCurrentStore } from '../hooks/useCurrentDataBySession'
 import { useStore } from 'zustand'
 import useCurrentSessionId from '../hooks/useCurrentSessionId'
 import { globalSessionEngine } from '../hooks/ChatMultiSessionController'
 
 const AIReActTaskChat: React.FC<AIReActTaskChatProps> = React.memo((props) => {
-  const { /* setShowFreeChat, */ setTimeLine /* , onTaskTabsChange */ } = props
+  const { setShowFreeChat, setTimeLine, onTaskTabsChange } = props
 
   const [leftExpand, setLeftExpand] = useState(true)
-  // const [expand, setExpand] = useState(false)
-  // const [hasTabs, setHasTabs] = useState(false)
+  const [expand, setExpand] = useState(false)
+  const [hasTabs, setHasTabs] = useState(false)
 
-  // const onIsExpand = useMemoizedFn(() => {
-  //   setLeftExpand(expand)
-  //   setShowFreeChat(expand)
-  //   setExpand((v) => !v)
-  // })
+  const onIsExpand = useMemoizedFn(() => {
+    setLeftExpand(expand)
+    setShowFreeChat(expand)
+    setExpand((v) => !v)
+  })
 
   useEffect(() => {
     setTimeLine(leftExpand)
   }, [leftExpand])
 
-  // const onTabsChange = useMemoizedFn((tabsLength: number) => {
-  //   const next = tabsLength > 0
-  //   setHasTabs(next)
-  //   onTaskTabsChange?.(next)
-  // })
+  const onTabsChange = useMemoizedFn((tabsLength: number) => {
+    const next = tabsLength > 0
+    setHasTabs(next)
+    onTaskTabsChange?.(next)
+  })
 
   // 无 tab：任务规划宽度强制为 0（覆盖 secondMinSize 默认 100px）；有 tab：时间线 30% + 规划区
-  // const firstNodeStyle = useCreation(() => {
-  //   if (!hasTabs) {
-  //     return {
-  //       width: '100%',
-  //       overflow: 'hidden',
-  //       maxWidth: leftExpand ? '' : '30px',
-  //       borderRight: leftExpand ? 'none' : '1px solid var(--Colors-Use-Neutral-Border)',
-  //     }
-  //   }
-  //   return {
-  //     width: leftExpand ? '30%' : undefined,
-  //     overflow: 'hidden',
-  //     maxWidth: leftExpand ? '' : '30px',
-  //     borderRight: leftExpand ? 'none' : '1px solid var(--Colors-Use-Neutral-Border)',
-  //   }
-  // }, [hasTabs, leftExpand])
+  const firstNodeStyle = useCreation(() => {
+    if (!hasTabs) {
+      return {
+        width: '100%',
+        overflow: 'hidden',
+        maxWidth: leftExpand ? '' : '30px',
+        borderRight: leftExpand ? 'none' : '1px solid var(--Colors-Use-Neutral-Border)',
+      }
+    }
+    return {
+      width: leftExpand ? '30%' : undefined,
+      overflow: 'hidden',
+      maxWidth: leftExpand ? '' : '30px',
+      borderRight: leftExpand ? 'none' : '1px solid var(--Colors-Use-Neutral-Border)',
+    }
+  }, [hasTabs, leftExpand])
 
-  // const secondNodeStyle = useCreation(() => {
-  //   if (!hasTabs) {
-  //     return {
-  //       width: 0,
-  //       minWidth: 0,
-  //       maxWidth: 0,
-  //       padding: 0,
-  //       overflow: 'hidden' as const,
-  //       flex: 'none',
-  //     }
-  //   }
-  //   return {
-  //     width: leftExpand ? '100%' : 'calc(100% - 30px)',
-  //     padding: 0,
-  //     overflow: 'auto hidden' as const,
-  //   }
-  // }, [hasTabs, leftExpand])
+  const secondNodeStyle = useCreation(() => {
+    if (!hasTabs) {
+      return {
+        width: 0,
+        minWidth: 0,
+        maxWidth: 0,
+        padding: 0,
+        overflow: 'hidden' as const,
+        flex: 'none',
+      }
+    }
+    return {
+      width: leftExpand ? '100%' : 'calc(100% - 30px)',
+      padding: 0,
+      overflow: 'auto hidden' as const,
+    }
+  }, [hasTabs, leftExpand])
 
   return (
     <div className={styles['ai-re-act-task-chat']}>
-      <div
-        style={{
-          width: leftExpand ? '100%' : 30,
-          height: '100%',
-          overflow: 'hidden',
-          borderRight: leftExpand ? 'none' : '1px solid var(--Colors-Use-Neutral-Border)',
-        }}
-      >
-        <AIReActTaskChatLeftSide leftExpand={leftExpand} setLeftExpand={setLeftExpand} />
-      </div>
-      {/* <YakitResizeBox
+      <YakitResizeBox
         firstRatio={hasTabs ? '30%' : '100%'}
         secondRatio={hasTabs ? undefined : '0%'}
         lineDirection="right"
@@ -113,7 +105,7 @@ const AIReActTaskChat: React.FC<AIReActTaskChatProps> = React.memo((props) => {
         secondMinSize={hasTabs ? 100 : 0}
         lineStyle={{ width: hasTabs && leftExpand ? 4 : 0 }}
         freeze={hasTabs && leftExpand}
-        isRecalculateWH={hasTabs}
+        isRecalculateWH={false && hasTabs}
         firstNodeStyle={firstNodeStyle}
         secondNodeStyle={secondNodeStyle}
         firstNode={<AIReActTaskChatLeftSide leftExpand={leftExpand} setLeftExpand={setLeftExpand} />}
@@ -129,7 +121,7 @@ const AIReActTaskChat: React.FC<AIReActTaskChatProps> = React.memo((props) => {
             }
           />
         }
-      /> */}
+      />
     </div>
   )
 })

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActTaskChat/AIReActTaskChatType.d.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActTaskChat/AIReActTaskChatType.d.ts
@@ -4,8 +4,7 @@ import type { ChatListRenderType } from '../hooks/aiRender'
 export interface AIReActTaskChatProps {
   setShowFreeChat: (show: boolean) => void
   setTimeLine: (show: boolean) => void
-  /** @deprecated 任务规划 tabs 是否有内容，用于外层自由对话变大 */
-  // onTaskTabsChange?: (hasTabs: boolean) => void
+  onTaskTabsChange?: (hasTabs: boolean) => void
 }
 
 export interface AIReActTaskChatLeftSideProps {


### PR DESCRIPTION
## 背景

上周在重构 AI Agent 会话布局时，误删了任务规划区 todolist tab 的展示逻辑，导致任务规划区在有 tabs 内容时无法正常驱动自由对话区的尺寸变化。

## 改动内容

本次提交恢复被误删的代码，涉及 4 个文件：

- **AIChatContent.tsx**：恢复 `hasTaskTabs` 状态及向 `AIReActTaskChat` 传递的 `onTaskTabsChange` 回调
- **useAIChatResizeBox.ts**：恢复 `hasTaskTabs` 参数参与详情区为空判断与 `firstNodeStyle` 宽度计算
- **AIReActTaskChat.tsx**：恢复 `YakitResizeBox` 布局（取代临时纯 div 布局）、`hasTabs` / `expand` 状态、`onTabsChange` / `onIsExpand` 方法及 `firstNodeStyle` / `secondNodeStyle` 计算
- **AIReActTaskChatType.d.ts**：恢复 `onTaskTabsChange` 可选属性声明

## 影响

任务规划区有 todolist tab 内容时，自由对话区按预期收窄；无 tab 内容时自由对话区恢复全宽。

## 合并方式

⚠️ 请使用 **Squash and merge**（第二种合并方式）合并，保留单条 commit。