### PR TITLE
fix(webfuzz): 下载 Body 按 HiddenIndex 定位 HTTPFlow

### DIFF
--- a/app/protos/grpc.proto
+++ b/app/protos/grpc.proto
@@ -7045,6 +7045,8 @@ message FuzzerResponse {
   string FixContentType = 60;
   bool IsSetContentTypeOptions = 61;
   repeated RandomChunkedResponse RandomChunkedData = 62;
+  // 与 http_flows / web_fuzzer_response 对齐的唯一键，下载 body 用它而不是 RuntimeID。
+  string HiddenIndex = 64;
 }
 
 message RandomChunkedResponse{
@@ -7108,6 +7110,8 @@ message GetHTTPFlowBodyByIdRequest {
   // 未设 = 返回完整 body（multipart 时现场流式重建完整 body）。
   // 用 optional 以区分「未设」与「part 0」。
   optional int32 PartIndex = 6;
+  // WebFuzzer 单条结果：按 HiddenIndex 定位 HTTPFlow，避免 RuntimeId 命中任务内其它 hop。
+  string HiddenIndex = 7;
 }
 
 message MITMExtractAggregateFlowFilterRow {

--- a/app/renderer/src/main/src/components/HTTPHistory.tsx
+++ b/app/renderer/src/main/src/components/HTTPHistory.tsx
@@ -120,6 +120,8 @@ export interface HTTPFlowBodyByIdRequest {
   BufSize?: number
   RuntimeId?: string
   IsRisk?: boolean
+  // WebFuzzer 单条结果：按 HiddenIndex 定位 HTTPFlow，避免 RuntimeId 命中任务内其它 hop。
+  HiddenIndex?: string
   // multipart 请求：指定要流式下载的文件 part 索引（来自 HTTPFlow.MultipartFiles）。
   // 不传 = 下载完整 body（multipart 时服务端现场流式重建完整 body）。
   PartIndex?: number

--- a/app/renderer/src/main/src/pages/fuzzer/HTTPFuzzerPage.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/HTTPFuzzerPage.tsx
@@ -383,6 +383,8 @@ export interface FuzzerResponse {
   FixContentType: string
   IsSetContentTypeOptions: boolean
   RandomChunkedData: RandomChunkedResponse[]
+  /** 与 http_flows / web_fuzzer_response 对齐的唯一键，下载 body 用它而不是 RuntimeID */
+  HiddenIndex?: string
 }
 export interface RandomChunkedResponse {
   /**@name 当前的 chunked index */
@@ -4901,8 +4903,12 @@ export const ResponseViewer: React.FC<ResponseViewerProps> = React.memo(
     })
 
     const editorDownBodyParams = useMemo(() => {
-      return { RuntimeId: fuzzerResponse.RuntimeID, IsRequest: false }
-    }, [fuzzerResponse.RuntimeID])
+      return {
+        HiddenIndex: fuzzerResponse.HiddenIndex,
+        RuntimeId: fuzzerResponse.RuntimeID,
+        IsRequest: false,
+      }
+    }, [fuzzerResponse.HiddenIndex, fuzzerResponse.RuntimeID])
 
     // 计算当前显示的值
     // - 流式阶段：强制用 header 作为稳定的 base（body 由 hook 增量追加）

--- a/app/renderer/src/main/src/pages/fuzzer/components/HTTPFuzzerPageTable/HTTPFuzzerPageTable.tsx
+++ b/app/renderer/src/main/src/pages/fuzzer/components/HTTPFuzzerPageTable/HTTPFuzzerPageTable.tsx
@@ -1247,6 +1247,7 @@ export const HTTPFuzzerPageTable: React.FC<HTTPFuzzerPageTableProps> = React.mem
                 onClickUrlWithoutQueryMenu={copyUrlWithoutQuery}
                 onClickOpenBrowserMenu={onClickOpenBrowserMenu}
                 downbodyParams={{
+                  HiddenIndex: currentSelectItem?.HiddenIndex,
                   RuntimeId: currentSelectItem?.RuntimeID,
                   IsRequest: currentSelectShowType === 'request',
                 }}


### PR DESCRIPTION
## Summary
- Sync proto: `FuzzerResponse.HiddenIndex` and `GetHTTPFlowBodyByIdRequest.HiddenIndex`.
- WebFuzzer download body passes `HiddenIndex` (keeps `RuntimeId` as fallback for older engines) so the selected result/hop is downloaded instead of the first flow under the shared runtime.

## Test plan
- [x] Rebuild/restart with yaklang that supports HiddenIndex body lookup
- [x] WebFuzzer follow-redirects: download intermediate hop body is correct
- [x] History download by `Id` still works
- [x] Old engine without HiddenIndex still falls back to RuntimeId

Depends on: yaklang HiddenIndex body download PR


Made with [Cursor](https://cursor.com)