### PR TITLE
feat: 优化 AI 对话输入栏、底栏样式，并支持工作区左右拖拽分栏

### DIFF
--- a/app/renderer/src/main/src/pages/ai-agent/aiAgentChat/AIAgentChatLayout/AIAgentChatLayout.module.scss
+++ b/app/renderer/src/main/src/pages/ai-agent/aiAgentChat/AIAgentChatLayout/AIAgentChatLayout.module.scss
@@ -9,20 +9,6 @@
     min-width: 0;
     height: 100%;
     overflow: hidden;
-    .chat-workspace {
-      width: 100%;
-      min-width: 0;
-      height: 100%;
-      overflow: hidden;
-      display: flex;
-      flex-direction: column;
-      background: var(--Colors-Use-Neutral-Bg);
-    }
-    .chat-content {
-      width: 100%;
-      min-width: 0;
-      height: 100%;
-    }
   }
   .footer-forge-form {
     z-index: 99;
@@ -34,4 +20,20 @@
     align-items: flex-end;
     justify-content: center;
   }
+}
+
+.chat-workspace {
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: var(--Colors-Use-Neutral-Bg);
+}
+
+.chat-content {
+  width: 100%;
+  min-width: 0;
+  height: 100%;
 }

--- a/app/renderer/src/main/src/pages/ai-agent/aiAgentChat/AIAgentChatLayout/AIAgentChatLayout.module.scss
+++ b/app/renderer/src/main/src/pages/ai-agent/aiAgentChat/AIAgentChatLayout/AIAgentChatLayout.module.scss
@@ -8,25 +8,18 @@
     flex: 1;
     min-width: 0;
     height: 100%;
-    display: flex;
+    overflow: hidden;
     .chat-workspace {
-      flex: 1;
+      width: 100%;
       min-width: 0;
       height: 100%;
       overflow: hidden;
       display: flex;
       flex-direction: column;
       background: var(--Colors-Use-Neutral-Bg);
-      border-right: 1px solid var(--Colors-Use-Neutral-Border);
-    }
-    .chat-workspace-hidden {
-      flex: 0 0 0;
-      width: 0;
-      border-right: 0;
-      pointer-events: none;
     }
     .chat-content {
-      flex: 1;
+      width: 100%;
       min-width: 0;
       height: 100%;
     }

--- a/app/renderer/src/main/src/pages/ai-agent/aiAgentChat/AIAgentChatLayout/AIAgentChatLayout.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiAgentChat/AIAgentChatLayout/AIAgentChatLayout.tsx
@@ -1,13 +1,13 @@
 import React, { memo, useEffect, useState } from 'react'
 import type { RefObject } from 'react'
 import { useMemoizedFn } from 'ahooks'
-import classNames from 'classnames'
 import { OutlineFlagIcon, OutlineViewlistIcon } from '@/assets/icon/outline'
 import { YakitSegmented } from '@/components/yakitUI/YakitSegmented/YakitSegmented'
 import {
   YakitDockablePane,
   yakitDockablePaneSegmentedLabel,
 } from '@/components/yakitUI/YakitDockablePane/YakitDockablePane'
+import { YakitResizeBox } from '@/components/yakitUI/YakitResizeBox/YakitResizeBox'
 import type { FileNodeProps } from '@/pages/yakRunner/FileTree/FileTreeType'
 import { AIForgeForm, AIToolForm } from '../../aiTriageChatTemplate/AITriageChatTemplate'
 import type { AIForgeFormSubmitParamsProps } from '../../aiTriageChatTemplate/type'
@@ -28,7 +28,7 @@ import styles from './AIAgentChatLayout.module.scss'
 const AIChatWelcome = React.lazy(() => import('../../aiChatWelcome/AIChatWelcome'))
 
 const MULTI_FUNC_PANE_WIDTH = 320
-const MIN_CHAT_CONTENT_WIDTH = 480
+const MIN_CHAT_CONTENT_WIDTH = 400
 
 export interface AIAgentChatLayoutProps {
   mode: AIAgentChatMode
@@ -106,26 +106,35 @@ export const AIAgentChatLayout: React.FC<AIAgentChatLayoutProps> = memo((props) 
   return (
     <div className={styles['chat-wrapper']}>
       <div className={styles['chat-content-wrapper']}>
-        <div
-          className={classNames(styles['chat-workspace'], {
-            [styles['chat-workspace-hidden']]: !workspaceVisible,
-          })}
-        >
-          <AIChatWorkspace
-            filePreviewData={filePreviewData}
-            setFilePreviewData={setFilePreviewData}
-            onTabsChange={onTabsChange}
-          />
-        </div>
-        <div className={styles['chat-content']}>
-          {mode === 'welcome' ? (
-            <React.Suspense fallback={<div>loading...</div>}>
-              <AIChatWelcome onTriageSubmit={onTriageSubmit} onSetReAct={onSetReAct} ref={aiChatWelcomeRef} />
-            </React.Suspense>
-          ) : (
-            <AIChatContent ref={aiReActChatRef} onChat={onChat} />
-          )}
-        </div>
+        <YakitResizeBox
+          freeze={workspaceVisible}
+          firstRatio={workspaceVisible ? '70%' : '0px'}
+          firstMinSize={workspaceVisible ? 280 : 0}
+          secondRatio={workspaceVisible ? '30%' : '100%'}
+          secondMinSize={MIN_CHAT_CONTENT_WIDTH}
+          firstNodeStyle={workspaceVisible ? undefined : { display: 'none', padding: 0 }}
+          lineStyle={workspaceVisible ? undefined : { display: 'none' }}
+          firstNode={
+            <div className={styles['chat-workspace']}>
+              <AIChatWorkspace
+                filePreviewData={filePreviewData}
+                setFilePreviewData={setFilePreviewData}
+                onTabsChange={onTabsChange}
+              />
+            </div>
+          }
+          secondNode={
+            <div className={styles['chat-content']}>
+              {mode === 'welcome' ? (
+                <React.Suspense fallback={<div>loading...</div>}>
+                  <AIChatWelcome onTriageSubmit={onTriageSubmit} onSetReAct={onSetReAct} ref={aiChatWelcomeRef} />
+                </React.Suspense>
+              ) : (
+                <AIChatContent ref={aiReActChatRef} onChat={onChat} />
+              )}
+            </div>
+          }
+        />
       </div>
       <YakitDockablePane
         open={multiFuncVisible}

--- a/app/renderer/src/main/src/pages/ai-agent/aiRunModeSelect/AIRunModeSelect.module.scss
+++ b/app/renderer/src/main/src/pages/ai-agent/aiRunModeSelect/AIRunModeSelect.module.scss
@@ -18,11 +18,11 @@
     color: var(--Colors-Use-Main-Primary);
     border-color: var(--Colors-Use-Main-Primary);
   }
-}
 
-@container ai-chat-textarea (max-width: 300px) {
-  .mode-btn-label {
-    display: none;
+  @container ai-chat-textarea (max-width: 300px) {
+    .mode-btn-label {
+      display: none;
+    }
   }
 }
 

--- a/app/renderer/src/main/src/pages/ai-agent/template/template.module.scss
+++ b/app/renderer/src/main/src/pages/ai-agent/template/template.module.scss
@@ -42,6 +42,28 @@ textarea.qs-input-textarea {
     overflow: hidden;
     justify-content: space-between;
     padding: 6px 12px 8px 12px;
+    /* 底栏选择器去边框，与设计稿一致：图标 + 文案 + 箭头 */
+    :global {
+      .ant-select {
+        background: transparent;
+      }
+      .ant-select .ant-select-selector {
+        background: transparent;
+        border: none;
+        box-shadow: none;
+      }
+      .ant-select-single:not(.ant-select-customize-input) .ant-select-selector {
+        padding: 0 2px;
+      }
+      .ant-select-single:hover {
+        background-color: transparent;
+      }
+      .ant-select-focused:not(.ant-select-disabled).ant-select:not(.ant-select-customize-input) .ant-select-selector,
+      .ant-select:not(.ant-select-customize-input):not(.ant-select-disabled) .ant-select-selector:hover {
+        border: none;
+        box-shadow: none;
+      }
+    }
     %self-adaptive {
       display: flex;
       overflow: hidden;

--- a/app/renderer/src/main/src/pages/ai-agent/template/template.module.scss
+++ b/app/renderer/src/main/src/pages/ai-agent/template/template.module.scss
@@ -42,7 +42,6 @@ textarea.qs-input-textarea {
     overflow: hidden;
     justify-content: space-between;
     padding: 6px 12px 8px 12px;
-    /* 底栏选择器去边框，与设计稿一致：图标 + 文案 + 箭头 */
     :global {
       .ant-select {
         background: transparent;

--- a/app/renderer/src/main/src/pages/ai-agent/template/template.module.scss
+++ b/app/renderer/src/main/src/pages/ai-agent/template/template.module.scss
@@ -45,20 +45,26 @@ textarea.qs-input-textarea {
     :global {
       .ant-select {
         background: transparent;
+        border-radius: 6px;
       }
       .ant-select .ant-select-selector {
         background: transparent;
         border: none;
         box-shadow: none;
+        border-radius: 6px;
       }
       .ant-select-single:not(.ant-select-customize-input) .ant-select-selector {
-        padding: 0 2px;
+        padding: 2px 6px;
       }
-      .ant-select-single:hover {
-        background-color: transparent;
+      .ant-select.ant-select-single:not(.ant-select-disabled):hover,
+      .ant-select.ant-select-open,
+      .ant-select.ant-select-focused:not(.ant-select-disabled) {
+        background-color: var(--Colors-Use-Neutral-Bg-Hover);
       }
-      .ant-select-focused:not(.ant-select-disabled).ant-select:not(.ant-select-customize-input) .ant-select-selector,
-      .ant-select:not(.ant-select-customize-input):not(.ant-select-disabled) .ant-select-selector:hover {
+      .ant-select.ant-select-single:not(.ant-select-disabled):hover .ant-select-selector,
+      .ant-select.ant-select-open .ant-select-selector,
+      .ant-select.ant-select-focused:not(.ant-select-disabled) .ant-select-selector {
+        background: transparent;
         border: none;
         box-shadow: none;
       }

--- a/app/renderer/src/main/src/pages/ai-agent/template/template.module.scss
+++ b/app/renderer/src/main/src/pages/ai-agent/template/template.module.scss
@@ -74,9 +74,6 @@ textarea.qs-input-textarea {
     .model-self-adaptive {
       @extend %self-adaptive;
     }
-    .reasoning-effort-self-adaptive {
-      @extend %self-adaptive;
-    }
     .focus-mode-self-adaptive {
       @extend %self-adaptive;
     }

--- a/app/renderer/src/main/src/pages/ai-agent/template/template.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/template/template.tsx
@@ -132,7 +132,6 @@ export const AIChatTextarea: React.FC<AIChatTextareaProps> = memo(
       return [
         { type: AIInputInnerFeatureEnum.AIReviewRuleSelect },
         { type: AIInputInnerFeatureEnum.AIModelSelect, props: { isOpen } },
-        { type: AIInputInnerFeatureEnum.AIReasoningEffortSelect },
       ]
     }, [props.footerLeftTypes, isOpen])
 
@@ -402,6 +401,7 @@ export const AIChatTextarea: React.FC<AIChatTextareaProps> = memo(
             {inputFooterLeft ?? (
               <div className={styles['footer-left']}>
                 <AIRunModeSelect />
+                <AIReasoningEffortSelect />
 
                 <OpenFileDropdown cb={onSetFileMention} onSelectImage={onSelectImage}>
                   <UploadFileButton title={t('YakitButton.openFolder')} className={styles['btn-base']} />

--- a/app/renderer/src/main/src/pages/ai-agent/template/template.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/template/template.tsx
@@ -115,9 +115,6 @@ export const AIChatTextarea: React.FC<AIChatTextareaProps> = memo(
                 case AIInputInnerFeatureEnum.AIModelSelect:
                   node = { type: AIInputInnerFeatureEnum.AIModelSelect, props: { isOpen } }
                   break
-                case AIInputInnerFeatureEnum.AIReasoningEffortSelect:
-                  node = { type: AIInputInnerFeatureEnum.AIReasoningEffortSelect }
-                  break
                 default:
                   break
               }
@@ -316,17 +313,6 @@ export const AIChatTextarea: React.FC<AIChatTextareaProps> = memo(
                   key={item.type}
                   {...item.props}
                   className={classNames(styles['model-self-adaptive'], item.props?.className)}
-                />
-              ),
-            )
-            break
-          case AIInputInnerFeatureEnum.AIReasoningEffortSelect:
-            node.push(
-              item.component || (
-                <AIReasoningEffortSelect
-                  key={item.type}
-                  {...item.props}
-                  className={classNames(styles['reasoning-effort-self-adaptive'], item.props?.className)}
                 />
               ),
             )

--- a/app/renderer/src/main/src/pages/ai-agent/template/type.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/template/type.ts
@@ -11,7 +11,6 @@ import type { AIChatMentionProps } from '../components/aiChatMention/type'
 import type { AIReviewRuleSelectProps } from '@/pages/ai-re-act/aiReviewRuleSelect/type'
 import type { AIModelSelectProps } from '../aiModelList/aiModelSelect/AIModelSelectType'
 import type { AIFocusModeProps } from '@/pages/ai-re-act/aiFocusMode/type'
-import type { AIReasoningEffortSelectProps } from '@/pages/ai-re-act/aiReasoningEffortSelect/type'
 import type { AIEnabledCapability } from '@/pages/ai-re-act/hooks/grpcApi'
 
 export interface QSInputTextareaProps extends Omit<TextAreaProps, 'bordered' | 'autoSize'> {}
@@ -44,7 +43,6 @@ export interface AIChatTextareaRefProps {
 export enum AIInputInnerFeatureEnum {
   AIReviewRuleSelect = 'AIReviewRuleSelect',
   AIModelSelect = 'AIModelSelect',
-  AIReasoningEffortSelect = 'AIReasoningEffortSelect',
 }
 export enum AIInputFooterRightEnum {
   AIFocusMode = 'AIFocusMode',
@@ -58,12 +56,8 @@ interface FooterLeftTypesBase<T extends string, U> {
 }
 type AIReviewRuleSelectType = FooterLeftTypesBase<AIInputInnerFeatureEnum.AIReviewRuleSelect, AIReviewRuleSelectProps>
 type AIModelSelectType = FooterLeftTypesBase<AIInputInnerFeatureEnum.AIModelSelect, AIModelSelectProps>
-type AIReasoningEffortSelectType = FooterLeftTypesBase<
-  AIInputInnerFeatureEnum.AIReasoningEffortSelect,
-  AIReasoningEffortSelectProps
->
 type AIFocusModeType = FooterLeftTypesBase<'AIFocusMode', AIFocusModeProps>
-export type FooterLeftTypesComponentProps = AIReviewRuleSelectType | AIModelSelectType | AIReasoningEffortSelectType
+export type FooterLeftTypesComponentProps = AIReviewRuleSelectType | AIModelSelectType
 export type FooterRightTypesComponentProps = AIFocusModeType
 export interface AIChatTextareaProps {
   ref?: React.ForwardedRef<AIChatTextareaRefProps>

--- a/app/renderer/src/main/src/pages/ai-re-act/aiFocusMode/AIFocusMode.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiFocusMode/AIFocusMode.tsx
@@ -124,7 +124,16 @@ export const AIFocusMode: React.FC<AIFocusModeProps> = React.memo((props) => {
                 <span className={styles['select-option-text']} title={`${item.label}`}>
                   {item.label}
                 </span>
-                {!props.disabled && <OutlineXIcon className={styles['icon-wrapper']} onClick={onRemove} />}
+                {!props.disabled && (
+                  <OutlineXIcon
+                    className={styles['icon-wrapper']}
+                    data-select-clear
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onRemove()
+                    }}
+                  />
+                )}
               </div>
             }
           >

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/aiToDoListWrapper/AIToDoListWrapper.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/aiToDoListWrapper/AIToDoListWrapper.module.scss
@@ -1,6 +1,18 @@
 .todoList-wrapper {
   height: 33px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  box-sizing: border-box;
+  padding: 0 12px 0 4px;
+  overflow: visible;
+  position: relative;
+  z-index: 10;
+  flex-shrink: 0;
   .to-do-list {
-    margin: 2px 4px 0 4px;
+    width: 100%;
+    max-width: 784px;
+    margin: 2px 0 0;
   }
 }

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/aiToDoListWrapper/AIToDoListWrapper.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/aiToDoListWrapper/AIToDoListWrapper.module.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   align-items: flex-start;
   box-sizing: border-box;
-  padding: 0 12px 0 4px;
+  padding: 0 4px 0 4px;
   overflow: visible;
   position: relative;
   z-index: 10;
@@ -13,6 +13,6 @@
   .to-do-list {
     width: 100%;
     max-width: 784px;
-    margin: 2px 0 0;
+    margin: 8px 0 0;
   }
 }

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.module.scss
@@ -3,10 +3,10 @@
   overflow: hidden auto;
   display: flex;
   justify-content: center;
-  padding-left: 4px;
+  // padding-left: 4px;
   flex: 1;
   position: relative;
-  margin-top: 2px;
+  margin-top: 8px;
   .re-act-contents-list {
     display: flex;
     flex-direction: column;
@@ -17,8 +17,8 @@
   .item-wrapper {
     width: 100%;
     box-sizing: border-box;
-    padding-left: 2px;
-    padding-right: 2px;
+    padding-left: 8px;
+    padding-right: 8px;
     max-width: 784px;
     margin: 0 auto;
     .item-inner {

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.module.scss
@@ -18,7 +18,7 @@
     width: 100%;
     box-sizing: border-box;
     padding-left: 2px;
-    padding-right: 12px;
+    padding-right: 2px;
     max-width: 784px;
     margin: 0 auto;
     .item-inner {

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.module.scss
@@ -3,7 +3,6 @@
   overflow: hidden auto;
   display: flex;
   justify-content: center;
-  // padding-left: 4px;
   flex: 1;
   position: relative;
   margin-top: 8px;

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReasoningEffortSelect/AIReasoningEffortSelect.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReasoningEffortSelect/AIReasoningEffortSelect.module.scss
@@ -1,5 +1,14 @@
 @use '../aiReviewRuleSelect/AIReviewRuleSelect.module.scss';
 
+.reasoning-effort-select {
+  :global {
+    .ant-select,
+    .ant-select-single:not(.ant-select-customize-input) .ant-select-selector {
+      border-radius: 20px;
+    }
+  }
+}
+
 /* 下拉列表底部的探测进度行（不阻断选项点击），与模型表单 ReasoningEffortSelect 样式一致 */
 .dropdown-loading {
   display: flex;

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReasoningEffortSelect/AIReasoningEffortSelect.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReasoningEffortSelect/AIReasoningEffortSelect.tsx
@@ -121,7 +121,7 @@ export const AIReasoningEffortSelect: React.FC<AIReasoningEffortSelectProps> = R
   ))
 
   return (
-    <div className={className}>
+    <div className={classNames(styles['reasoning-effort-select'], className)}>
       <AIChatSelect
         getList={ensureEffortProbed}
         dropdownRender={(menu) => {

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReviewRuleSelect/AIReviewRuleSelect.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReviewRuleSelect/AIReviewRuleSelect.module.scss
@@ -134,6 +134,11 @@
     word-break: break-all;
     line-height: 16px;
   }
+  @container ai-chat-textarea (max-width: 300px) {
+    .select-option-text {
+      display: none;
+    }
+  }
   .icon-wrapper {
     display: flex;
     width: 16px;
@@ -163,12 +168,6 @@
   }
   .select-manual-icon-wrapper {
     background: var(--Colors-Use-Purple-Bg-Hover);
-  }
-}
-
-@container ai-chat-textarea (max-width: 300px) {
-  .select-option-text {
-    display: none;
   }
 }
 

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReviewRuleSelect/AIReviewRuleSelect.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReviewRuleSelect/AIReviewRuleSelect.module.scss
@@ -156,19 +156,41 @@
     }
   }
   .select-ai-icon-wrapper {
-    background: var(--Colors-Use-Success-Bg-Hover);
+    background: var(--Colors-Use-Success-Primary);
+    svg {
+      color: var(--Colors-Use-Basic-Background);
+    }
   }
   .select-yolo-icon-wrapper {
-    background: var(--Colors-Use-Error-Bg-Hover);
+    background: var(--Colors-Use-Error-Primary);
+    svg {
+      color: var(--Colors-Use-Basic-Background);
+    }
   }
   .select-manual-icon-wrapper {
-    background: var(--Colors-Use-Purple-Bg-Hover);
+    background: var(--Colors-Use-Purple-Primary);
+    svg {
+      color: var(--Colors-Use-Basic-Background);
+    }
   }
 }
 
 @container ai-chat-textarea (max-width: 300px) {
   .select-option-text {
     display: none;
+  }
+}
+
+/* 已选场景有关闭按钮时不展示下拉箭头，并去掉箭头预留宽度 */
+.ai-chat-select-wrapper:has([data-select-clear]) {
+  :global {
+    .ant-select-arrow {
+      display: none;
+    }
+    .ant-select-single.ant-select-show-arrow .ant-select-selection-item,
+    .ant-select-single.ant-select-show-arrow .ant-select-selection-placeholder {
+      padding-right: 0;
+    }
   }
 }
 

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReviewRuleSelect/AIReviewRuleSelect.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReviewRuleSelect/AIReviewRuleSelect.module.scss
@@ -156,22 +156,13 @@
     }
   }
   .select-ai-icon-wrapper {
-    background: var(--Colors-Use-Success-Primary);
-    svg {
-      color: var(--Colors-Use-Basic-Background);
-    }
+    background: var(--Colors-Use-Success-Bg-Hover);
   }
   .select-yolo-icon-wrapper {
-    background: var(--Colors-Use-Error-Primary);
-    svg {
-      color: var(--Colors-Use-Basic-Background);
-    }
+    background: var(--Colors-Use-Error-Bg-Hover);
   }
   .select-manual-icon-wrapper {
-    background: var(--Colors-Use-Purple-Primary);
-    svg {
-      color: var(--Colors-Use-Basic-Background);
-    }
+    background: var(--Colors-Use-Purple-Bg-Hover);
   }
 }
 


### PR DESCRIPTION
1. feat: 优化 AI 对话输入栏与底栏样式（9285b23e0）
  - 「思考」移到「模式」后面
  - 思考选择器加圆角
  - 小屏：「模式」只显示 icon；场景有关闭按钮时不显示下拉箭头，并去掉箭头占位宽度
  - 底栏改成无边框：图标 + 文案 + 箭头；回答模式图标改为实心圆
  - 待办列表 / 对话列宽等相关样式调整

2. refactor: AI对话布局改用YakitResizeBox实现拖拽分栏（33ff7dc54）
  - 工作区与对话从 flex 改为 YakitResizeBox，可左右拖拽
  - 默认比例约 左 30% / 右 70%；无工作区 tab 时左侧收起、对话铺满

合并方式
请用 Squash and merge
<img width="1344" height="829" alt="image" src="https://github.com/user-attachments/assets/2eb5d32f-efc8-4b92-a0e7-40f8919d534f" />
