### PR TITLE
fix(update): download path in windows not follow system setting

### DIFF
--- a/app/main/__test__/filePath.test.js
+++ b/app/main/__test__/filePath.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import vm from 'node:vm'
+
+const filePathSource = fs.readFileSync(path.resolve(process.cwd(), 'app/main/filePath.js'), 'utf8')
+
+const loadFilePath = (electronApp) => {
+  const module = { exports: {} }
+  const mockFs = {
+    existsSync: () => true,
+    readFileSync: () => '{}',
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    copyFileSync: vi.fn(),
+  }
+
+  vm.runInNewContext(filePathSource, {
+    module,
+    exports: module.exports,
+    console: { log: vi.fn() },
+    require: (id) => {
+      if (id === 'electron') return { app: electronApp }
+      if (id === 'electron-is-dev') return false
+      if (id === 'os') return { homedir: () => '/home/yakit-test', platform: () => 'linux' }
+      if (id === 'path') return path
+      if (id === 'process') return { platform: 'win32', env: {} }
+      if (id === 'fs') return mockFs
+      throw new Error(`Unexpected module: ${id}`)
+    },
+  })
+
+  return module.exports
+}
+
+describe('getYakitInstallDir', () => {
+  it('uses the system downloads directory', () => {
+    const downloadsPath = 'D:\\WindowsKu\\Download'
+    const getPath = vi.fn(() => downloadsPath)
+    const { getYakitInstallDir } = loadFilePath({ getName: () => 'yakit', getPath, isPackaged: false })
+
+    expect(getYakitInstallDir()).toBe(downloadsPath)
+    expect(getPath).toHaveBeenCalledWith('downloads')
+  })
+
+  it('falls back to the legacy home directory when Electron cannot resolve the path', () => {
+    const getPath = vi.fn(() => {
+      throw new Error('downloads path unavailable')
+    })
+    const { getYakitInstallDir } = loadFilePath({ getName: () => 'yakit', getPath, isPackaged: false })
+
+    expect(getYakitInstallDir()).toBe(path.join('/home/yakit-test', 'Downloads'))
+  })
+})

--- a/app/main/filePath.js
+++ b/app/main/filePath.js
@@ -185,7 +185,13 @@ const _ensureDir = (dir) => {
 
 const getYaklangEngineDir = () => path.join(getYakitHome(), 'yak-engine')
 
-const getYakitInstallDir = () => path.join(os.homedir(), 'Downloads')
+const getYakitInstallDir = () => {
+  try {
+    return app.getPath('downloads')
+  } catch (e) {
+    return path.join(os.homedir(), 'Downloads')
+  }
+}
 
 const getYakOnlineRagLatest = () => path.join(getYakitHome(), 'projects/libs/rag_files')
 

--- a/app/main/handlers/upgradeUtil.js
+++ b/app/main/handlers/upgradeUtil.js
@@ -567,7 +567,7 @@ module.exports = {
         } else {
           downloadUrl = await getDownloadUrl(version, 'YakitCE')
         }
-        // 可能存在中文的下载文件夹，就判断下Downloads文件夹是否存在，不存在则新建一个
+        // 确保系统下载目录存在
         if (!fs.existsSync(getYakitInstallDir())) fs.mkdirSync(getYakitInstallDir(), { recursive: true })
         const dest = path.join(getYakitInstallDir(), path.basename(downloadUrl))
         try {
@@ -1437,7 +1437,7 @@ module.exports = {
           } else {
             downloadUrl = await getDownloadUrl(version, 'YakitCE')
           }
-          // 可能存在中文的下载文件夹，就判断下Downloads文件夹是否存在，不存在则新建一个
+          // 确保系统下载目录存在
           if (!fs.existsSync(getYakitInstallDir())) fs.mkdirSync(getYakitInstallDir(), { recursive: true })
           const dest = path.join(getYakitInstallDir(), path.basename(downloadUrl))
           try {


### PR DESCRIPTION
windows默认下载路径支持用户自定义调整所以不能认为windows的下载路径为user/Downloads文件夹。应该尝试动态获取，并在失败时回退