### PR TITLE
update/render-2.08.28

### DIFF
--- a/app/renderer/src/main/package.json
+++ b/app/renderer/src/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main",
-  "version": "2.08.25",
+  "version": "2.08.28",
   "private": true,
   "dependencies": {
     "@ant-design/compatible": "^1.0.8",


### PR DESCRIPTION
## 概述

主渲染端版本号由 2.08.25 提升至 2.08.28。

## 改动内容

- `app/renderer/src/main/package.json`：`version` 字段由 `2.08.25` 更新为 `2.08.28`

## 影响范围

仅版本号变更，不改变用户可见行为。

## 合并方式

请使用 **Rebase and merge** 合并。