### PR TITLE
update/link-render-2.08.28

### DIFF
--- a/app/renderer/engine-link-startup/package.json
+++ b/app/renderer/engine-link-startup/package.json
@@ -1,7 +1,7 @@
 {
   "name": "engine-link-startup",
   "private": true,
-  "version": "2.08.25",
+  "version": "2.08.28",
   "type": "module",
   "scripts": {
     "cli": "node scripts/cli.cjs",


### PR DESCRIPTION
## 概述

Link 渲染端版本号由 2.08.25 提升至 2.08.28。

## 改动内容

- `app/renderer/engine-link-startup/package.json`：`version` 字段由 `2.08.25` 更新为 `2.08.28`

## 影响范围

仅版本号变更，不改变用户可见行为。

## 合并方式

请使用 **Rebase and merge** 合并。