### PR TITLE
feat(aiAgent): 为默认对话加载标题补充「会话初始化中...」占位文案

### DIFF
--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/aiMemoryList/AIMemoryList.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/aiMemoryList/AIMemoryList.tsx
@@ -108,12 +108,13 @@ const AIMemoryList: React.FC<AIMemoryListProps> = React.memo((props) => {
   })
   const onClearMemory = useMemoizedFn(() => {
     setLoading(true)
-    /** TODO - 多会话清空记忆库，数据清空后其余会话会有新数据往记忆库中增加，导致看起来清空失败 */
+    /** NOTE - 多会话清空记忆库，数据清空后其余会话会有新数据往记忆库中增加，导致看起来清空失败 */
     grpcDeleteAIMemoryEntity({
       Filter: {},
     })
       .then(() => {
         rawData.memoryList = cloneDeep(DefaultMemoryList)
+        store.getState().updateStateCount('memoryListUpdate')
       })
       .finally(() => {
         setTimeout(() => {

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/defaultConstant.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/defaultConstant.test.ts
@@ -26,7 +26,7 @@ describe('defaultConstant', () => {
       status: AITaskStatus.created,
     })
     expect(DefaultAgentLoadingTitle).toEqual({
-      casualTitle: '',
+      casualTitle: '会话初始化中...',
       planTitle: '',
     })
     expect(DefaultTaskPlanEndGate).toEqual({ endReceived: false, pendingStatus: undefined })

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/yakExecResult.handlers.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/yakExecResult.handlers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { aiYakExecResultDataHandlers } from '../grpcStreamHandler/yakExecResult'
 import { makeGrpcJsonRes, makeHandlerRequest } from './fixtures'
+import { DefaultAgentLoadingTitle } from '../defaultConstant'
 import { AITaskStatus } from '../grpcApi'
 import { AIChatQSDataTypeEnum, type ChatTaskNodeGroup } from '../aiRender'
 
@@ -75,7 +76,7 @@ describe('yakExecResult handlers', () => {
       chatType: 'task',
     })
     aiYakExecResultDataHandlers.status(req)
-    expect(req.store.getState().currentLoadingTitle.casualTitle).toBe('')
+    expect(req.store.getState().currentLoadingTitle.casualTitle).toBe(DefaultAgentLoadingTitle.casualTitle)
     expect(req.store.getState().currentLoadingTitle.planTitle).toBe('')
   })
 
@@ -109,7 +110,7 @@ describe('yakExecResult handlers', () => {
     aiYakExecResultDataHandlers.status(req)
     const node = req.rawData.contents.get(nodeId) as ChatTaskNodeGroup
     expect(node.data.loadingTitle).toBe('sub-working')
-    expect(req.store.getState().currentLoadingTitle.casualTitle).toBe('')
+    expect(req.store.getState().currentLoadingTitle.casualTitle).toBe(DefaultAgentLoadingTitle.casualTitle)
   })
 
   it('D10: status uses default TASK_NODE_GROUP loadingTitle when value is empty', () => {

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/defaultConstant.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/defaultConstant.ts
@@ -147,7 +147,7 @@ export const DefaultAgentChatStatus: AgentChatStatus = {
 }
 
 export const DefaultAgentLoadingTitle: AgentLoadingTitle = {
-  casualTitle: '',
+  casualTitle: '会话初始化中...',
   planTitle: '',
 }
 


### PR DESCRIPTION
## 改动说明

AI Agent 默认对话加载标题 `casualTitle` 原为空字符串，会话初始化阶段无任何占位提示，体验略空。

本次将其默认值改为 `会话初始化中...`，让用户在创建会话到首个内容返回前的过渡阶段能看到明确的加载提示。

### 改动范围

- `app/renderer/src/main/src/pages/ai-re-act/hooks/defaultConstant.ts`
  - `DefaultAgentLoadingTitle.casualTitle`：`''` → `'会话初始化中...'`

## 合并方式

（第一种合并方式）。