### PR TITLE
feat(aiAgent): 新增跳过计划子任务能力并重构会话建联回调

### DIFF
--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/HistoryTaskTree.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/HistoryTaskTree.tsx
@@ -26,7 +26,7 @@ import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import useAIAgentStore from '../../useContext/useStore'
 import useAIAgentDispatcher from '../../useContext/useDispatcher'
 import { randomString } from '@/utils/randomUtil'
-import { useCurrentMeta, useCurrentStore } from '@/pages/ai-re-act/hooks/useCurrentDataBySession'
+import { useCurrentStore } from '@/pages/ai-re-act/hooks/useCurrentDataBySession'
 import { useStore } from 'zustand'
 import useCurrentSessionId from '@/pages/ai-re-act/hooks/useCurrentSessionId'
 import { formatAIAgentSetting, onReStart } from '../../utils'
@@ -266,23 +266,18 @@ export const AIHistoryContinueTask: React.FC<AIHistoryContinueTaskProps> = React
 export const AIHistorySkipTask: React.FC<{ taskId?: string | null; isTask?: boolean }> = React.memo(
   ({ taskId, isTask = true }) => {
     const { t } = useI18nNamespaces(['aiAgent'])
-    const syncIdOfStopSubTask = useRef<string>('')
     const store = useCurrentStore()
-    const syncIDUpdate = useStore(store, (state) => state.syncIDUpdate)
-
-    const meta = useCurrentMeta()
     const sessionId = useCurrentSessionId()
     const { onSend } = useAIAgentDispatcher()
     const onCancelTask = useMemoizedFn(() => {
       if (isTask) {
         if (!taskId) return
-        syncIdOfStopSubTask.current = randomString(8)
         const info: AIInputEvent = {
           IsSyncMessage: true,
           SyncType: AIInputEventSyncTypeEnum.SYNC_TYPE_SKIP_SUBTASK_IN_PLAN,
           SyncJsonInput: JSON.stringify({ reason: '用户认为这个任务不需要执行', subtask_id: taskId }),
 
-          SyncID: syncIdOfStopSubTask.current,
+          SyncID: randomString(8),
         }
         onSend({ token: sessionId, type: 'task', params: info })
       } else {
@@ -295,9 +290,7 @@ export const AIHistorySkipTask: React.FC<{ taskId?: string | null; isTask?: bool
       }
     })
 
-    const skipLoading = useCreation(() => {
-      return !!meta.syncIDMap?.get(syncIdOfStopSubTask.current)
-    }, [syncIDUpdate])
+    const skipLoading = useStore(store, (state) => !!taskId && state.skipSubtaskTaskIDs.includes(taskId))
     return (
       <YakitPopconfirm
         title={t('AITree.cancelSubtaskConfirm')}

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/HistoryTaskTree.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/HistoryTaskTree.tsx
@@ -221,7 +221,7 @@ export const AIHistoryContinueTask: React.FC<AIHistoryContinueTaskProps> = React
   const onChatStart = useMemoizedFn((data) => {
     onStart({
       ...data,
-      onSuccess: () => {
+      onLinkSuccess: () => {
         sendRecoverParamsRef.current && onSendRecover(sendRecoverParamsRef.current)
       },
     })

--- a/app/renderer/src/main/src/pages/ai-agent/useContext/AIAgentContext.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/useContext/AIAgentContext.ts
@@ -4,6 +4,7 @@ import type { AISession } from '../type/aiChat'
 import type { AIChatIPCStartParams } from '@/pages/ai-re-act/hooks/type'
 import { AIAgentSettingDefault } from '../defaultConstant'
 import type { useChatIPC } from '@/pages/ai-re-act/hooks/useChatIPC'
+import type { ChatMultiSessionController } from '@/pages/ai-re-act/hooks/ChatMultiSessionController'
 
 export interface AIAgentContextStore {
   /** 全局配置 */
@@ -13,9 +14,10 @@ export interface AIAgentContextStore {
 }
 
 /** 上层 onStart 入参：route/pageId 由 useChatIPC 注入，调用方无需传递 */
-export interface UseChatIPCStartParams extends Omit<AIChatIPCStartParams, 'route' | 'pageId'> {
-  onSuccess?: (sessionId: string) => void
-}
+export interface UseChatIPCStartParams
+  extends
+    Omit<AIChatIPCStartParams, 'route' | 'pageId'>,
+    NonNullable<Parameters<ChatMultiSessionController['handleStartSession']>[1]> {}
 export interface AIAgentContextDispatcher extends ReturnType<typeof useChatIPC> {
   setSetting: Dispatch<SetStateAction<AIAgentSetting>>
   getSetting: () => AIAgentSetting

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/AIReActChat.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/AIReActChat.tsx
@@ -191,7 +191,7 @@ export const AIReActChat: React.FC<AIReActChatProps> = React.memo(
         onStart({
           token: session,
           params,
-          onSuccess: () => {
+          onLinkSuccess: () => {
             // 必须成功链接后再设置 activeChat
             if (!sessionID && newChat) setActiveChat && setActiveChat(newChat)
           },

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/ChatMultiSessionController.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/ChatMultiSessionController.ts
@@ -945,11 +945,17 @@ export class ChatMultiSessionController {
       // 记录跳过子任务操作
       if (
         params.IsSyncMessage &&
-        params.SyncType === AIInputEventSyncTypeEnum.SYNC_TYPE_SKIP_SUBTASK_IN_PLAN &&
+        (params.SyncType === AIInputEventSyncTypeEnum.SYNC_TYPE_SKIP_SUBTASK_IN_PLAN ||
+          params.SyncType === AIInputEventSyncTypeEnum.SYNC_TYPE_REACT_CANCEL_TASK) &&
         params.SyncJsonInput
       ) {
         try {
-          const subTaskID = JSON.parse(params.SyncJsonInput)?.subtask_id
+          let subTaskID = ''
+          if (params.SyncType === AIInputEventSyncTypeEnum.SYNC_TYPE_SKIP_SUBTASK_IN_PLAN) {
+            subTaskID = JSON.parse(params.SyncJsonInput)?.subtask_id
+          } else if (params.SyncType === AIInputEventSyncTypeEnum.SYNC_TYPE_REACT_CANCEL_TASK) {
+            subTaskID = JSON.parse(params.SyncJsonInput)?.task_id
+          }
           if (subTaskID) {
             store.setState((state) => {
               if (state.skipSubtaskTaskIDs.includes(subTaskID)) return

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/ChatMultiSessionController.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/ChatMultiSessionController.ts
@@ -942,7 +942,7 @@ export class ChatMultiSessionController {
         store.getState().updateStateCount('syncIDUpdate')
       }
 
-      // 记录跳过子任务操作
+      // 记录跳过子任务/取消任务操作（写入 skipSubtaskTaskIDs 表示对应按钮进入 loading）
       if (
         params.IsSyncMessage &&
         (params.SyncType === AIInputEventSyncTypeEnum.SYNC_TYPE_SKIP_SUBTASK_IN_PLAN ||

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/ChatMultiSessionController.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/ChatMultiSessionController.ts
@@ -754,7 +754,15 @@ export class ChatMultiSessionController {
    * - 无 UserQuery：视为恢复态，置 initLoading，pong 后 hydrate 或发 recovery_history
    * @returns 是否真正发起了建连
    */
-  public handleStartSession(requestParams: AIChatIPCStartParams, cb?: (sessionId: string) => void): boolean {
+  public handleStartSession(
+    requestParams: AIChatIPCStartParams,
+    cb?: {
+      /** 会话建联开始的回调事件 */
+      onLinkStart?: (sessionId: string) => void
+      /** 会话建联成功后的回调事件 */
+      onLinkSuccess?: (sessionId: string) => void
+    },
+  ): boolean {
     const { token: sessionId, params, route, pageId, localSource } = requestParams
     if (this.readyChannels.has(sessionId)) {
       yakitNotify('warning', '会话已经存在，请勿重复建立！')
@@ -769,6 +777,9 @@ export class ChatMultiSessionController {
     })
 
     const { request, store, rawData, meta } = this.ensureSession(sessionId)
+    // 该行最好放在上面一行的后面，因为ensureSession方法初始化了session的数据环境
+    // 如果放到上行的前面，可能导致onLinkStart引起的UI变化，无法拿到对应session的数据环境
+    cb?.onLinkStart?.(sessionId)
     const userQuery = (params.Params?.UserQuery || '').trim()
 
     // 恢复态：遮罩防止 hydrate / recovery 期间误点（UI 订阅 store.initLoading）
@@ -833,7 +844,7 @@ export class ChatMultiSessionController {
         },
       })
     }
-    meta.onLinkSuccess = cb
+    meta.onLinkSuccess = cb?.onLinkSuccess
 
     // 读 IDB + 查最新事件 id（不依赖本会话流），完成后再 IPC start
     void this.prepareSessionPersistBeforeStart(sessionId).finally(() => {
@@ -929,6 +940,23 @@ export class ChatMultiSessionController {
       if (params.IsSyncMessage && params.SyncID) {
         meta.syncIDMap.set(params.SyncID, true)
         store.getState().updateStateCount('syncIDUpdate')
+      }
+
+      // 记录跳过子任务操作
+      if (
+        params.IsSyncMessage &&
+        params.SyncType === AIInputEventSyncTypeEnum.SYNC_TYPE_SKIP_SUBTASK_IN_PLAN &&
+        params.SyncJsonInput
+      ) {
+        try {
+          const subTaskID = JSON.parse(params.SyncJsonInput)?.subtask_id
+          if (subTaskID) {
+            store.setState((state) => {
+              if (state.skipSubtaskTaskIDs.includes(subTaskID)) return
+              state.skipSubtaskTaskIDs = [...state.skipSubtaskTaskIDs, subTaskID]
+            })
+          }
+        } catch (error) {}
       }
 
       switch (type) {
@@ -1328,6 +1356,7 @@ export class ChatMultiSessionController {
           'capability_inventory',
           'react_task_created',
           'plan_exec_tasks',
+          'skip_subtask_in_plan',
         ].includes(res.NodeId)
       ) {
         funcKey = res.NodeId

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/ChatMultiSessionController.pageIndex.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/ChatMultiSessionController.pageIndex.test.ts
@@ -377,6 +377,61 @@ describe('ChatMultiSessionController start / send / history', () => {
     expect(ctrl.ensureSession('s-skip').store.getState().skipSubtaskTaskIDs).toEqual([])
   })
 
+  it('A28: cancel task send records task_id; event clears it', () => {
+    ctrl.handleStartSession(startParams('s-cancel'))
+    const cancelParams = {
+      IsSyncMessage: true,
+      SyncType: AIInputEventSyncTypeEnum.SYNC_TYPE_REACT_CANCEL_TASK,
+      SyncJsonInput: JSON.stringify({ task_id: 'react-1' }),
+    }
+
+    ctrl.handleSendMessage({ token: 's-cancel', type: 'task', params: cancelParams as any })
+    expect(ctrl.ensureSession('s-cancel').store.getState().skipSubtaskTaskIDs).toEqual(['react-1'])
+
+    ctrl.handleSendMessage({ token: 's-cancel', type: 'task', params: cancelParams as any })
+    expect(ctrl.ensureSession('s-cancel').store.getState().skipSubtaskTaskIDs).toEqual(['react-1'])
+
+    ctrl.handleGrpcOutputEvent(
+      's-cancel',
+      makeGrpcJsonRes(
+        'structured',
+        {
+          message: 'ok',
+          reason: '',
+          subtask_id: 'react-1',
+          subtask_index: '0',
+          subtask_name: '',
+          success: true,
+        },
+        { NodeId: 'skip_subtask_in_plan' },
+      ),
+    )
+    expect(ctrl.ensureSession('s-cancel').store.getState().skipSubtaskTaskIDs).toEqual([])
+  })
+
+  it('A29: skip/cancel payload without id is not recorded', () => {
+    ctrl.handleStartSession(startParams('s-noop'))
+    ctrl.handleSendMessage({
+      token: 's-noop',
+      type: 'task',
+      params: {
+        IsSyncMessage: true,
+        SyncType: AIInputEventSyncTypeEnum.SYNC_TYPE_REACT_CANCEL_TASK,
+        SyncJsonInput: JSON.stringify({}),
+      } as any,
+    })
+    ctrl.handleSendMessage({
+      token: 's-noop',
+      type: 'task',
+      params: {
+        IsSyncMessage: true,
+        SyncType: AIInputEventSyncTypeEnum.SYNC_TYPE_SKIP_SUBTASK_IN_PLAN,
+        SyncJsonInput: JSON.stringify({ reason: '用户认为这个任务不需要执行' }),
+      } as any,
+    })
+    expect(ctrl.ensureSession('s-noop').store.getState().skipSubtaskTaskIDs).toEqual([])
+  })
+
   it('A17: send without ready warns when active', () => {
     ctrl.setActiveShowSession('ghost')
     expect(() =>

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/ChatMultiSessionController.pageIndex.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/ChatMultiSessionController.pageIndex.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ChatMultiSessionController } from '../ChatMultiSessionController'
 import { YakitRoute } from '@/enums/yakitRoute'
 import { ipcRendererMock, resetIpcMocks } from './setupElectron'
-import { AITaskStatus } from '../grpcApi'
+import { AIInputEventSyncTypeEnum, AITaskStatus } from '../grpcApi'
 import { DefaultCurrentExecTaskTree } from '../defaultConstant'
 import { makeGrpcJsonRes } from './fixtures'
 
@@ -328,6 +328,53 @@ describe('ChatMultiSessionController start / send / history', () => {
   it('A14: no UserQuery enters restore loading', () => {
     ctrl.handleStartSession(startParams('s-restore', 'page-1', ''))
     expect(ctrl.ensureSession('s-restore').store.getState().initLoading).toBe(true)
+  })
+
+  it('A23: onLinkStart after ensureSession; onLinkSuccess after pong', async () => {
+    const onLinkStart = vi.fn()
+    const onLinkSuccess = vi.fn()
+    expect(ctrl.handleStartSession(startParams('s-cb'), { onLinkStart, onLinkSuccess })).toBe(true)
+    expect(onLinkStart).toHaveBeenCalledWith('s-cb')
+    expect(ctrl.ensureSession('s-cb').store).toBeTruthy()
+    expect(onLinkSuccess).not.toHaveBeenCalled()
+
+    ctrl.handleGrpcOutputEvent('s-cb', makeGrpcJsonRes('pong', {}))
+    await vi.waitFor(() => {
+      expect(onLinkSuccess).toHaveBeenCalledWith('s-cb')
+    })
+  })
+
+  it('A24: skip subtask send records id; grpc event clears it', () => {
+    ctrl.handleStartSession(startParams('s-skip'))
+    const skipParams = {
+      IsSyncMessage: true,
+      SyncType: AIInputEventSyncTypeEnum.SYNC_TYPE_SKIP_SUBTASK_IN_PLAN,
+      SyncJsonInput: JSON.stringify({ reason: '用户认为这个任务不需要执行', subtask_id: 'sub-1' }),
+      SyncID: 'sync-skip-1',
+    }
+
+    ctrl.handleSendMessage({ token: 's-skip', type: 'task', params: skipParams as any })
+    expect(ctrl.ensureSession('s-skip').store.getState().skipSubtaskTaskIDs).toEqual(['sub-1'])
+
+    ctrl.handleSendMessage({ token: 's-skip', type: 'task', params: skipParams as any })
+    expect(ctrl.ensureSession('s-skip').store.getState().skipSubtaskTaskIDs).toEqual(['sub-1'])
+
+    ctrl.handleGrpcOutputEvent(
+      's-skip',
+      makeGrpcJsonRes(
+        'structured',
+        {
+          message: 'ok',
+          reason: '用户认为这个任务不需要执行',
+          subtask_id: 'sub-1',
+          subtask_index: '0',
+          subtask_name: 'leaf',
+          success: true,
+        },
+        { NodeId: 'skip_subtask_in_plan' },
+      ),
+    )
+    expect(ctrl.ensureSession('s-skip').store.getState().skipSubtaskTaskIDs).toEqual([])
   })
 
   it('A17: send without ready warns when active', () => {

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/aiOther.handlers.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/aiOther.handlers.test.ts
@@ -86,4 +86,40 @@ describe('aiOther other handlers', () => {
     aiOtherDataHandlers.notify(req)
     expect(req.store.getState().notifyMessage?.content).toBe('n1')
   })
+
+  it('D3: skip_subtask_in_plan removes matching id', () => {
+    const req = makeHandlerRequest({
+      res: makeGrpcJsonRes(
+        'structured',
+        {
+          message: 'ok',
+          reason: 'user skip',
+          subtask_id: 'sub-1',
+          subtask_index: '0',
+          subtask_name: 'leaf',
+          success: true,
+        },
+        { NodeId: 'skip_subtask_in_plan' },
+      ),
+    })
+    req.store.setState((state) => {
+      state.skipSubtaskTaskIDs = ['sub-1', 'sub-2']
+    })
+    aiOtherDataHandlers.skip_subtask_in_plan(req)
+    expect(req.store.getState().skipSubtaskTaskIDs).toEqual(['sub-2'])
+  })
+
+  it('D3: skip_subtask_in_plan missing subtask_id logs error', () => {
+    const pushLog = vi.fn()
+    const req = makeHandlerRequest({
+      res: makeGrpcJsonRes('structured', { success: false, subtask_id: '' }, { NodeId: 'skip_subtask_in_plan' }),
+      pushLog,
+    })
+    req.store.setState((state) => {
+      state.skipSubtaskTaskIDs = ['sub-keep']
+    })
+    aiOtherDataHandlers.skip_subtask_in_plan(req)
+    expect(pushLog).toHaveBeenCalledWith(expect.objectContaining({ level: 'error' }))
+    expect(req.store.getState().skipSubtaskTaskIDs).toEqual(['sub-keep'])
+  })
 })

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/chatStore.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/chatStore.test.ts
@@ -10,6 +10,7 @@ describe('chatStore basics', () => {
     expect(store.getState().currentChatStatus).toEqual(DefaultAgentChatStatus)
     expect(store.getState().currentLoadingTitle).toEqual(DefaultAgentLoadingTitle)
     expect(store.getState().currentReviewDetail).toEqual({ token: '', renderNum: 0 })
+    expect(store.getState().skipSubtaskTaskIDs).toEqual([])
     expect(store.getState().showPlanList).toBe(false)
     expect(store.getState().cancelChatLoading).toBe(false)
     expect(store.getState().timelinesLoading).toBe(false)

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/grpcAIOutputEventHandlers.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/grpcAIOutputEventHandlers.test.ts
@@ -24,5 +24,6 @@ describe('grpcAIMessageHandlers', () => {
     for (const key of Object.keys(expected)) {
       expect(typeof grpcAIMessageHandlers[key]).toBe('function')
     }
+    expect(typeof grpcAIMessageHandlers.skip_subtask_in_plan).toBe('function')
   })
 })

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/aiRender.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/aiRender.ts
@@ -586,6 +586,12 @@ export interface ChatStoreState {
    */
   currentPlanReviewExtraUpdate: number
 
+  /**
+   * 正在执行跳过子任务的任务ID集合
+   * 如果存在则代表正在执行跳过操作，loading中
+   */
+  skipSubtaskTaskIDs: string[]
+
   items: SessionRenderContent['items']
   groups: SessionRenderContent['groups']
   tasks: SessionRenderContent['tasks']

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/aiRender.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/aiRender.ts
@@ -587,8 +587,8 @@ export interface ChatStoreState {
   currentPlanReviewExtraUpdate: number
 
   /**
-   * 正在执行跳过子任务的任务ID集合
-   * 如果存在则代表正在执行跳过操作，loading中
+   * 正在执行跳过子任务/取消任务的任务 ID 集合
+   * 如果存在则代表对应操作正在进行中（loading），收到完成事件后清除
    */
   skipSubtaskTaskIDs: string[]
 

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/chatStore.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/chatStore.ts
@@ -1,4 +1,4 @@
-import { AIChatQSDataTypeEnum, type CurrentExecTaskTree, type ChatStoreState } from './aiRender'
+import { AIChatQSDataTypeEnum, type ChatStoreState } from './aiRender'
 import { createStore } from 'zustand/vanilla'
 import { immer } from 'zustand/middleware/immer'
 import { enableMapSet } from 'immer'
@@ -53,6 +53,8 @@ export const createChatStore = (options?: CreateChatStoreOptions) => {
 
       currentReviewDetail: { token: '', renderNum: 0 },
       currentPlanReviewExtraUpdate: 0,
+
+      skipSubtaskTaskIDs: [],
 
       items: {},
       groups: {},

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcApi.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcApi.ts
@@ -1178,7 +1178,7 @@ export declare namespace AIAgentGrpcApi {
     summary_markdown: string
   }
 
-  /** 自由对话子 agent 任务创建消息 */
+  /** 跳过计划子任务（skip_subtask_in_plan）请求的响应 */
   export interface SkipSubtaskInPlan {
     message: string
     reason: string

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcApi.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcApi.ts
@@ -1177,6 +1177,16 @@ export declare namespace AIAgentGrpcApi {
     title: string
     summary_markdown: string
   }
+
+  /** 自由对话子 agent 任务创建消息 */
+  export interface SkipSubtaskInPlan {
+    message: string
+    reason: string
+    subtask_id: string
+    subtask_index: string
+    subtask_name: string
+    success: boolean
+  }
 }
 
 // #region AI相关普通接口的请求和定义结构

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcStreamHandler/aiOther.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcStreamHandler/aiOther.ts
@@ -498,6 +498,23 @@ const handleReactTaskCreated: AIMessageHandler = (requestInfo) => {
   })
 }
 
+const handleSkipSubtaskInPlan: AIMessageHandler = (requestInfo) => {
+  const { res, store } = requestInfo
+  if (res.Type !== 'structured' || res.NodeId !== 'skip_subtask_in_plan') return
+
+  const ipcContent = Uint8ArrayToString(res.Content) || ''
+  const info = JSON.parse(ipcContent) as AIAgentGrpcApi.SkipSubtaskInPlan
+
+  if (!info.subtask_id) {
+    requestInfo.pushLog({ level: 'error', message: `${res.NodeId}数据异常: ${ipcContent}` })
+    return
+  }
+  store.setState((state) => {
+    if (!state.skipSubtaskTaskIDs.includes(info.subtask_id)) return
+    state.skipSubtaskTaskIDs = state.skipSubtaskTaskIDs.filter((item) => item !== info.subtask_id)
+  })
+}
+
 export const aiOtherDataHandlers = {
   http_fuzz_request_change: handleHttpFuzzRequestChange,
   http_flow_fuzz_status: handleHttpFlowFuzzStatus,
@@ -519,4 +536,5 @@ export const aiOtherDataHandlers = {
   plan: handlePlan,
   yaklang_code_change: handleYaklangCodeChange,
   react_task_created: handleReactTaskCreated,
+  skip_subtask_in_plan: handleSkipSubtaskInPlan,
 } as const

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/useChatIPC.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/useChatIPC.ts
@@ -1,5 +1,6 @@
 // useChatIPC.ts
 import { useEffect } from 'react'
+import type { ChatMultiSessionController } from './ChatMultiSessionController'
 import { globalSessionEngine } from './ChatMultiSessionController'
 import type { AIChatSendParams } from './type'
 import { useMemoizedFn } from 'ahooks'
@@ -13,7 +14,7 @@ export function useChatIPC(route: YakitRouteType, pageId: string) {
    * isSessionReady 已连则直接返回（不动已有监听）→ 用入参 token 挂监听 → handleStartSession
    * prepare 异步，invoke 晚于本同步栈挂监听，不会丢流；token 不依赖 React 闭包里的 SessionID
    */
-  const onStart = useMemoizedFn(({ token, params, onSuccess, localSource }: UseChatIPCStartParams) => {
+  const onStart = useMemoizedFn(({ token, params, localSource, onLinkStart, onLinkSuccess }: UseChatIPCStartParams) => {
     if (globalSessionEngine.isSessionReady(token)) {
       yakitNotify('warning', '会话已经存在，请勿重复建立！')
       return
@@ -32,7 +33,14 @@ export function useChatIPC(route: YakitRouteType, pageId: string) {
       globalSessionEngine.handleSessionEnd(token, res)
     })
 
-    globalSessionEngine.handleStartSession({ token, params, route, pageId, localSource }, onSuccess)
+    let cb: Parameters<ChatMultiSessionController['handleStartSession']>[1] = undefined
+    if (onLinkStart || onLinkSuccess) {
+      cb = {
+        onLinkStart,
+        onLinkSuccess,
+      }
+    }
+    globalSessionEngine.handleStartSession({ token, params, route, pageId, localSource }, cb)
   })
 
   const onSend = useMemoizedFn((payload: AIChatSendParams) => {


### PR DESCRIPTION
## 概述

为 AI Agent 对话新增「跳过计划子任务（skip_subtask_in_plan）」能力，并在过程中将会话建联回调从单一 `onSuccess` 拆分为 `onLinkStart` / `onLinkSuccess` 两个更精确的事件。附配套测试覆盖两类改动的核心路径。

## 改动内容

### 1. 新增跳过计划子任务能力

- **`grpcApi.ts`**：新增 `SkipSubtaskInPlan` 结构体定义，包含 `subtask_id` / `subtask_name` / `reason` / `success` 等字段。
- **`aiRender.ts` / `chatStore.ts`**：在 chatStore 中新增 `skipSubtaskTaskIDs: string[]` 状态，用于记录正在执行跳过操作的子任务 ID 集合（存在即代表 loading 中）。
- **`ChatMultiSessionController.ts`**：
  - 在 sync 消息处理中，当 `SyncType === SYNC_TYPE_SKIP_SUBTASK_IN_PLAN` 时解析 `SyncJsonInput`，将 `subtask_id` 写入 `skipSubtaskTaskIDs`。
  - 在 NodeId 路由表中补充 `skip_subtask_in_plan`，使该消息能正确分发到 `aiOther` 处理器。
- **`aiOther.ts`**：新增 `handleSkipSubtaskInPlan` 处理器，接收 `skip_subtask_in_plan` 结构化消息后，将对应 `subtask_id` 从 `skipSubtaskTaskIDs` 中移除，表示跳过动作完成。

### 2. 重构会话建联回调

- **`ChatMultiSessionController.ts`**：`handleStartSession` 的第二个参数由 `(sessionId: string) => void` 改为对象形式 `{ onLinkStart?, onLinkSuccess? }`：
  - `onLinkStart`：会话建联**开始**时触发（在 `ensureSession` 之后立即调用，确保 UI 变化能拿到对应 session 的数据环境）。
  - `onLinkSuccess`：会话建联**成功**后触发（原 `onSuccess` 语义）。
- **`useChatIPC.ts` / `AIAgentContext.ts`**：`UseChatIPCStartParams` 同步调整为透传 `onLinkStart` / `onLinkSuccess`，类型直接复用 `handleStartSession` 的入参类型，避免重复定义。
- **`AIReActChat.tsx` / `HistoryTaskTree.tsx`**：原有 `onSuccess` 调用点更名为 `onLinkSuccess`，语义不变。

### 3. 配套测试

- **`ChatMultiSessionController.pageIndex.test.ts`**：
  - A23：验证 `onLinkStart` 在 `ensureSession` 后立即触发、`onLinkSuccess` 在 pong 后触发。
  - A24：验证发送跳过子任务 sync 消息会记录 `subtask_id` 到 `skipSubtaskTaskIDs`（重复发送去重），收到 `skip_subtask_in_plan` 消息后清除该 ID。
- **`aiOther.handlers.test.ts`**：
  - D3：`skip_subtask_in_plan` 处理器正确移除匹配 ID；缺少 `subtask_id` 时记录错误日志且不误改状态。
- **`chatStore.test.ts`**：断言初始 `skipSubtaskTaskIDs` 为空数组。
- **`grpcAIOutputEventHandlers.test.ts`**：断言 `skip_subtask_in_plan` 已注册为可调用 handler。

### 4. UI 对接与取消任务 loading 扩展（4afd56e7a）

- **`HistoryTaskTree.tsx`**：`AIHistorySkipTask` 的 loading 从旧 `meta.syncIDMap` + SyncID 方案切换为订阅 `skipSubtaskTaskIDs`，跳过（`SKIP_SUBTASK_IN_PLAN`）与取消（`REACT_CANCEL_TASK`）按钮统一进入「发送记录 → 事件清除」闭环；移除不再使用的 ref 与计数器订阅。
- **`ChatMultiSessionController.ts`**：记录逻辑扩展——`REACT_CANCEL_TASK` 消息也按 `task_id` 写入 `skipSubtaskTaskIDs`（与 `SKIP_SUBTASK_IN_PLAN` 按 `subtask_id` 解析并列）。
- **`ChatMultiSessionController.pageIndex.test.ts`**：新增 A28（取消任务发送记录 `task_id`、重复去重、事件清除）、A29（两种消息 payload 缺 id 时不记录）。

## 动机

- 业务上需要支持在计划执行阶段跳过指定子任务，并在 UI 层体现「跳过中 → 跳过完成」的状态流转。
- 原有 `onSuccess` 回调只能表达「建联成功」一个时机，无法满足「建联刚开始就需要响应」的场景（如遮罩、初始化占位等），因此拆分为 `onLinkStart` / `onLinkSuccess` 两个事件，时机更精确。

## 影响范围

- 涉及模块：`ai-re-act` 会话引擎（`ChatMultiSessionController` / `chatStore` / `grpcApi` / `aiOther` / `useChatIPC`）、`ai-agent`（`AIAgentContext` / `AIReActChat` / `HistoryTaskTree`），及其 `__test__` 目录下对应测试。
- `onSuccess` → `onLinkSuccess` 为 rename + 语义保持的改动，调用方已全部适配。
- 不涉及构建/CI/依赖变更。

## 关联

- 后端引擎 PR：yaklang/yaklang#4946（feat(ai): 子代理任务取消完成后再发送返回消息，asyncDeferCallback 延迟机制）

合并方式选1
