### PR TITLE
fix: 状态码列筛选偶发失效导致筛出错误结果

### DIFF
--- a/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.tsx
@@ -1090,13 +1090,12 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
     useMemoizedFn(() => {
       if (updateAdvancedSearch) {
         const { shieldHosts } = splitHTTPFlowTableShieldData(getShieldData().data)
-        let newParams = { ...getParams() }
-        newParams = {
-          ...newParams,
-          ...buildHTTPFlowTableAdvancedQuery(filterConfig, shieldHosts),
-        }
+        const advancedQuery = buildHTTPFlowTableAdvancedQuery(filterConfig, shieldHosts)
         refreshTabsContRef.current = true
-        setParams(newParams)
+        setParams((prev) => ({
+          ...prev,
+          ...advancedQuery,
+        }))
         emiter.emit('onGetAdvancedSearchDataEvent', JSON.stringify(filterConfig))
       }
     }),

--- a/app/renderer/src/main/src/hook/useVirtualTableHook/useVirtualTableHook.ts
+++ b/app/renderer/src/main/src/hook/useVirtualTableHook/useVirtualTableHook.ts
@@ -871,22 +871,11 @@ export default function useVirtualTableHook<
   const setP = useMemoizedFn((newParams: ParamsTProps) => {
     queryEpochRef.current += 1
     isGrpcRef.current = false
-    const data: ParamsTProps = {
-      ...newParams,
-      Pagination: {
-        ...params.Pagination,
-        ...newParams.Pagination,
-      },
-      Filter: {
-        ...params.Filter,
-        ...newParams.Filter,
-      },
+    if (newParams.Pagination?.Order) {
+      sortRef.current.order = newParams.Pagination.Order as 'none' | 'asc' | 'desc'
     }
-    if (data.Pagination.Order) {
-      sortRef.current.order = data.Pagination.Order as 'none' | 'asc' | 'desc'
-    }
-    if (data.Pagination.OrderBy) {
-      sortRef.current.orderBy = data.Pagination.OrderBy
+    if (newParams.Pagination?.OrderBy) {
+      sortRef.current.orderBy = newParams.Pagination.OrderBy
     }
     if (typeof newParams.startLoop === 'boolean') {
       newParams.startLoop ? startT() : stopT()
@@ -894,7 +883,17 @@ export default function useVirtualTableHook<
     if (typeof newParams.endLoop === 'boolean') {
       isAllowSetEndLoopRef.current = true
     }
-    setParams(data)
+    setParams((prev) => ({
+      ...newParams,
+      Pagination: {
+        ...prev.Pagination,
+        ...newParams.Pagination,
+      },
+      Filter: {
+        ...prev.Filter,
+        ...newParams.Filter,
+      },
+    }))
   })
 
   return [


### PR DESCRIPTION
第二个合并方式
高级筛选 useDebounceEffect 与列筛选 onTableChange 各有 500ms 防抖，当两者相近触发时，useDebounceEffect 回调中 getParams()
取 paramsRef.current 可能拿到旧值（React 未重新渲染），导致
列筛选设置的 StatusCode 丢失，后端返回未筛选状态码的结果。

改用函数式 setParams((prev) => ...) 确保始终基于最新 state
合并，避免竞态条件下 StatusCode 被覆盖丢失。