### PR TITLE
update/pack-1.4.8-0828

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yakit",
-  "version": "1.4.8-0825",
+  "version": "1.4.8-0828",
   "description": "Yakit is for yaklang.io Electron GUI Entry",
   "main": "app/main/index.js",
   "scripts": {


### PR DESCRIPTION
## 概述

Yakit 应用打包版本号由 1.4.8-0825 提升至 1.4.8-0828。

## 改动内容

- 根目录 `package.json`：`version` 字段由 `1.4.8-0825` 更新为 `1.4.8-0828`

## 影响范围

仅版本号变更，不改变用户可见行为。

## 合并方式

请使用 **Rebase and merge** 合并。