### PR TITLE
fix: 右键菜单点击含 stopPropagation 的按钮无法关闭

### DIFF
--- a/app/renderer/src/main/src/components/yakitUI/YakitMenu/showByRightContext.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitMenu/showByRightContext.tsx
@@ -102,10 +102,9 @@ export const showByRightContext = (props: YakitMenuProp | ReactNode, x?: number,
       document.addEventListener(
         'click',
         function onClickOutsize() {
-          destory()
-          document.removeEventListener('click', onClickOutsize)
+          setTimeout(() => destory(), 0)
         },
-        true,
+        { capture: true, once: true },
       )
       // document.addEventListener("contextmenu", function onContextMenuOutsize() {
       //     destory()

--- a/app/renderer/src/main/src/components/yakitUI/YakitMenu/showByRightContext.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitMenu/showByRightContext.tsx
@@ -99,10 +99,14 @@ export const showByRightContext = (props: YakitMenuProp | ReactNode, x?: number,
 
   const render = () => {
     setTimeout(() => {
-      document.addEventListener('click', function onClickOutsize() {
-        destory()
-        document.removeEventListener('click', onClickOutsize)
-      })
+      document.addEventListener(
+        'click',
+        function onClickOutsize() {
+          destory()
+          document.removeEventListener('click', onClickOutsize)
+        },
+        true,
+      )
       // document.addEventListener("contextmenu", function onContextMenuOutsize() {
       //     destory()
       //     document.removeEventListener("contextmenu", onContextMenuOutsize)


### PR DESCRIPTION
第二个合并方式
React 17+ 将事件委托从 document 移到 root 容器后，合成事件的
stopPropagation 会阻止原生事件冒泡到 document。Fuzzer 页面部分
按钮调用了 e.stopPropagation()，导致 showByRightContext 注册在 document 上的冒泡阶段 click 监听收不到事件，菜单不关闭。

改用捕获阶段（capture: true）监听，事件在到达目标元素前触发，
不受 stopPropagation 影响。