### PR TITLE
feat: 右键插件结果支持弹窗、抽屉、新页签，空态支持获取插件，快捷键执行

### DIFF
--- a/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.constants.ts
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.constants.ts
@@ -20,6 +20,8 @@ export interface codecHistoryPluginProps {
   /** 动作执行链路，context-menu 为新流式执行 */
   executionType?: ContextMenuAction['ExecutionType']
   action?: ContextMenuAction
+  /** 引擎 Shortcut 原始字符串 */
+  shortcut?: string
 }
 
 export interface HTTPHeaderItem {

--- a/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.tsx
@@ -2533,6 +2533,7 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
   useHTTPFlowTableShortcutKeys({
     inViewport,
     getSelected,
+    getData: () => data,
     getSelectedRows: () => selectedRows,
     getSelectedRowKeys: () => selectedRowKeys,
     getIsAllSelect: () => isAllSelect,

--- a/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.tsx
@@ -53,7 +53,7 @@ import emiter from '@/utils/eventBus/eventBus'
 import { MITMConsts } from '@/pages/mitm/MITMConsts'
 import type { HTTPHistorySourcePageType } from '../HTTPHistory'
 import { useHttpFlowStore } from '@/store/httpFlow'
-import { OutlineCogIcon, OutlineFilterIcon, OutlineRefreshIcon } from '@/assets/icon/outline'
+import { OutlineClouddownloadIcon, OutlineCogIcon, OutlineFilterIcon, OutlineRefreshIcon } from '@/assets/icon/outline'
 import { SolidStarIcon } from '@/assets/icon/solid'
 import useVirtualTableHook from '@/hook/useVirtualTableHook/useVirtualTableHook'
 import type { ParamsTProps, VirtualTableRefreshReason } from '@/hook/useVirtualTableHook/useVirtualTableHookType'
@@ -62,6 +62,8 @@ import { IconSolidAIIcon, IconSolidAIWhiteIcon } from '@/assets/icon/colors'
 import { YakitRoute } from '@/enums/yakitRoute'
 import { ManageRightClickPluginsTabKey } from '@/pages/manageRightClickPlugins/constants'
 import { getSceneTabActions } from '@/pages/manageRightClickPlugins/utils'
+import { parseContextMenuShortcut } from '@/pages/manageRightClickPlugins/shortcut'
+import { convertKeyboardToUIKey } from '@/utils/globalShortcutKey/utils'
 import cloneDeep from 'lodash/cloneDeep'
 import { setClipboardText } from '@/utils/clipboard'
 import { RemoteHistoryGV } from '@/enums/history'
@@ -2267,8 +2269,10 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
 
   // 右键插件(单选)
   const [codecSingleHistoryPlugin, setCodecSingleHistoryPlugin] = useState<codecHistoryPluginProps[]>([])
+  const [isGetSinglePlugin, setIsGetSinglePlugin] = useState<boolean>(false)
   const searchCodecSingleHistoryPlugin = useMemoizedFn(() => {
-    getSceneTabActions(ManageRightClickPluginsTabKey.PluginExtensionSingle).then(({ list }) => {
+    getSceneTabActions(ManageRightClickPluginsTabKey.PluginExtensionSingle).then(({ list, noData }) => {
+      setIsGetSinglePlugin(noData)
       setCodecSingleHistoryPlugin(
         list.map((action) => {
           return {
@@ -2278,6 +2282,7 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
             isAiPlugin: !!action.IsAIPlugin,
             executionType: action.ExecutionType,
             action,
+            shortcut: action.Shortcut || '',
           }
         }),
       )
@@ -2286,9 +2291,10 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
 
   // 右键插件(多选)
   const [codecMultipleHistoryPlugin, setCodecMultipleHistoryPlugin] = useState<codecHistoryPluginProps[]>([])
-  /** 多选 tab 是否已被用户自定义过（含清空） */
+  const [isGetMultiplePlugin, setIsGetMultiplePlugin] = useState<boolean>(false)
   const searchCodecMultipleHistoryPlugin = useMemoizedFn(() => {
-    getSceneTabActions(ManageRightClickPluginsTabKey.PluginExtensionMultiple).then(({ list }) => {
+    getSceneTabActions(ManageRightClickPluginsTabKey.PluginExtensionMultiple).then(({ list, noData }) => {
+      setIsGetMultiplePlugin(noData)
       setCodecMultipleHistoryPlugin(
         list.map((action) => {
           return {
@@ -2298,6 +2304,7 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
             isAiPlugin: !!action.IsAIPlugin,
             executionType: action.ExecutionType,
             action,
+            shortcut: action.Shortcut || '',
           }
         }),
       )
@@ -2324,19 +2331,29 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
 
   const addIconLabel = useMemoizedFn((data: codecHistoryPluginProps[]) => {
     const items = data.map((item) => {
+      const shortcutKeys = parseContextMenuShortcut(item.shortcut || item.action?.Shortcut)
+      const keysContent = shortcutKeys.length > 0 ? convertKeyboardToUIKey(shortcutKeys) : null
+      const nameLabel = (
+        <>
+          {item.isAiPlugin && (
+            <>
+              <IconSolidAIIcon className={'ai-plugin-menu-icon-default'} />
+              <IconSolidAIWhiteIcon className={'ai-plugin-menu-icon-hover'} />
+            </>
+          )}
+          {item.key}
+        </>
+      )
       const baseItem = {
         ...item,
         key: `${PLUGIN_PREFIX}${item.key}`,
-        label: (
-          <>
-            {item.isAiPlugin && (
-              <>
-                <IconSolidAIIcon className={'ai-plugin-menu-icon-default'} />
-                <IconSolidAIWhiteIcon className={'ai-plugin-menu-icon-hover'} />
-              </>
-            )}
-            {item.key}
-          </>
+        label: keysContent ? (
+          <div className={style['editor-context-menu-keybind-wrapper']}>
+            <div className={style['content-style']}>{nameLabel}</div>
+            <div className={classNames(style['keybind-style'], 'keys-style')}>{keysContent}</div>
+          </div>
+        ) : (
+          nameLabel
         ),
       }
 
@@ -2366,10 +2383,25 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
   })
   const getCodecHistoryPlugin = useMemoizedFn(() => {
     const isMultiple = selectedRowKeys.length > 1
+    const isGetPlugin = isMultiple ? isGetMultiplePlugin : isGetSinglePlugin
     const plugins = isMultiple ? codecMultipleHistoryPlugin : codecSingleHistoryPlugin
 
     if (plugins.length > 0) {
       return addIconLabel(plugins)
+    }
+
+    if (isGetPlugin) {
+      return [
+        {
+          key: 'Get*plug-in',
+          label: (
+            <>
+              <OutlineClouddownloadIcon style={{ marginRight: 4 }} />
+              {t('HTTPFlowTable.getPlugin')}
+            </>
+          ),
+        },
+      ]
     }
 
     return [getManageRightClickPluginsMenuItem()]
@@ -2501,6 +2533,14 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
   useHTTPFlowTableShortcutKeys({
     inViewport,
     getSelected,
+    getSelectedRows: () => selectedRows,
+    getSelectedRowKeys: () => selectedRowKeys,
+    getIsAllSelect: () => isAllSelect,
+    getTotal: () => total,
+    onClearSelection: resetSelected,
+    singlePlugins: codecSingleHistoryPlugin,
+    multiplePlugins: codecMultipleHistoryPlugin,
+    pageType,
     downstreamProxyStr,
     fromMITM,
     t,
@@ -2700,6 +2740,7 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
     onShieldDomain,
     onBatch,
     onViewAttachmentDataRefresh,
+    onClearSelection: resetSelected,
   })
 
   useEffect(() => {

--- a/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.utils.ts
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.utils.ts
@@ -601,3 +601,31 @@ export function getFullRange(id: number, count = 10, minId = 1, maxId = null) {
   }
   return range
 }
+
+/** History 表格批量操作单次最大条数 */
+export const HTTP_FLOW_TABLE_BATCH_MAX_ROWS = 200
+
+export type ResolveHTTPFlowTableBatchSelectionResult =
+  | { ok: true; rows: HTTPFlow[]; ids: string[] }
+  | { ok: false; reason: 'max_exceeded' }
+
+export interface ResolveHTTPFlowTableBatchSelectionOptions {
+  selectedRowKeys: string[]
+  selectedRows: HTTPFlow[]
+  isAllSelect: boolean
+  total: number
+  maxRows?: number
+}
+
+/** 解析 History 表格多选/全选目标行，供批量右键、packetScan、插件快捷键等共用 */
+export const resolveHTTPFlowTableBatchSelection = (
+  options: ResolveHTTPFlowTableBatchSelectionOptions,
+): ResolveHTTPFlowTableBatchSelectionResult => {
+  const { selectedRowKeys, selectedRows, isAllSelect, total, maxRows = HTTP_FLOW_TABLE_BATCH_MAX_ROWS } = options
+  if (isAllSelect) {
+    if (total > maxRows) return { ok: false, reason: 'max_exceeded' }
+  } else if (selectedRowKeys.length > maxRows) {
+    return { ok: false, reason: 'max_exceeded' }
+  }
+  return { ok: true, rows: selectedRows, ids: selectedRowKeys }
+}

--- a/app/renderer/src/main/src/components/HTTPFlowTable/__test__/HTTPFlowTable.utils.test.ts
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/__test__/HTTPFlowTable.utils.test.ts
@@ -22,8 +22,83 @@ import {
   splitHTTPFlowTableShieldData,
   uniqStrings,
   parseIncludeIds,
+  resolveHTTPFlowTableBatchSelection,
 } from '@/components/HTTPFlowTable/HTTPFlowTable.utils'
 import { HTTP_FLOW_FAVORITE_TAG, type HTTPFlow } from '@/components/HTTPFlowTable/HTTPFlowTable.constants'
+
+describe('resolveHTTPFlowTableBatchSelection', () => {
+  const makeFlow = (id: number): HTTPFlow => ({ Id: id }) as HTTPFlow
+
+  it('returns selected rows for normal multi-select', () => {
+    const rows = [makeFlow(1), makeFlow(2)]
+    expect(
+      resolveHTTPFlowTableBatchSelection({
+        selectedRowKeys: ['1', '2'],
+        selectedRows: rows,
+        isAllSelect: false,
+        total: 2,
+      }),
+    ).toEqual({ ok: true, rows, ids: ['1', '2'] })
+  })
+
+  it('all-select only checks total limit and returns current selection', () => {
+    const rows = [makeFlow(1)]
+    expect(
+      resolveHTTPFlowTableBatchSelection({
+        selectedRowKeys: ['1'],
+        selectedRows: rows,
+        isAllSelect: true,
+        total: 3,
+      }),
+    ).toEqual({ ok: true, rows, ids: ['1'] })
+  })
+
+  it('rejects when all-select total exceeds max rows', () => {
+    expect(
+      resolveHTTPFlowTableBatchSelection({
+        selectedRowKeys: ['1'],
+        selectedRows: [makeFlow(1)],
+        isAllSelect: true,
+        total: 201,
+      }),
+    ).toEqual({ ok: false, reason: 'max_exceeded' })
+  })
+
+  it('rejects when multi-select count exceeds max rows', () => {
+    expect(
+      resolveHTTPFlowTableBatchSelection({
+        selectedRowKeys: Array.from({ length: 201 }, (_, i) => `${i}`),
+        selectedRows: [],
+        isAllSelect: false,
+        total: 201,
+      }),
+    ).toEqual({ ok: false, reason: 'max_exceeded' })
+  })
+
+  it('all-select with single row still returns selected rows', () => {
+    const rows = [makeFlow(1)]
+    expect(
+      resolveHTTPFlowTableBatchSelection({
+        selectedRowKeys: ['1'],
+        selectedRows: rows,
+        isAllSelect: true,
+        total: 1,
+      }),
+    ).toEqual({ ok: true, rows, ids: ['1'] })
+  })
+
+  it('respects custom maxRows limit', () => {
+    expect(
+      resolveHTTPFlowTableBatchSelection({
+        selectedRowKeys: ['1', '2', '3'],
+        selectedRows: [makeFlow(1), makeFlow(2), makeFlow(3)],
+        isAllSelect: false,
+        total: 3,
+        maxRows: 2,
+      }),
+    ).toEqual({ ok: false, reason: 'max_exceeded' })
+  })
+})
 
 describe('parseIncludeIds', () => {
   it('parses single and comma-separated numbers into an id array', () => {

--- a/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableContextMenu.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableContextMenu.tsx
@@ -34,6 +34,7 @@ import {
 } from './HTTPFlowTable.actions'
 import type { HistoryMenuData, HTTPFlow } from './HTTPFlowTable.constants'
 import { hydrateHTTPFlowRequest, hydrateHTTPFlowRequests } from './HTTPFlowTable.packet'
+import { resolveHTTPFlowTableBatchSelection, HTTP_FLOW_TABLE_BATCH_MAX_ROWS } from './HTTPFlowTable.utils'
 import { isHTTPFlowFavorite } from './HTTPFlowTable.utils'
 import style from './HTTPFlowTable.module.scss'
 import { PLUGIN_PREFIX, PLUGIN_RIGHT_MAG } from '../yakitUI/YakitEditor/YakitEditor'
@@ -112,6 +113,7 @@ export interface UseHTTPFlowTableContextMenuOptions {
   onShieldDomain: (flow: HTTPFlow) => void
   onBatch: (f: (element: HTTPFlow) => void, number: number, all?: boolean, rows?: HTTPFlow[]) => void
   onViewAttachmentDataRefresh: (id: number) => void
+  onClearSelection: () => void
 }
 
 export const useHTTPFlowTableContextMenu = (options: UseHTTPFlowTableContextMenuOptions) => {
@@ -155,6 +157,7 @@ export const useHTTPFlowTableContextMenu = (options: UseHTTPFlowTableContextMenu
     onShieldDomain,
     onBatch,
     onViewAttachmentDataRefresh,
+    onClearSelection,
   } = options
 
   const menuData = useMemo(() => {
@@ -614,6 +617,13 @@ export const useHTTPFlowTableContextMenu = (options: UseHTTPFlowTableContextMenu
     }) => {
       const menuItemName = keyPath[0]
 
+      const emitGetPluginEvent = () => {
+        emiter.emit(
+          'onOpenFuzzerModal',
+          JSON.stringify({ scriptName: key, isAiPlugin: 'isGetPlugin', pluginType: ['codec', 'context-menu'] }),
+        )
+      }
+
       const emitPluginEvent = (child: HistoryMenuData, isExec: boolean, scriptName: string) => {
         if (!rows.length) {
           yakitNotify('warning', t('HTTPFlowTable.pleaseSelectData'))
@@ -664,6 +674,12 @@ export const useHTTPFlowTableContextMenu = (options: UseHTTPFlowTableContextMenu
           const tab = key.split('_')[1]
           emiter.emit('openPage', JSON.stringify({ route: YakitRoute.ManageRightClickPlugins, params: { tab } }))
         })
+        return
+      }
+
+      // ----- 点击获取插件 -----
+      if (key === 'Get*plug-in') {
+        emitGetPluginEvent()
         return
       }
 
@@ -928,6 +944,20 @@ export const useHTTPFlowTableContextMenu = (options: UseHTTPFlowTableContextMenu
       })
   })
 
+  const resolveBatchSelectionOrNotify = useMemoizedFn(() => {
+    const resolved = resolveHTTPFlowTableBatchSelection({
+      selectedRowKeys,
+      selectedRows,
+      isAllSelect,
+      total,
+    })
+    if (!resolved.ok) {
+      yakitNotify('warning', t('HTTPFlowTable.maxSendData', { number: HTTP_FLOW_TABLE_BATCH_MAX_ROWS }))
+      return null
+    }
+    return resolved
+  })
+
   const onMultipleClick = useMemoizedFn(async (key: string, keyPath: string[]) => {
     const batchContextMenu = getBatchContextMenu()
     const menuName = keyPath[keyPath.length - 1]
@@ -937,46 +967,22 @@ export const useHTTPFlowTableContextMenu = (options: UseHTTPFlowTableContextMenu
         onPluginExtensionHandle({ key, keyPath, id: [], rows: [], menu: batchContextMenu })
         return
       }
-      let sendIds: string[] = selectedRowKeys
-      let sendRows: HTTPFlow[] = selectedRows
-      if (isAllSelect) {
-        if (total > 200) {
-          yakitNotify('warning', t('HTTPFlowTable.maxSendData', { number: 200 }))
-          return
-        }
-        sendIds = data.map((item) => item.Id + '')
-        sendRows = data
-      } else if (sendIds.length > 200) {
-        yakitNotify('warning', t('HTTPFlowTable.maxSendData', { number: 200 }))
-        return
-      }
-      onPluginExtensionHandle({ key, keyPath, id: sendIds, rows: sendRows, menu: batchContextMenu })
-      setSelectedRowKeys([])
-      setSelectedRows([])
+      const resolved = resolveBatchSelectionOrNotify()
+      if (!resolved) return
+      onPluginExtensionHandle({ key, keyPath, id: resolved.ids, rows: resolved.rows, menu: batchContextMenu })
+      onClearSelection()
       return
     }
 
     if (keyPath.includes('packetScan')) {
-      let sendIds: string[] = selectedRowKeys
-      if (isAllSelect) {
-        if (total > 200) {
-          yakitNotify('warning', t('HTTPFlowTable.maxSendData', { number: 200 }))
-          return
-        } else {
-          sendIds = data.map((item) => item.Id + '')
-        }
-      } else {
-        if (sendIds.length > 200) {
-          yakitNotify('warning', t('HTTPFlowTable.maxSendData', { number: 200 }))
-          return
-        }
-      }
+      const resolved = resolveBatchSelectionOrNotify()
+      if (!resolved) return
       const currentItemScan = menuData.find((f) => f.onClickBatch && f.key === 'packetScan')
       const currentItemPacketScan = packetScanDefaultValue.find((f) => f.Verbose === key || f.VerboseUi === key)
       if (!currentItemScan || !currentItemPacketScan) return
 
       onBatchExecPacketScan({
-        httpFlowIds: sendIds,
+        httpFlowIds: resolved.ids,
         maxLength: currentItemScan.number || 0,
         currentPacketScan: currentItemPacketScan,
       })

--- a/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableContextMenu.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableContextMenu.tsx
@@ -946,8 +946,8 @@ export const useHTTPFlowTableContextMenu = (options: UseHTTPFlowTableContextMenu
 
   const resolveBatchSelectionOrNotify = useMemoizedFn(() => {
     const resolved = resolveHTTPFlowTableBatchSelection({
-      selectedRowKeys,
-      selectedRows,
+      selectedRowKeys: isAllSelect ? data.map((item) => String(item.Id)) : selectedRowKeys,
+      selectedRows: isAllSelect ? data : selectedRows,
       isAllSelect,
       total,
     })

--- a/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableShortcutKeys.ts
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableShortcutKeys.ts
@@ -38,6 +38,7 @@ const isEditableTarget = (target: EventTarget | null) => {
 export interface UseHTTPFlowTableShortcutKeysOptions {
   inViewport: boolean
   getSelected: () => HTTPFlow | undefined
+  getData: () => HTTPFlow[]
   getSelectedRows: () => HTTPFlow[]
   getSelectedRowKeys: () => (string | number)[]
   getIsAllSelect: () => boolean
@@ -66,6 +67,7 @@ export const useHTTPFlowTableShortcutKeys = (options: UseHTTPFlowTableShortcutKe
   const {
     inViewport,
     getSelected,
+    getData,
     getSelectedRows,
     getSelectedRowKeys,
     getIsAllSelect,
@@ -147,9 +149,10 @@ export const useHTTPFlowTableShortcutKeys = (options: UseHTTPFlowTableShortcutKe
 
     let rows: HTTPFlow[] = []
     if (isMultiple) {
+      const data = getData()
       const resolved = resolveHTTPFlowTableBatchSelection({
-        selectedRowKeys: selectedKeys.map(String),
-        selectedRows: getSelectedRows(),
+        selectedRowKeys: isAllSelect ? data.map((item) => String(item.Id)) : selectedKeys.map(String),
+        selectedRows: isAllSelect ? data : getSelectedRows(),
         isAllSelect,
         total: getTotal(),
       })
@@ -162,7 +165,10 @@ export const useHTTPFlowTableShortcutKeys = (options: UseHTTPFlowTableShortcutKe
       const selected = getSelected()
       if (selected) rows = [selected]
     }
-    if (!rows.length) return
+    if (!rows.length) {
+      yakitNotify('warning', t('HTTPFlowTable.pleaseSelectData'))
+      return
+    }
     runPluginByShortcut(hit, rows)
     if (isAllSelect || isMultiple) onClearSelection()
   })

--- a/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableShortcutKeys.ts
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableShortcutKeys.ts
@@ -1,5 +1,7 @@
+import { useEffect } from 'react'
+import { useMemoizedFn } from 'ahooks'
 import { showResponseViaHTTPFlowID } from '@/components/ShowInBrowser'
-import type { HTTPFlow } from '@/components/HTTPFlowTable/HTTPFlowTable.constants'
+import type { codecHistoryPluginProps, HTTPFlow } from '@/components/HTTPFlowTable/HTTPFlowTable.constants'
 import type { SingleManualHijackInfoMessage } from '@/pages/mitm/MITMHacker/utils'
 import { generateCSRFPocByRequest } from '@/pages/invoker/fromPacketToYakCode'
 import { newWebsocketFuzzerTab } from '@/pages/websocket/WebsocketFuzzer'
@@ -7,17 +9,43 @@ import { setClipboardText } from '@/utils/clipboard'
 import { ShortcutKeyFocusType } from '@/utils/globalShortcutKey/events/global'
 import { YakitMultipleShortcutKey } from '@/utils/globalShortcutKey/events/multiple/yakitMultiple'
 import useShortcutKeyTrigger from '@/utils/globalShortcutKey/events/useShortcutKeyTrigger'
+import {
+  convertKeyEventToKeyCombination,
+  getCurrentShortcutFocus,
+  getIsActiveShortcutKeyPage,
+} from '@/utils/globalShortcutKey/utils'
 import { openExternalWebsite } from '@/utils/openWebsite'
 import { yakitNotify } from '@/utils/notification'
 import type { YakDeleteHTTPFlowRequest } from '@/utils/yakQueryHTTPFlow'
+import { runContextMenuAction } from '@/pages/manageRightClickPlugins/runContextMenuAction'
+import { ContextMenuExecutionType, type ContextMenuHttpsState } from '@/pages/manageRightClickPlugins/types'
+import { matchContextMenuShortcut } from '@/pages/manageRightClickPlugins/shortcut'
+import emiter from '@/utils/eventBus/eventBus'
 import { hydrateHTTPFlowRequest } from './HTTPFlowTable.packet'
+import { HTTP_FLOW_TABLE_BATCH_MAX_ROWS, resolveHTTPFlowTableBatchSelection } from './HTTPFlowTable.utils'
 
 const isMonacoFocused = (focus?: string[] | null) =>
   (focus || []).some((item) => item.startsWith(ShortcutKeyFocusType.Monaco))
 
+/** 焦点在输入框/文本域/富文本等可编辑元素时，不拦截插件快捷键 */
+const isEditableTarget = (target: EventTarget | null) => {
+  if (!target) return false
+  const el = target as HTMLElement
+  const tag = el.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable
+}
+
 export interface UseHTTPFlowTableShortcutKeysOptions {
   inViewport: boolean
   getSelected: () => HTTPFlow | undefined
+  getSelectedRows: () => HTTPFlow[]
+  getSelectedRowKeys: () => (string | number)[]
+  getIsAllSelect: () => boolean
+  getTotal: () => number
+  onClearSelection: () => void
+  singlePlugins: codecHistoryPluginProps[]
+  multiplePlugins: codecHistoryPluginProps[]
+  pageType?: string
   downstreamProxyStr: string
   fromMITM: boolean
   t: (...args: any[]) => any
@@ -38,6 +66,14 @@ export const useHTTPFlowTableShortcutKeys = (options: UseHTTPFlowTableShortcutKe
   const {
     inViewport,
     getSelected,
+    getSelectedRows,
+    getSelectedRowKeys,
+    getIsAllSelect,
+    getTotal,
+    onClearSelection,
+    singlePlugins,
+    multiplePlugins,
+    pageType,
     downstreamProxyStr,
     fromMITM,
     t,
@@ -54,6 +90,90 @@ export const useHTTPFlowTableShortcutKeys = (options: UseHTTPFlowTableShortcutKe
       .then(action)
       .catch((error) => yakitNotify('error', `Query HTTPFlow failed: ${error}`))
   }
+
+  const runPluginByShortcut = useMemoizedFn((plugin: codecHistoryPluginProps, rows: HTTPFlow[]) => {
+    const ids = rows.map((item) => item.Id)
+    if (plugin.executionType === ContextMenuExecutionType.ContextMenu && plugin.action) {
+      const httpsValues = new Set(rows.map((item) => !!item.IsHTTPS))
+      let httpsState: ContextMenuHttpsState = 'unknown'
+      if (httpsValues.size > 1) httpsState = 'mixed'
+      else if (httpsValues.size === 1) httpsState = httpsValues.has(true) ? 'https' : 'http'
+
+      runContextMenuAction({
+        action: plugin.action,
+        configureParams: false,
+        request: {
+          Source: pageType || 'History',
+          Trigger: 'shortcut',
+          HttpsState: httpsState,
+          HTTPFlowIDs: ids.map((item) => Number(item)),
+          HasRequest: false,
+          HasResponse: false,
+          PacketRevision: '',
+        },
+      })
+      return
+    }
+    emiter.emit(
+      'onOpenFuzzerModal',
+      JSON.stringify({
+        text: ids.join(','),
+        scriptName: plugin.key,
+        params: plugin.params,
+        isAiPlugin: plugin.isAiPlugin,
+        isExec: true,
+      }),
+    )
+  })
+
+  const onContextMenuPluginKeyDown = useMemoizedFn((ev: KeyboardEvent) => {
+    if (getIsActiveShortcutKeyPage()) return
+    if (isMonacoFocused(getCurrentShortcutFocus())) return
+    if (isEditableTarget(ev.target)) return
+    const keys = convertKeyEventToKeyCombination(ev)
+    if (!keys) return
+
+    const selectedKeys = getSelectedRowKeys()
+    const isAllSelect = getIsAllSelect()
+    const isMultiple = selectedKeys.length > 1
+    const plugins = isMultiple ? multiplePlugins : singlePlugins
+    if (!plugins.length) return
+
+    const hit = plugins.find((plugin) => matchContextMenuShortcut(keys, plugin.shortcut || plugin.action?.Shortcut))
+    if (!hit) return
+
+    ev.preventDefault()
+    ev.stopImmediatePropagation()
+
+    let rows: HTTPFlow[] = []
+    if (isMultiple) {
+      const resolved = resolveHTTPFlowTableBatchSelection({
+        selectedRowKeys: selectedKeys.map(String),
+        selectedRows: getSelectedRows(),
+        isAllSelect,
+        total: getTotal(),
+      })
+      if (!resolved.ok) {
+        yakitNotify('warning', t('HTTPFlowTable.maxSendData', { number: HTTP_FLOW_TABLE_BATCH_MAX_ROWS }))
+        return
+      }
+      rows = resolved.rows
+    } else {
+      const selected = getSelected()
+      if (selected) rows = [selected]
+    }
+    if (!rows.length) return
+    runPluginByShortcut(hit, rows)
+    if (isAllSelect || isMultiple) onClearSelection()
+  })
+  // 右键插件 Shortcut：capture 阶段优先匹配，避免被全局快捷键吞掉
+  useEffect(() => {
+    if (!inViewport) return
+    document.addEventListener('keydown', onContextMenuPluginKeyDown, true)
+    return () => {
+      document.removeEventListener('keydown', onContextMenuPluginKeyDown, true)
+    }
+  }, [inViewport, onContextMenuPluginKeyDown])
 
   useShortcutKeyTrigger('sendAndJump*common', (focus) => {
     const selected = getSelected?.()

--- a/app/renderer/src/main/src/components/layout/UILayout.tsx
+++ b/app/renderer/src/main/src/components/layout/UILayout.tsx
@@ -2048,13 +2048,14 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
       <Suspense fallback={null}>
         <YakitGetOnlinePlugin
           visible={coedcPluginShow}
-          pluginType={['codec']}
+          pluginType={openFuzzerModalVarRef.current?.pluginType || ['codec']}
           setVisible={(v) => {
             setCoedcPluginShow(v)
           }}
           onFinish={() => {
             // 此处通知刷新各类基于codec插件菜单
             emiter.emit('refreshContextMenuActions')
+            emiter.emit('refreshContextMenuPlugins')
           }}
           getContainer={codecPluginContainerRef.current}
         />

--- a/app/renderer/src/main/src/components/yakChat/chatCS.tsx
+++ b/app/renderer/src/main/src/components/yakChat/chatCS.tsx
@@ -143,6 +143,7 @@ export interface OpenFuzzerModal extends Omit<CodecParamsProps, 'isAiPlugin'> {
   isAiPlugin: string | boolean
   params?: YakParamProps[]
   isExec?: boolean
+  pluginType?: string[]
 }
 
 /** 将 new Date 转换为日期 */

--- a/app/renderer/src/main/src/components/yakitUI/YakitDrawer/YakitDrawer.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitDrawer/YakitDrawer.tsx
@@ -156,6 +156,7 @@ export const showYakitDrawer = (props: ShowDrawerProps) => {
         if (yakitDrawerRootDiv) {
           yakitDrawerRootDiv.unmount()
         }
+        div.remove()
       }, 400)
     },
   }

--- a/app/renderer/src/main/src/components/yakitUI/YakitDrawer/YakitDrawer.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitDrawer/YakitDrawer.tsx
@@ -103,7 +103,11 @@ const YakitBaseDrawer: React.FC<ShowDrawerProps> = (props) => {
 
 export const showYakitDrawer = (props: ShowDrawerProps) => {
   const div = document.createElement('div')
-  document.body.appendChild(div)
+  if (!!props.getContainer && props.getContainer instanceof HTMLElement) {
+    props.getContainer.appendChild(div)
+  } else {
+    document.body.appendChild(div)
+  }
 
   let setter: (r: boolean) => any = () => {}
   let yakitDrawerRootDiv

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/EditorMenu.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/EditorMenu.tsx
@@ -20,6 +20,8 @@ export interface EditorMenuItemProps {
   title?: string
   /** @description !!! 请最少使用其中一个(ctrl/alt/meta/shift)[不能重复使用] 搭配 字母或F1-12 使用快捷键功能 */
   keybindings?: string
+  /** 原始按键数组（右键插件 Shortcut 等，不走编辑器事件名映射） */
+  shortcutKeys?: string[]
   isCustom?: boolean
 }
 export interface EditorMenuItemDividerProps {

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/YakitEditor.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/YakitEditor.tsx
@@ -453,7 +453,7 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
     }
 
     keyToOnRunRef.current = { ...keyToRun }
-  }, [contextMenu, customHTTPMutatePlugin, contextMenuPlugin, extraMenuListsObj, baseMenuListsObj])
+  }, [contextMenu, customHTTPMutatePlugin, contextMenuPlugin, extraMenuListsObj, baseMenuListsObj, isGetPlugin])
 
   /** 数据包内容版本（FNV-1a hash），插件执行回来后校验内容是否变化 */
   const packetRevision = (request: string | undefined, response: string | undefined) => {

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/YakitEditor.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/YakitEditor.tsx
@@ -87,6 +87,7 @@ import {
   ContextMenuExecutionType,
   type ContextMenuAction,
   type ContextMenuPacketActionResult,
+  type ContextMenuTrigger,
 } from '@/pages/manageRightClickPlugins/types'
 
 // ===== 拆分模块导入 =====
@@ -112,10 +113,11 @@ import {
   SmartDecodeFloatPanel,
   snapshotRect,
 } from '@/pages/fuzzer/HTTPFuzzerEditorMenu'
-import { OutlineCogIcon } from '@/assets/icon/outline'
+import { OutlineClouddownloadIcon, OutlineCogIcon } from '@/assets/icon/outline'
 import { YakitRoute } from '@/enums/yakitRoute'
 import { ManageRightClickPluginsTabKey } from '@/pages/manageRightClickPlugins/constants'
 import { checkContextMenuVersion } from '@/pages/manageRightClickPlugins/utils'
+import { parseContextMenuShortcut } from '@/pages/manageRightClickPlugins/shortcut'
 
 // re-export 保持外部导入路径兼容
 export { PLUGIN_PREFIX }
@@ -338,7 +340,7 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
   const ref = useRef<HTMLDivElement>(null)
   const [inViewport] = useInViewport(ref)
 
-  const { customHTTPMutatePlugin, contextMenuPlugin } = usePluginSearch({
+  const { customHTTPMutatePlugin, contextMenuPlugin, isGetPlugin } = usePluginSearch({
     menuType,
     inViewport,
   })
@@ -368,8 +370,9 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
       // 自定义HTTP数据包变形
       ;(extraMenuListsObj['http'].menu[0] as EditorMenuItemProps).children = newHttpChildren
 
-      // 插件扩展（为保持key值唯一性，添加 plugin- ）
+      // 右键插件（为保持key值唯一性，添加 plugin- ）
       const newCustomContextMenu = contextMenuPlugin.map((item) => {
+        const shortcutKeys = parseContextMenuShortcut(item.action?.Shortcut)
         const baseItem = {
           key: `${PLUGIN_PREFIX}${item.value}`,
           label: (
@@ -387,6 +390,7 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
           params: item.params,
           executionType: item.executionType,
           action: item.action,
+          shortcutKeys: shortcutKeys.length > 0 ? shortcutKeys : undefined,
         } as EditorMenuItemProps
 
         // 如果有参数，添加子菜单
@@ -418,7 +422,22 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
       } as EditorMenuItemProps
       newCustomContextMenu.push(manageContextMenuItem)
       ;(extraMenuListsObj['customcontextmenu'].menu[0] as EditorMenuItemProps).children =
-        contextMenuPlugin.length > 0 ? newCustomContextMenu : [manageContextMenuItem]
+        contextMenuPlugin.length > 0
+          ? newCustomContextMenu
+          : isGetPlugin
+            ? [
+                {
+                  key: 'Get*plug-in',
+                  label: (
+                    <>
+                      <OutlineClouddownloadIcon style={{ marginRight: 4 }} />
+                      {t('YakitEditor.getPlugin')}
+                    </>
+                  ),
+                  isGetPlugin: true,
+                } as EditorMenuItemProps,
+              ]
+            : [manageContextMenuItem]
     } catch (e) {
       failed(`get custom plugin failed: ${e}`)
     }
@@ -457,7 +476,12 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
 
   /** context-menu 类型插件在编辑器场景的触发：以当前编辑器内容(可含另一侧)为数据包执行，并支持回填 */
   const runEditorContextMenuAction = useMemoizedFn(
-    (editor: YakitIMonacoEditor, action: ContextMenuAction, isExec: boolean) => {
+    (
+      editor: YakitIMonacoEditor,
+      action: ContextMenuAction,
+      isExec: boolean,
+      trigger: ContextMenuTrigger = 'context-menu',
+    ) => {
       const currentValue = fetchEditorFullContent(editor)
       // 角色三级判定：显式指定 > 内容嗅探（状态行开头为 response）
       const role = contextMenuPacket?.role || (/^HTTP\/\d(?:\.\d)?\s/.test(currentValue) ? 'response' : 'request')
@@ -472,7 +496,7 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
           role === 'response' ? currentContent : contextMenuPacket?.peerValue,
         )
         if (result.PacketRevision !== revision || currentRevision !== revision) {
-          yakitNotify('warning', '数据包在插件执行期间已变化，未应用插件修改')
+          yakitNotify('warning', t('YakitEditor.packetChangedDuringPluginExecution'))
           return false
         }
         const model = editor.getModel()
@@ -490,7 +514,7 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
           if (contextMenuPacket?.onPeerValueChange) {
             contextMenuPacket.onPeerValueChange(rawBytesToPacketText(peerBytes))
           } else {
-            yakitNotify('warning', '插件同时修改了另一侧数据包，但当前页面未提供回填入口')
+            yakitNotify('warning', t('YakitEditor.pluginModifiedPeerPacketNoFillEntry'))
           }
         }
         return true
@@ -502,7 +526,7 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
         onPacketResult: readOnly ? undefined : applyPacketResult,
         request: {
           Source: contextMenuPacket?.source || 'http-packet-editor',
-          Trigger: 'context-menu',
+          Trigger: trigger,
           HttpsState: contextMenuPacket?.httpsState || 'unknown',
           HTTPFlowIDs: contextMenuPacket?.httpFlowId ? [contextMenuPacket.httpFlowId] : [],
           Request: request === undefined ? undefined : StringToUint8Array(request),
@@ -517,12 +541,13 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
 
   /** 菜单功能点击处理事件 */
   const { run: menuItemHandle } = useDebounceFn(
-    useMemoizedFn((key: string, keyPath: string[]) => {
+    useMemoizedFn((key: string, keyPath: string[], fromShortcut = false) => {
       if (!editor) return
       /** 是否执行过方法(onRightContextMenu) */
       let executeFunc = false
       const menuName = keyPath[keyPath.length - 1]
       const menuItemName = keyPath[0]
+      const trigger: ContextMenuTrigger = fromShortcut ? 'shortcut' : 'context-menu'
       for (let name in keyToOnRunRef.current) {
         const allMenu = { ...baseMenuListsObj, ...extraMenuListsObj, ...contextMenu }
         if (
@@ -551,7 +576,10 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
               }
               // 点击二级菜单
               if (item.key === menuItemName) {
-                if (item.key.startsWith(PLUGIN_RIGHT_MAG)) {
+                if (item.isGetPlugin) {
+                  // 当子项为获取插件
+                  data = 'isGetPlugin'
+                } else if (item.key.startsWith(PLUGIN_RIGHT_MAG)) {
                   // 当子项为管理右键插件：跳转前校验引擎版本，版本不足则拦截并提示
                   checkContextMenuVersion().then((versionValid) => {
                     if (!versionValid) return
@@ -591,7 +619,7 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
             contextMenuActionItem.executionType === ContextMenuExecutionType.ContextMenu &&
             contextMenuActionItem.action
           ) {
-            runEditorContextMenuAction(editor, contextMenuActionItem.action, isExec !== false)
+            runEditorContextMenuAction(editor, contextMenuActionItem.action, isExec !== false, trigger)
             executeFunc = true
             onRightContextMenu(menuItemName)
             break
@@ -1567,16 +1595,20 @@ export const YakitEditor: React.FC<YakitEditorProps> = React.memo((props) => {
                 // 是否直接使用编辑器快捷键 不走自定义逻辑
                 const isUseDefaultShortcut = isYakEditorDefaultShortcut(e.browserEvent)
                 if (!isUseDefaultShortcut) {
-                  // 判断当前输入是否激活 编辑器内部快捷键
+                  const keys = convertKeyEventToKeyCombination(e.browserEvent)
+                  if (keys) {
+                    const sortKeys = sortKeysCombination(keys)
+                    const keyToMenu = keyBindingRef.current[sortKeys.join('-')]
+                    // 编辑器内置菜单快捷键 + 右键插件 Shortcut 均走 keyBindingRef
+                    if (keyToMenu) {
+                      menuItemHandle(keyToMenu[0], keyToMenu, true)
+                      e.browserEvent.stopImmediatePropagation()
+                      return
+                    }
+                  }
+                  // 判断当前输入是否激活 编辑器内部快捷键（已注册事件但未挂菜单时仍拦截）
                   const isActiveYakEditor = isYakEditorShortcut(e.browserEvent)
                   if (isActiveYakEditor) {
-                    const keys = convertKeyEventToKeyCombination(e.browserEvent)
-                    if (keys) {
-                      let sortKeys = sortKeysCombination(keys)
-                      const keyToMenu = keyBindingRef.current[sortKeys.join('-')]
-                      if (!keyToMenu) return
-                      menuItemHandle(keyToMenu[0], keyToMenu)
-                    }
                     e.browserEvent.stopImmediatePropagation()
                     return
                   }

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/contextMenus.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/contextMenus.tsx
@@ -270,7 +270,17 @@ export const extraMenuLists: (t: TFunction) => OtherMenuListProps = (t) => {
               text = selectText
             }
           }
-          emiter.emit('onOpenFuzzerModal', JSON.stringify({ text, scriptName: key, isAiPlugin, params, isExec }))
+          emiter.emit(
+            'onOpenFuzzerModal',
+            JSON.stringify({
+              text,
+              scriptName: key,
+              isAiPlugin,
+              params,
+              isExec,
+              pluginType: ['codec', 'context-menu'],
+            }),
+          )
         } catch (e) {
           failed(`custom context menu execute failed: ${e}`)
         }

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/hooks/usePluginSearch.ts
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/hooks/usePluginSearch.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useMemoizedFn } from 'ahooks'
 import { queryYakScriptList } from '@/pages/yakitStore/network'
 import type { YakScript } from '@/pages/invoker/schema'
@@ -18,6 +18,7 @@ export interface UsePluginSearchParams {
 export interface UsePluginSearchResult {
   customHTTPMutatePlugin: CodecTypeProps[]
   contextMenuPlugin: contextMenuProps[]
+  isGetPlugin: boolean
   setCustomHTTPMutatePlugin: (info: CodecTypeProps[]) => void
   setContextMenuPlugin: (info: contextMenuProps[]) => void
   onRefreshPluginCodecMenu: () => void
@@ -62,8 +63,10 @@ export const usePluginSearch = (params: UsePluginSearchParams): UsePluginSearchR
   })
 
   // 右键插件
+  const [isGetPlugin, setIsGetPlugin] = useState<boolean>(false)
   const searchCodecCustomContextMenuPlugin = useMemoizedFn(() => {
-    getSceneTabActions(ManageRightClickPluginsTabKey.PacketContextMenu).then(({ list }) => {
+    getSceneTabActions(ManageRightClickPluginsTabKey.PacketContextMenu).then(({ list, noData }) => {
+      setIsGetPlugin(noData)
       setContextMenuPlugin(
         list.map((action) => {
           return {
@@ -103,6 +106,7 @@ export const usePluginSearch = (params: UsePluginSearchParams): UsePluginSearchR
   return {
     customHTTPMutatePlugin,
     contextMenuPlugin,
+    isGetPlugin,
     setCustomHTTPMutatePlugin,
     setContextMenuPlugin,
     onRefreshPluginCodecMenu,

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/menus/__test__/menuHelpers.test.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/menus/__test__/menuHelpers.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { contextMenuKeybindingHandle } from '../menuHelpers'
+import type { KeyboardToFuncProps } from '../../YakitEditorType'
+import type { EditorMenuItemType } from '../../EditorMenu'
+
+const t = (key: string) => key
+const newRef = () => ({ current: {} as KeyboardToFuncProps })
+
+describe('contextMenuKeybindingHandle 快捷键映射注册', () => {
+  it('后注册的同组合不覆盖先注册的菜单项（内置菜单优先于右键插件）', () => {
+    const keyBindingRef = newRef()
+    const data: EditorMenuItemType[] = [
+      {
+        key: 'built-in',
+        label: '内置菜单项',
+        shortcutKeys: ['Control', 'KEY_D'],
+      },
+      {
+        key: 'plugin-item',
+        label: '右键插件',
+        shortcutKeys: ['Control', 'KEY_D'],
+      },
+    ]
+
+    contextMenuKeybindingHandle(t as any, keyBindingRef as any, '', data)
+
+    expect(keyBindingRef.current['Control-KEY_D']).toEqual(['built-in'])
+  })
+
+  it('父子级路径完整保留：带 parentKey 的项注册为 [子key, 父key]', () => {
+    const keyBindingRef = newRef()
+    const data: EditorMenuItemType[] = [
+      {
+        key: 'parent',
+        label: '父级（二级菜单）',
+        children: [
+          {
+            key: 'execPlugin',
+            label: '执行插件',
+          },
+        ],
+        shortcutKeys: ['Control', 'KEY_E'],
+      },
+    ]
+
+    contextMenuKeybindingHandle(t as any, keyBindingRef as any, '', data)
+
+    expect(keyBindingRef.current['Control-KEY_E']).toEqual(['parent'])
+  })
+
+  it('不同组合各自注册互不影响', () => {
+    const keyBindingRef = newRef()
+    const data: EditorMenuItemType[] = [
+      {
+        key: 'built-in',
+        label: '内置菜单项',
+        shortcutKeys: ['Control', 'KEY_D'],
+      },
+      {
+        key: 'plugin-item',
+        label: '右键插件',
+        shortcutKeys: ['Control', 'KEY_G'],
+      },
+    ]
+
+    contextMenuKeybindingHandle(t as any, keyBindingRef as any, '', data)
+
+    expect(keyBindingRef.current['Control-KEY_D']).toEqual(['built-in'])
+    expect(keyBindingRef.current['Control-KEY_G']).toEqual(['plugin-item'])
+  })
+})

--- a/app/renderer/src/main/src/components/yakitUI/YakitEditor/menus/menuHelpers.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitEditor/menus/menuHelpers.tsx
@@ -43,9 +43,23 @@ export const sortMenuFun = (dataSource, sortData) => {
 }
 
 /**
+ * 注册快捷键映射；同组合已被先注册的菜单项占用时不覆盖（菜单数组前段的内置项先注册，天然优先于右键插件）
+ */
+const registerKeyBinding = (
+  keyBindingRef: React.MutableRefObject<KeyboardToFuncProps>,
+  keys: string[],
+  menuKey: string,
+  parentKey: string,
+) => {
+  const sortKey = sortKeysCombination(keys).join('-')
+  if (keyBindingRef.current[sortKey]) return
+  keyBindingRef.current[sortKey] = parentKey ? [menuKey, parentKey] : [menuKey]
+}
+
+/**
  * 菜单自定义快捷键渲染处理事件
  *
- * 为 cut/copy/paste 及带 keybindings 的菜单项添加快捷键文字展示
+ * 为 cut/copy/paste 及带 keybindings / shortcutKeys 的菜单项添加快捷键文字展示
  * @param t i18n 翻译函数
  * @param keyBindingRef 记录快捷键映射的 ref
  * @param parentKey 父级菜单 key
@@ -68,6 +82,8 @@ export const contextMenuKeybindingHandle = (
       const info = { ...item } as EditorMenuItemProps
       if (info.children && info.children.length > 0) {
         info.children = contextMenuKeybindingHandle(t, keyBindingRef, info.key, info.children)
+        // 右键插件等：父级（二级菜单）仍需展示/注册 shortcutKeys
+        applyShortcutKeysToMenuItem(info, keyBindingRef, parentKey)
       } else {
         if (info.key === 'cut' && info.label === t('YakitEditor.cut')) {
           const keysContent = convertKeyboardToUIKey([YakitKeyMod.CtrlCmd, YakitKeyBoard.KEY_X])
@@ -111,8 +127,7 @@ export const contextMenuKeybindingHandle = (
           const keysContent = convertKeyboardToUIKey(keyArr)
           // 记录自定义快捷键映射按键的回调事件
           if (keysContent) {
-            let sortKeys = sortKeysCombination(keyArr)
-            keyBindingRef.current[sortKeys.join('-')] = parentKey ? [info.key, parentKey] : [info.key]
+            registerKeyBinding(keyBindingRef, keyArr, info.key, parentKey)
           }
 
           info.label = keysContent ? (
@@ -124,9 +139,31 @@ export const contextMenuKeybindingHandle = (
             info.label
           )
         }
+
+        applyShortcutKeysToMenuItem(info, keyBindingRef, parentKey)
       }
       menus.push(info)
     }
   }
   return menus
+}
+
+/** 将原始 shortcutKeys 展示到菜单并注册到 keyBindingRef */
+const applyShortcutKeysToMenuItem = (
+  info: EditorMenuItemProps,
+  keyBindingRef: React.MutableRefObject<KeyboardToFuncProps>,
+  parentKey: string,
+) => {
+  if (!info.shortcutKeys || info.shortcutKeys.length === 0) return
+  const keysContent = convertKeyboardToUIKey(info.shortcutKeys)
+  if (!keysContent) return
+
+  registerKeyBinding(keyBindingRef, info.shortcutKeys, info.key, parentKey)
+
+  info.label = (
+    <div className={styles['editor-context-menu-keybind-wrapper']}>
+      <div className={styles['content-style']}>{info.label}</div>
+      <div className={classNames(styles['keybind-style'], 'keys-style')}>{keysContent}</div>
+    </div>
+  )
 }

--- a/app/renderer/src/main/src/components/yakitUI/YakitModal/YakitModalConfirm.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitModal/YakitModalConfirm.tsx
@@ -285,6 +285,7 @@ export const showYakitModal = (props: ShowModalV2Props) => {
                 if (yakitModalRootDiv) {
                   yakitModalRootDiv.unmount()
                 }
+                div.remove()
               })
             }}
           >
@@ -318,6 +319,7 @@ export const showYakitModal = (props: ShowModalV2Props) => {
         if (yakitModalRootDiv) {
           yakitModalRootDiv.unmount()
         }
+        div.remove()
       }, 400)
     },
   }

--- a/app/renderer/src/main/src/locales/en/manageRightClickPlugins.json
+++ b/app/renderer/src/main/src/locales/en/manageRightClickPlugins.json
@@ -15,7 +15,16 @@
     "maxAddLimit": "You can add up to {{UpperLimit}} plugins",
     "added": "Added",
     "searchPlaceholder": "Search plugin name, description or hook",
-    "noMatchedPlugins": "No matching plugins"
+    "noMatchedPlugins": "No matching plugins",
+    "resultModeLabel": "Result Display",
+    "resultModeDialog": "Pop-up",
+    "resultModeDrawer": "Right drawer",
+    "resultModeTab": "New tab",
+    "shortcutLabel": "Shortcut",
+    "setShortcutMenu": "Set shortcut",
+    "setResultModeMenu": "Set result display",
+    "pluginShortcutConflict": "Plugin conflict: {{name}} - this shortcut is already used by another plugin in the same scene",
+    "systemShortcutConflict": "System shortcut conflict: {{name}} - please rebind to avoid conflicting with existing shortcuts"
   },
   "ContextMenuExecutionHost": {
     "executeFailed": "Context menu plugin execution failed: {{error}}",
@@ -40,12 +49,16 @@
     "contextMenuSaveBeforeRun": "Right-click plugins must be saved first, then triggered from the corresponding History or HTTP packet scenario",
     "contextMenuRunFromScene": "Right-click plugins must be triggered from the corresponding History or HTTP packet scenario",
     "contextMenuSaveAndTrigger": "After saving the plugin, trigger it from the History or HTTP packet right-click menu",
+    "contextMenuSaveAndTriggerShort": "Save and trigger from the right-click menu",
+    "executeFromRightClickMenu": "Execute from right-click menu",
     "contextMenuEnableAndTrigger": "After saving and enabling the plugin in right-click plugin management, trigger it from the corresponding History or HTTP packet scenario"
   },
   "grpc": {
     "queryContextMenuActionsFailed": "Failed to query context menu plugins: {{error}}",
     "setContextMenuActionBindingFailed": "Failed to save context menu plugin binding: {{error}}",
-    "cancelContextMenuActionFailed": "Failed to cancel context menu plugin: {{error}}"
+    "cancelContextMenuActionFailed": "Failed to cancel context menu plugin: {{error}}",
+    "fetchPluginDetailFailed": "Failed to fetch local plugin details: {{error}}",
+    "fetchPluginDetailFailedNoUUID": "Plugin UUID cannot be empty"
   },
   "utils": {
     "engineVersionTooLow": "Engine version is too low, please update to a version above {{version}}"

--- a/app/renderer/src/main/src/locales/en/utils.json
+++ b/app/renderer/src/main/src/locales/en/utils.json
@@ -171,6 +171,7 @@
   },
   "ShortcutKey": {
     "editorConflict": "Editor conflict: {{name}} - this shortcut will be overridden in the editor",
+    "contextMenuPluginConflict": "Right-click plugin conflict: {{name}} - please rebind to avoid conflicting with plugin shortcuts",
     "screenshot": "Screenshot",
     "closeCurrentPage": "Close current page",
     "addSubPage": "Add sub page",

--- a/app/renderer/src/main/src/locales/en/yakitUi.json
+++ b/app/renderer/src/main/src/locales/en/yakitUi.json
@@ -369,6 +369,8 @@
     "modifyToUploadPacketPostOnly": "Modify to Upload Packet (POST parameters only)",
     "encodeResult": "Encoded Result",
     "replaceContent": "Replace Content",
+    "packetChangedDuringPluginExecution": "Packet changed during plugin execution, plugin modifications not applied",
+    "pluginModifiedPeerPacketNoFillEntry": "Plugin also modified the peer packet, but the current page has no fill-in entry",
     "manualHostConfigTip": "To manually specify the target address or perform Host collision, please configure \"Advanced Settings - Real Host\"",
     "HTTPPacketYakitEditor": {
       "copyCurlCommand": "Copy cURL Command",

--- a/app/renderer/src/main/src/locales/zh-TW/manageRightClickPlugins.json
+++ b/app/renderer/src/main/src/locales/zh-TW/manageRightClickPlugins.json
@@ -15,7 +15,16 @@
     "maxAddLimit": "最多新增 {{UpperLimit}} 個外掛",
     "added": "已新增",
     "searchPlaceholder": "搜尋外掛名稱、說明或 Hook",
-    "noMatchedPlugins": "沒有匹配的外掛"
+    "noMatchedPlugins": "沒有匹配的外掛",
+    "resultModeLabel": "結果展示",
+    "resultModeDialog": "彈窗",
+    "resultModeDrawer": "右側抽屜",
+    "resultModeTab": "新頁簽",
+    "shortcutLabel": "快捷鍵",
+    "setShortcutMenu": "設定快捷鍵",
+    "setResultModeMenu": "設定結果展示",
+    "pluginShortcutConflict": "右鍵外掛衝突：{{name}} - 此快捷鍵已被同場景其他外掛佔用",
+    "systemShortcutConflict": "系統快捷鍵衝突：{{name}} - 請重新設定，避免與既有快捷鍵衝突"
   },
   "ContextMenuExecutionHost": {
     "executeFailed": "右鍵外掛執行失敗: {{error}}",
@@ -40,12 +49,16 @@
     "contextMenuSaveBeforeRun": "右鍵外掛需要儲存後，從對應的 History 或 HTTP 資料包場景觸發",
     "contextMenuRunFromScene": "右鍵外掛需要從對應的 History 或 HTTP 資料包場景觸發",
     "contextMenuSaveAndTrigger": "儲存外掛後，從對應的 History 或 HTTP 資料包右鍵選單觸發執行",
+    "contextMenuSaveAndTriggerShort": "儲存後從右鍵選單觸發執行",
+    "executeFromRightClickMenu": "從右鍵選單執行",
     "contextMenuEnableAndTrigger": "儲存並在右鍵外掛管理中啟用後，從對應的 History 或 HTTP 資料包場景觸發執行"
   },
   "grpc": {
     "queryContextMenuActionsFailed": "查詢右鍵外掛失敗: {{error}}",
     "setContextMenuActionBindingFailed": "儲存右鍵外掛配置失敗: {{error}}",
-    "cancelContextMenuActionFailed": "取消右鍵外掛失敗: {{error}}"
+    "cancelContextMenuActionFailed": "取消右鍵外掛失敗: {{error}}",
+    "fetchPluginDetailFailed": "查詢本地外掛詳情失敗: {{error}}",
+    "fetchPluginDetailFailedNoUUID": "查詢外掛的UUID不能為空"
   },
   "utils": {
     "engineVersionTooLow": "引擎版本過低，請更新到高於 {{version}} 的版本"

--- a/app/renderer/src/main/src/locales/zh-TW/utils.json
+++ b/app/renderer/src/main/src/locales/zh-TW/utils.json
@@ -171,6 +171,7 @@
   },
   "ShortcutKey": {
     "editorConflict": "編輯器衝突：{{name}} - 此快捷鍵設定將會在編輯器中被覆蓋",
+    "contextMenuPluginConflict": "右鍵外掛衝突：{{name}} - 請重新設定，避免與右鍵外掛快捷鍵衝突",
     "screenshot": "截圖",
     "closeCurrentPage": "關閉當前頁面",
     "addSubPage": "新增二級頁面",

--- a/app/renderer/src/main/src/locales/zh-TW/yakitUi.json
+++ b/app/renderer/src/main/src/locales/zh-TW/yakitUi.json
@@ -369,6 +369,8 @@
     "modifyToUploadPacketPostOnly": "修改為上傳資料包（僅POST引數）",
     "encodeResult": "編碼結果",
     "replaceContent": "替換內容",
+    "packetChangedDuringPluginExecution": "資料包在外掛執行期間已變化，未應用外掛修改",
+    "pluginModifiedPeerPacketNoFillEntry": "外掛同時修改了另一側資料包，但當前頁面未提供回填入口",
     "manualHostConfigTip": "如需手動指定目標地址或 Host 碰撞，請配置\"高階配置-真實Host\"",
     "HTTPPacketYakitEditor": {
       "copyCurlCommand": "複製 curl 命令",

--- a/app/renderer/src/main/src/locales/zh/manageRightClickPlugins.json
+++ b/app/renderer/src/main/src/locales/zh/manageRightClickPlugins.json
@@ -15,7 +15,16 @@
     "maxAddLimit": "最多添加 {{UpperLimit}} 个插件",
     "added": "已添加",
     "searchPlaceholder": "搜索插件名称、说明或 Hook",
-    "noMatchedPlugins": "没有匹配的插件"
+    "noMatchedPlugins": "没有匹配的插件",
+    "resultModeLabel": "结果展示",
+    "resultModeDialog": "弹窗",
+    "resultModeDrawer": "右侧抽屉",
+    "resultModeTab": "新页签",
+    "shortcutLabel": "快捷键",
+    "setShortcutMenu": "设置快捷键",
+    "setResultModeMenu": "设置结果展示",
+    "pluginShortcutConflict": "右键插件冲突：{{name}} - 此快捷键已被同场景其他插件占用",
+    "systemShortcutConflict": "系统快捷键冲突：{{name}} - 请重新设置，避免与已有快捷键冲突"
   },
   "ContextMenuExecutionHost": {
     "executeFailed": "右键插件执行失败: {{error}}",
@@ -40,12 +49,16 @@
     "contextMenuSaveBeforeRun": "右键插件需要保存后，从对应的 History 或 HTTP 数据包场景触发",
     "contextMenuRunFromScene": "右键插件需要从对应的 History 或 HTTP 数据包场景触发",
     "contextMenuSaveAndTrigger": "保存插件后，从对应的 History 或 HTTP 数据包右键菜单触发执行",
+    "contextMenuSaveAndTriggerShort": "保存后从右键菜单执行",
+    "executeFromRightClickMenu": "从右键菜单执行",
     "contextMenuEnableAndTrigger": "保存并在右键插件管理中启用后，从对应的 History 或 HTTP 数据包场景触发执行"
   },
   "grpc": {
     "queryContextMenuActionsFailed": "查询右键插件失败: {{error}}",
     "setContextMenuActionBindingFailed": "保存右键插件配置失败: {{error}}",
-    "cancelContextMenuActionFailed": "取消右键插件失败: {{error}}"
+    "cancelContextMenuActionFailed": "取消右键插件失败: {{error}}",
+    "fetchPluginDetailFailed": "查询本地插件详情失败: {{error}}",
+    "fetchPluginDetailFailedNoUUID": "查询插件的UUID不能为空"
   },
   "utils": {
     "engineVersionTooLow": "引擎版本过低，请更新到高于 {{version}} 的版本"

--- a/app/renderer/src/main/src/locales/zh/utils.json
+++ b/app/renderer/src/main/src/locales/zh/utils.json
@@ -171,6 +171,7 @@
   },
   "ShortcutKey": {
     "editorConflict": "编辑器冲突：{{name}} - 此快捷键设置将会在编辑器中被覆盖",
+    "contextMenuPluginConflict": "右键插件冲突：{{name}} - 请重新设置，避免与右键插件快捷键冲突",
     "screenshot": "截图",
     "closeCurrentPage": "关闭当前页面",
     "addSubPage": "新增二级页面",

--- a/app/renderer/src/main/src/locales/zh/yakitUi.json
+++ b/app/renderer/src/main/src/locales/zh/yakitUi.json
@@ -369,6 +369,8 @@
     "modifyToUploadPacketPostOnly": "修改为上传数据包（仅POST参数）",
     "encodeResult": "编码结果",
     "replaceContent": "替换内容",
+    "packetChangedDuringPluginExecution": "数据包在插件执行期间已变化，未应用插件修改",
+    "pluginModifiedPeerPacketNoFillEntry": "插件同时修改了另一侧数据包，但当前页面未提供回填入口",
     "manualHostConfigTip": "如需手动指定目标地址或 Host 碰撞，请配置\"高级配置-真实Host\"",
     "HTTPPacketYakitEditor": {
       "copyCurlCommand": "复制 curl 命令",

--- a/app/renderer/src/main/src/pages/customizeMenu/CustomizeMenu.module.scss
+++ b/app/renderer/src/main/src/pages/customizeMenu/CustomizeMenu.module.scss
@@ -431,15 +431,15 @@
         }
 
         .second-menu-edit-icon {
-          width: 16px;
-          height: 16px;
+          width: 14px;
+          height: 14px;
 
           svg {
-            width: 16px;
-            height: 16px;
+            width: 14px;
+            height: 14px;
             margin-right: 0;
             cursor: pointer;
-            color: var(--Colors-Use-Neutral-Text-1-Title);
+            color: var(--Colors-Use-Neutral-Disable);
 
             &:hover {
               color: var(--Colors-Use-Main-Primary);
@@ -690,6 +690,7 @@
   :global {
     .ant-popover-inner {
       padding: 4px;
+
       .ant-popover-inner-content {
         height: 40vh;
       }

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.module.scss
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.module.scss
@@ -613,6 +613,9 @@
     .ant-modal-wrap {
       position: absolute;
     }
+    .ant-drawer {
+      position: absolute;
+    }
   }
 }
 

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/ContextMenuActionExecution.module.scss
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/ContextMenuActionExecution.module.scss
@@ -3,6 +3,12 @@
   background: var(--Colors-Use-Basic-Background);
 }
 
+.execution[data-mode='dialog'] {
+  height: 70vh;
+  overflow-y: overlay;
+  background: var(--Colors-Use-Basic-Background);
+}
+
 // 头部右侧操作区（执行/停止 + 进度条 + 刷新 + 编辑），对齐 LocalPluginExecuteDetailHeard 的布局
 .plugin-head-executing {
   display: flex;

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/ContextMenuActionExecution.tsx
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/ContextMenuActionExecution.tsx
@@ -9,9 +9,7 @@ import { YakitEmpty } from '@/components/yakitUI/YakitEmpty/YakitEmpty'
 import { YakitSpin } from '@/components/yakitUI/YakitSpin/YakitSpin'
 import PluginTabs from '@/components/businessUI/PluginTabs/PluginTabs'
 import useHoldGRPCStream from '@/hook/useHoldGRPCStream/useHoldGRPCStream'
-import { YakitRoute } from '@/enums/yakitRoute'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
-import { usePageInfo } from '@/store/pageInfo'
 import type { YakExecutorParam } from '@/pages/invoker/YakExecutorParams'
 import type { YakScript } from '@/pages/invoker/schema'
 import { PluginDetailHeader } from '@/pages/plugins/baseTemplate'
@@ -32,13 +30,13 @@ import type { YakParamProps } from '@/pages/plugins/pluginsType'
 import { ParamsToGroupByGroupName, getValueByType, getYakExecutorParam } from '@/pages/plugins/editDetails/utils'
 import type { ModifyPluginCallback } from '@/pages/pluginEditor/pluginEditor/PluginEditor'
 import { ModifyYakitPlugin } from '@/pages/pluginEditor/modifyYakitPlugin/ModifyYakitPlugin'
-import { grpcFetchLocalPluginDetail } from '@/pages/pluginHub/utils/grpc'
 import { randomString } from '@/utils/randomUtil'
 import { yakitNotify } from '@/utils/notification'
-import { cancelContextMenuAction, executeContextMenuAction } from './api'
+import { cancelContextMenuAction, executeContextMenuAction, grpcFetchLocalPluginDetailByUUID } from './api'
 import { getContextMenuExecution, removeContextMenuExecution, updateContextMenuExecution } from './executionRegistry'
-import type { ContextMenuActionEvent, ContextMenuPacketActionResult } from './types'
+import { ContextMenuResultMode, type ContextMenuActionEvent, type ContextMenuPacketActionResult } from './types'
 import { YakitAlert } from '@/components/yakitUI/YakitAlert/YakitAlert'
+import { getMainOperatorPageBodyContainer } from '@/utils/getMainOperatorPageBodyContainer'
 import styles from './ContextMenuActionExecution.module.scss'
 
 const { ipcRenderer } = window.require('electron')
@@ -60,15 +58,10 @@ const ExecutionStatus = {
   Expired: 'Expired',
 } as const
 
-export const ContextMenuActionExecution: React.FC<{ pageId: string; mode: 'dialog' | 'drawer' | 'tab' }> = React.memo(
-  ({ pageId, mode }) => {
+export const ContextMenuActionExecution: React.FC<{ executionID: string; mode: ContextMenuResultMode }> = React.memo(
+  ({ executionID, mode }) => {
     const { t, i18nRefresh } = useI18nNamespaces(['manageRightClickPlugins', 'yakitUi'])
-    // #region 执行上下文：从 pageInfo 缓存按 pageId 读取 executionID
-    const pageInfo = usePageInfo((s) => {
-      const currentItem = s.pages.get(YakitRoute.ContextMenuResult)?.pageList?.find((item) => item.pageId === pageId)
-      return currentItem?.pageParamsInfo?.contextMenuResultPageInfo
-    })
-    const executionID = pageInfo?.executionID || ''
+    // #region 执行上下文：直接持有 executionID（Tab 路由壳层 / 弹窗抽屉宿主均以此传入）
     /** registry 刷新版本：插件编辑/刷新后回写 registry 并自增，驱动 execution 重新读取与表单重建 */
     const [registryVersion, setRegistryVersion] = useState(0)
     const execution = getContextMenuExecution(executionID)
@@ -141,8 +134,7 @@ export const ContextMenuActionExecution: React.FC<{ pageId: string; mode: 'dialo
     const [plugin, setPlugin] = useState<YakScript | null>(null)
     const [pluginLoading, setPluginLoading] = useState(false)
     const [editHint, setEditHint] = useState(false)
-    /** 页面根容器：作为编辑抽屉的 getContainer，抽屉高度跟随容器*/
-    const pageWrapperRef = useRef<HTMLDivElement>(null)
+    const pageWrapperRef = useRef<HTMLElement>()
     // #endregion
 
     // #region Tab 切换
@@ -220,9 +212,9 @@ export const ContextMenuActionExecution: React.FC<{ pageId: string; mode: 'dialo
 
     // #region 插件详情加载与编辑
     const loadPlugin = useMemoizedFn(() => {
-      if (!execution?.action.PluginName) return
+      if (!execution?.action.PluginUUID) return
       setPluginLoading(true)
-      grpcFetchLocalPluginDetail({ Name: execution.action.PluginName, UUID: execution.action.PluginUUID }, true)
+      grpcFetchLocalPluginDetailByUUID({ UUID: execution.action.PluginUUID }, true)
         .then((res) => {
           setPlugin(res)
           if (execution.action.PluginUUID !== res.UUID) return
@@ -253,6 +245,7 @@ export const ContextMenuActionExecution: React.FC<{ pageId: string; mode: 'dialo
       e.stopPropagation()
       if (!plugin) return
       if (editHint) return
+      pageWrapperRef.current = getMainOperatorPageBodyContainer()
       setEditHint(true)
     })
 
@@ -372,19 +365,19 @@ export const ContextMenuActionExecution: React.FC<{ pageId: string; mode: 'dialo
     // #region 渲染物料：头部信息与操作按钮
     const headerProps = useMemo(
       () => ({
-        pluginName: execution?.action.PluginName || '',
-        help: execution?.action.Help || '',
+        pluginName: plugin?.ScriptName || '',
+        help: plugin?.Help || '',
         tags: plugin?.Tags || '',
-        img: plugin?.HeadImg || execution?.action.HeadImg || '',
+        img: plugin?.HeadImg || '',
         user: plugin?.Author || '-',
-        pluginId: execution?.action.PluginUUID || '',
+        pluginId: plugin?.UUID || '',
         updated_at: plugin?.UpdatedAt || 0,
         prImgs: (plugin?.CollaboratorInfo || []).map((ele) => ({
           headImg: ele.HeadImg,
           userName: ele.UserName,
         })),
       }),
-      [execution?.action, plugin],
+      [plugin],
     )
 
     /** 头部右侧的刷新/编辑按钮（执行/停止按钮在 extraNode 内单独拼装） */
@@ -414,11 +407,7 @@ export const ContextMenuActionExecution: React.FC<{ pageId: string; mode: 'dialo
     }
 
     return (
-      <div
-        ref={pageWrapperRef}
-        className={classNames(styles['execution'], detailStyles['details-content-wrapper'])}
-        data-mode={mode}
-      >
+      <div className={classNames(styles['execution'], detailStyles['details-content-wrapper'])} data-mode={mode}>
         <PluginTabs
           activeKey={activeTab}
           tabPosition="right"
@@ -509,7 +498,10 @@ export const ContextMenuActionExecution: React.FC<{ pageId: string; mode: 'dialo
                       {extraParamsGroup.length > 0 && (
                         <YakitButton
                           type="text"
-                          onClick={() => setExtraParamsVisible(true)}
+                          onClick={() => {
+                            pageWrapperRef.current = getMainOperatorPageBodyContainer()
+                            setExtraParamsVisible(true)
+                          }}
                           disabled={loading}
                           size="large"
                         >
@@ -604,6 +596,7 @@ export const ContextMenuActionExecution: React.FC<{ pageId: string; mode: 'dialo
           }}
           jsonSchemaListRef={jsonSchemaListRef}
           jsonSchemaInitial={jsonSchemaInitial}
+          getContainer={mode === ContextMenuResultMode.Tab ? undefined : pageWrapperRef.current || undefined}
         />
       </div>
     )

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/ContextMenuExecutionHost.tsx
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/ContextMenuExecutionHost.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useMemoizedFn } from 'ahooks'
+import { showYakitDrawer } from '@/components/yakitUI/YakitDrawer/YakitDrawer'
+import { showYakitModal } from '@/components/yakitUI/YakitModal/YakitModalConfirm'
 import { PluginHasParamsModal } from '@/components/pluginHasParamsDrawer/PluginHasParamsDrawer'
 import { YakitRoute } from '@/enums/yakitRoute'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
@@ -13,8 +15,10 @@ import { getValueByType, ParamsToGroupByGroupName } from '@/pages/plugins/editDe
 import emiter from '@/utils/eventBus/eventBus'
 import { getRemoteValue, setRemoteValue } from '@/utils/kv'
 import { yakitNotify } from '@/utils/notification'
+import { ContextMenuActionExecution } from './ContextMenuActionExecution'
 import { registerContextMenuExecution } from './executionRegistry'
-import type { RunContextMenuActionOptions } from './types'
+import { ContextMenuResultMode, type RunContextMenuActionOptions } from './types'
+import { getMainOperatorPageBodyContainer } from '@/utils/getMainOperatorPageBodyContainer'
 
 interface ParamsModalValue {
   /** 表单初始值（key = 参数 Field，value = 默认值或缓存值） */
@@ -96,23 +100,61 @@ export const ContextMenuExecutionHost: React.FC = React.memo(() => {
   const [paramsModalValue, setParamsModalValue] = useState<ParamsModalValue>(emptyParamsModalValue)
 
   /**
-   * 启动执行：注册到 executionRegistry 拿 executionID，然后新开「右键插件结果」Tab
-   * 本期统一以新开 Tab 展示执行结果（含 Auto/Dialog/Drawer，均降级为 Tab）
-   * TODO: dialog
-   * TODO: drawer
+   * 启动执行：注册到 executionRegistry 拿 executionID，按结果展示方式分发载体
+   * - tab：新开「右键插件结果」Tab
+   * - drawer：右侧抽屉展示
+   * - dialog：弹窗展示
+   * 组件卸载（关 Tab / 关弹窗 / 关抽屉）时自清理：取消执行 + 移除注册表
    */
   const launch = useMemoizedFn((options: RunContextMenuActionOptions, params: YakExecutorParam[] = []) => {
     const executionID = registerContextMenuExecution({ ...options, params })
-    emiter.emit(
-      'openPage',
-      JSON.stringify({
-        route: YakitRoute.ContextMenuResult,
-        params: {
-          executionID,
-          pluginName: options.action.PluginName,
-        },
-      }),
-    )
+    const title = `${options.action.PluginName} · ${options.action.HookName}`
+    // auto 与 tab 同为开 Tab 展示，归一后传入组件
+    const mode =
+      options.action.ResultMode === ContextMenuResultMode.Auto ? ContextMenuResultMode.Tab : options.action.ResultMode
+    const content = <ContextMenuActionExecution executionID={executionID} mode={mode} />
+    const getContainer = getMainOperatorPageBodyContainer()
+
+    switch (options.action.ResultMode) {
+      case ContextMenuResultMode.Drawer:
+        const m1 = showYakitDrawer({
+          title,
+          width: '90%',
+          placement: 'right',
+          content,
+          bodyStyle: { padding: 0 },
+          getContainer,
+          onCancel: () => {
+            m1.destroy()
+          },
+        })
+        break
+      case ContextMenuResultMode.Dialog:
+        const m2 = showYakitModal({
+          title,
+          width: '90%',
+          footer: null,
+          maskClosable: false,
+          content,
+          getContainer,
+          onCancel: () => {
+            m2.destroy()
+          },
+        })
+        break
+      default:
+        emiter.emit(
+          'openPage',
+          JSON.stringify({
+            route: YakitRoute.ContextMenuResult,
+            params: {
+              executionID,
+              pluginName: options.action.PluginName,
+            },
+          }),
+        )
+        break
+    }
   })
 
   const loadCachedParams = async (options: RunContextMenuActionOptions): Promise<YakExecutorParam[]> => {

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/ContextMenuExecutionHost.tsx
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/ContextMenuExecutionHost.tsx
@@ -105,6 +105,11 @@ export const ContextMenuExecutionHost: React.FC = React.memo(() => {
     activeResultRef.current = undefined
     active?.destroy()
   })
+  useEffect(() => {
+    return () => {
+      closeActiveResult()
+    }
+  }, [closeActiveResult])
 
   /**
    * 启动执行：注册到 executionRegistry 拿 executionID，按结果展示方式分发载体

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/ContextMenuExecutionHost.tsx
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/ContextMenuExecutionHost.tsx
@@ -98,12 +98,20 @@ export const ContextMenuExecutionHost: React.FC = React.memo(() => {
   const loadingRef = useRef<boolean>(false)
   const [paramsVisible, setParamsVisible] = useState(false)
   const [paramsModalValue, setParamsModalValue] = useState<ParamsModalValue>(emptyParamsModalValue)
+  /** 当前打开的结果弹窗/抽屉句柄：新开结果窗口前先销毁旧的，避免快捷键连按堆叠多个执行 */
+  const activeResultRef = useRef<{ destroy: () => void }>()
+  const closeActiveResult = useMemoizedFn(() => {
+    const active = activeResultRef.current
+    activeResultRef.current = undefined
+    active?.destroy()
+  })
 
   /**
    * 启动执行：注册到 executionRegistry 拿 executionID，按结果展示方式分发载体
    * - tab：新开「右键插件结果」Tab
    * - drawer：右侧抽屉展示
    * - dialog：弹窗展示
+   * 弹窗/抽屉同一时刻只保留一个，重复触发时销毁旧窗口再开新的
    * 组件卸载（关 Tab / 关弹窗 / 关抽屉）时自清理：取消执行 + 移除注册表
    */
   const launch = useMemoizedFn((options: RunContextMenuActionOptions, params: YakExecutorParam[] = []) => {
@@ -116,7 +124,8 @@ export const ContextMenuExecutionHost: React.FC = React.memo(() => {
     const getContainer = getMainOperatorPageBodyContainer()
 
     switch (options.action.ResultMode) {
-      case ContextMenuResultMode.Drawer:
+      case ContextMenuResultMode.Drawer: {
+        closeActiveResult()
         const m1 = showYakitDrawer({
           title,
           width: '90%',
@@ -125,11 +134,15 @@ export const ContextMenuExecutionHost: React.FC = React.memo(() => {
           bodyStyle: { padding: 0 },
           getContainer,
           onCancel: () => {
+            if (activeResultRef.current === m1) activeResultRef.current = undefined
             m1.destroy()
           },
         })
+        activeResultRef.current = m1
         break
-      case ContextMenuResultMode.Dialog:
+      }
+      case ContextMenuResultMode.Dialog: {
+        closeActiveResult()
         const m2 = showYakitModal({
           title,
           width: '90%',
@@ -138,10 +151,13 @@ export const ContextMenuExecutionHost: React.FC = React.memo(() => {
           content,
           getContainer,
           onCancel: () => {
+            if (activeResultRef.current === m2) activeResultRef.current = undefined
             m2.destroy()
           },
         })
+        activeResultRef.current = m2
         break
+      }
       default:
         emiter.emit(
           'openPage',

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.module.scss
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.module.scss
@@ -252,13 +252,36 @@
         min-width: 0;
       }
 
+      .selected-item-name-shortcut {
+        color: var(--Colors-Use-Neutral-Text-3-Secondary);
+        font-size: 12px;
+        line-height: 16px;
+        white-space: nowrap;
+        margin-left: auto;
+        margin-right: 8px;
+        order: 3;
+      }
+
       .selected-item-name-actions {
         display: flex;
         align-items: center;
         flex-shrink: 0;
+        order: 2;
 
         svg {
           margin-right: 0;
+        }
+
+        button:hover {
+          svg {
+            color: var(--Colors-Use-Main-Primary);
+          }
+        }
+      }
+
+      .setting-icon-active {
+        svg {
+          color: var(--Colors-Use-Main-Primary);
         }
       }
 
@@ -266,10 +289,6 @@
         font-size: 11px;
         color: var(--Colors-Use-Neutral-Disable);
         line-height: 16px;
-      }
-
-      .setting-icon {
-        color: var(--Colors-Use-Neutral-Text-1-Title);
       }
 
       .remove-icon {
@@ -469,12 +488,19 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+
+  .setting-menu-shortcut-keys {
+    color: var(--Colors-Use-Neutral-Text-3-Secondary);
+    font-size: 12px;
+    white-space: nowrap;
+  }
 }
 
-.setting-menu-shortcut-keys {
-  color: var(--Colors-Use-Neutral-Disable);
-  font-size: 12px;
-  white-space: nowrap;
+:global(.ant-dropdown-menu-item-active),
+:global(.ant-dropdown-menu-item-selected) {
+  .setting-menu-shortcut-item .setting-menu-shortcut-keys {
+    color: var(--Colors-Use-Main-On-Primary);
+  }
 }
 
 .setting-menu-result-item {
@@ -502,6 +528,12 @@
 
     .right {
       width: 350px;
+    }
+
+    // 小屏空间不足时隐藏插件快捷键展示
+    .selected-item-name-shortcut,
+    .setting-menu-shortcut-keys {
+      display: none;
     }
   }
 }

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.module.scss
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.module.scss
@@ -187,17 +187,22 @@
       border: 1px solid var(--Colors-Use-Neutral-Border);
       border-radius: 4px;
       display: flex;
-      align-items: center;
+      flex-direction: column;
       flex: 1;
       width: calc(100% - 40px);
 
-      svg {
-        margin-right: 8px;
-        color: var(--Colors-Use-Neutral-Disable);
-      }
+      .selected-item-main {
+        display: flex;
+        align-items: center;
 
-      .drag-icon-active {
-        color: var(--Colors-Use-Main-Primary);
+        svg {
+          margin-right: 8px;
+          color: var(--Colors-Use-Neutral-Disable);
+        }
+
+        .drag-icon-active {
+          color: var(--Colors-Use-Main-Primary);
+        }
       }
 
       .plugin-avatar {
@@ -224,7 +229,16 @@
       }
 
       .selected-item-body {
-        width: calc(100% - 70px);
+        flex: 1;
+        min-width: 0;
+        width: auto;
+      }
+
+      .selected-item-name-row {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        min-width: 0;
       }
 
       .selected-item-name {
@@ -235,12 +249,27 @@
         overflow: hidden;
         word-break: break-all;
         line-height: 16px;
+        min-width: 0;
+      }
+
+      .selected-item-name-actions {
+        display: flex;
+        align-items: center;
+        flex-shrink: 0;
+
+        svg {
+          margin-right: 0;
+        }
       }
 
       .selected-item-desc {
         font-size: 11px;
         color: var(--Colors-Use-Neutral-Disable);
         line-height: 16px;
+      }
+
+      .setting-icon {
+        color: var(--Colors-Use-Neutral-Text-1-Title);
       }
 
       .remove-icon {
@@ -376,6 +405,89 @@
       opacity: 0.5;
     }
   }
+}
+
+.set-shortcut-key-wrapper {
+  display: flex;
+  flex-direction: column;
+
+  .title {
+    color: var(--Colors-Use-Neutral-Text-3-Secondary);
+    font-size: 14px;
+    line-height: 24px;
+  }
+
+  .input {
+    margin-top: 10px;
+    width: 100%;
+    height: 36px;
+    padding: 6px 10px;
+    color: var(--Colors-Use-Neutral-Text-1-Title);
+    border: 1px solid var(--Colors-Use-Main-Border);
+    border-radius: 4px;
+    text-align: center;
+  }
+
+  .empty::after {
+    display: inline-block;
+    content: '';
+    width: 2px;
+    height: 100%;
+    background-color: var(--Colors-Use-Main-Primary);
+    animation: blink 1s infinite;
+  }
+
+  @keyframes blink {
+    0%,
+    100% {
+      opacity: 1;
+    }
+
+    50% {
+      opacity: 0;
+    }
+  }
+
+  .keys-ui {
+    margin-top: 16px;
+    color: var(--Colors-Use-Main-Primary);
+    font-size: 14px;
+    line-height: 24px;
+    height: 24px;
+    text-align: center;
+
+    .warn {
+      font-size: 12px;
+      color: var(--Colors-Use-Error-Primary);
+    }
+  }
+}
+
+.setting-menu-shortcut-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.setting-menu-shortcut-keys {
+  color: var(--Colors-Use-Neutral-Disable);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.setting-menu-result-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.setting-menu-check {
+  color: currentColor;
+  font-size: 12px;
 }
 
 @media screen and (max-width: 900px) {

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.module.scss
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.module.scss
@@ -488,19 +488,6 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-
-  .setting-menu-shortcut-keys {
-    color: var(--Colors-Use-Neutral-Text-3-Secondary);
-    font-size: 12px;
-    white-space: nowrap;
-  }
-}
-
-:global(.ant-dropdown-menu-item-active),
-:global(.ant-dropdown-menu-item-selected) {
-  .setting-menu-shortcut-item .setting-menu-shortcut-keys {
-    color: var(--Colors-Use-Main-On-Primary);
-  }
 }
 
 .setting-menu-result-item {
@@ -531,8 +518,7 @@
     }
 
     // 小屏空间不足时隐藏插件快捷键展示
-    .selected-item-name-shortcut,
-    .setting-menu-shortcut-keys {
+    .selected-item-name-shortcut {
       display: none;
     }
   }

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.tsx
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.tsx
@@ -18,15 +18,32 @@ import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
 import { YakitInput } from '@/components/yakitUI/YakitInput/YakitInput'
 import { YakitPopconfirm } from '@/components/yakitUI/YakitPopconfirm/YakitPopconfirm'
 import { YakitEmpty } from '@/components/yakitUI/YakitEmpty/YakitEmpty'
+import { YakitModal } from '@/components/yakitUI/YakitModal/YakitModal'
+import { YakitDropdownMenu } from '@/components/yakitUI/YakitDropdownMenu/YakitDropdownMenu'
+import type { YakitMenuItemProps, YakitMenuItemType } from '@/components/yakitUI/YakitMenu/YakitMenu'
 import { CloudDownloadIcon, DragSortIcon } from '@/assets/newIcon'
-import { OutlineBanIcon, OutlinePhotographIcon, OutlineRefreshIcon, OutlineXIcon } from '@/assets/icon/outline'
+import {
+  OutlineBanIcon,
+  OutlineCogIcon,
+  OutlinePencilaltIcon,
+  OutlinePhotographIcon,
+  OutlineRefreshIcon,
+  OutlineXIcon,
+} from '@/assets/icon/outline'
 import { PrivateOutlineDefaultPluginIcon } from '@/routes/privateIcon'
-import { YakitGetOnlinePlugin } from '@/pages/mitm/MITMServerHijacking/MITMPluginLocalList'
 import emiter from '@/utils/eventBus/eventBus'
+import { convertKeyboardToUIKey, setIsActiveShortcutKeyPage } from '@/utils/globalShortcutKey/utils'
+import { YakitKeyBoard } from '@/utils/globalShortcutKey/keyboard'
+import type { YakScript } from '@/pages/invoker/schema'
+import type { ModifyPluginCallback } from '@/pages/pluginEditor/pluginEditor/PluginEditor'
+import { ModifyYakitPlugin } from '@/pages/pluginEditor/modifyYakitPlugin/ModifyYakitPlugin'
+import { getMainOperatorPageBodyContainer } from '@/utils/getMainOperatorPageBodyContainer'
 import { DROP_AVAILABLE, DROP_SELECTED, getGroupTabByKey, GroupTabList, UpperLimit } from './constants'
 import { fetchSceneActions } from './utils'
-import { grpcSetContextMenuActionBinding } from './api'
+import { grpcSetContextMenuActionBinding, grpcFetchLocalPluginDetailByUUID } from './api'
 import type { ContextMenuAction } from './types'
+import { ContextMenuResultMode, LEGACY_CONTEXT_MENU_PLUGIN_TYPE, type ContextMenuScene } from './types'
+import { checkContextMenuShortcutConflict, parseContextMenuShortcut, serializeContextMenuShortcut } from './shortcut'
 import styles from './ManageRightClickPlugins.module.scss'
 
 /** 拖拽排序：将 startIndex 项移动到 endIndex */
@@ -52,6 +69,8 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
   // #region 当前选中的分组 tab
   const [currentTabKey, setCurrentTabKey] = useState<string>(() => pageInfo?.tab || GroupTabList[0].key)
   const currentTabKeyRef = useLatest(currentTabKey)
+  /** 当前打开设置菜单的插件（保证同时只展开一个） */
+  const [openSettingKey, setOpenSettingKey] = useState<string>('')
   useEffect(() => {
     if (pageInfo?.tab) {
       setCurrentTabKey(pageInfo.tab)
@@ -59,6 +78,7 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
   }, [pageInfo?.tab])
   const onSelectTab = useMemoizedFn((key: string) => {
     setCurrentTabKey(key)
+    setOpenSettingKey('')
   })
   const currentGroupLabel = useMemo(() => {
     const labelKey = getGroupTabByKey(currentTabKey)?.label
@@ -96,8 +116,6 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
   }, [availableActions, keyword])
   /** 拖拽目标区域标识（用于高亮当前拖拽落点） */
   const [destinationDrag, setDestinationDrag] = useState<string>(DROP_SELECTED)
-  /** 空态「获取插件」下载弹窗 */
-  const [getPluginVisible, setGetPluginVisible] = useState<boolean>(false)
   // #endregion
 
   // #region 数据刷新
@@ -158,7 +176,7 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
   // #endregion
 
   // #region 已选插件的增删改操作
-  /** 绑定保存串行锁：多步保存（拖拽重排 / 插入后移）进行中时忽略新的增删拖拽，避免交叉写入导致服务端顺序错乱 */
+  /** 绑定保存串行锁：任何绑定保存请求在途期间忽略新的增删/拖拽/配置修改，避免交叉写入导致服务端顺序错乱或旧字段覆盖 */
   const bindingSavingRef = useRef(false)
   /**
    * 添加动作到已选列表（按钮点击 / 右侧拖入）
@@ -201,19 +219,69 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
     addActionToSelected(action)
   })
 
+  /** 切换执行结果展示方式（codec 兼容类型沿用旧 CODEC 行为，不支持切换） */
+  const onChangeResultMode = useMemoizedFn(async (action: ContextMenuAction, mode: ContextMenuResultMode) => {
+    if (bindingSavingRef.current) return
+    if (action.PluginType === LEGACY_CONTEXT_MENU_PLUGIN_TYPE) return
+    const tabKey = currentTabKeyRef.current
+    bindingSavingRef.current = true
+    try {
+      const ok = await saveBinding({ ...action, ResultMode: mode }, true, action.Sort)
+      if (!ok) {
+        refreshSelectedPlugins()
+        return
+      }
+      updateActionsByTab((prev) => ({
+        ...prev,
+        [tabKey]: (prev[tabKey] || []).map((i) =>
+          i.ActionID === action.ActionID && i.PluginUUID === action.PluginUUID ? { ...i, ResultMode: mode } : i,
+        ),
+      }))
+    } finally {
+      bindingSavingRef.current = false
+    }
+  })
+
+  /** 保存插件快捷键 */
+  const onChangeShortcut = useMemoizedFn(async (action: ContextMenuAction, shortcut: string) => {
+    if (bindingSavingRef.current) return
+    const tabKey = currentTabKeyRef.current
+    bindingSavingRef.current = true
+    try {
+      const ok = await saveBinding(action, true, action.Sort, shortcut)
+      if (!ok) {
+        refreshSelectedPlugins()
+        return
+      }
+      updateActionsByTab((prev) => ({
+        ...prev,
+        [tabKey]: (prev[tabKey] || []).map((i) =>
+          i.ActionID === action.ActionID && i.PluginUUID === action.PluginUUID ? { ...i, Shortcut: shortcut } : i,
+        ),
+      }))
+    } finally {
+      bindingSavingRef.current = false
+    }
+  })
+
   /** 移除插件（核心插件锁定不可移除） */
   const onRemovePlugin = useMemoizedFn(async (action: ContextMenuAction) => {
     if (bindingSavingRef.current) return
     if (action.Locked || action.IsCorePlugin) return
     const tabKey = currentTabKeyRef.current
-    const ok = await saveBinding(action, false, action.Sort, '')
-    if (!ok) return
-    updateActionsByTab((prev) => ({
-      ...prev,
-      [tabKey]: (prev[tabKey] || []).filter(
-        (i) => !(i.ActionID === action.ActionID && i.PluginUUID === action.PluginUUID),
-      ),
-    }))
+    bindingSavingRef.current = true
+    try {
+      const ok = await saveBinding(action, false, action.Sort, '')
+      if (!ok) return
+      updateActionsByTab((prev) => ({
+        ...prev,
+        [tabKey]: (prev[tabKey] || []).filter(
+          (i) => !(i.ActionID === action.ActionID && i.PluginUUID === action.PluginUUID),
+        ),
+      }))
+    } finally {
+      bindingSavingRef.current = false
+    }
   })
 
   /** 清空当前 tab 已选插件（核心插件保留） */
@@ -223,13 +291,18 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
     const currentList = actionsByTabRef.current[tabKey] || []
     const removable = currentList.filter((action) => !action.Locked && !action.IsCorePlugin)
     if (removable.length === 0) return
-    const results = await Promise.all(removable.map((action) => requestBinding(action, false, action.Sort, '')))
-    emiter.emit('refreshContextMenuActions')
-    const failed = removable.filter((_, index) => !results[index])
-    updateActionsByTab((prev) => ({
-      ...prev,
-      [tabKey]: [...currentList.filter((action) => action.Locked || action.IsCorePlugin), ...failed],
-    }))
+    bindingSavingRef.current = true
+    try {
+      const results = await Promise.all(removable.map((action) => requestBinding(action, false, action.Sort, '')))
+      emiter.emit('refreshContextMenuActions')
+      const failed = removable.filter((_, index) => !results[index])
+      updateActionsByTab((prev) => ({
+        ...prev,
+        [tabKey]: [...currentList.filter((action) => action.Locked || action.IsCorePlugin), ...failed],
+      }))
+    } finally {
+      bindingSavingRef.current = false
+    }
   })
   // #endregion
 
@@ -355,8 +428,16 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
                           >
                             <SelectedPluginItem
                               plugin={item}
+                              siblings={selectedActions}
+                              scene={getGroupTabByKey(currentTabKey)?.scene}
                               isDragging={snapshot.isDragging}
+                              settingMenuOpen={openSettingKey === `${item.PluginUUID}:${item.ActionID}`}
+                              onSettingMenuOpenChange={(open) => {
+                                setOpenSettingKey(open ? `${item.PluginUUID}:${item.ActionID}` : '')
+                              }}
                               onRemove={onRemovePlugin}
+                              onChangeResultMode={onChangeResultMode}
+                              onChangeShortcut={onChangeShortcut}
                             />
                           </div>
                         )}
@@ -415,25 +496,9 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
             selectedActions={selectedActions}
             onAddPlugin={onAddPlugin}
             onRemovePlugin={onRemovePlugin}
-            getPluginVisible={getPluginVisible}
-            setGetPluginVisible={setGetPluginVisible}
           />
         </div>
       </DragDropContext>
-
-      {/* 空态获取插件：下载 codec 与右键插件类型 */}
-      <YakitGetOnlinePlugin
-        visible={getPluginVisible}
-        pluginType={['codec', 'context-menu']}
-        setVisible={setGetPluginVisible}
-        onFinish={() => {
-          emiter.emit('refreshContextMenuActions')
-          emiter.emit('refreshContextMenuPlugins')
-        }}
-        getContainer={
-          document.getElementById(`main-operator-page-body-${YakitRoute.ManageRightClickPlugins}`) || undefined
-        }
-      />
     </div>
   )
 }
@@ -443,14 +508,206 @@ export default ManageRightClickPlugins
 // #region 已选插件单项
 interface SelectedPluginItemProps {
   plugin: ContextMenuAction
+  siblings: ContextMenuAction[]
+  scene?: ContextMenuScene
   isDragging: boolean
+  settingMenuOpen: boolean
+  onSettingMenuOpenChange: (open: boolean) => void
   onRemove: (plugin: ContextMenuAction) => void
+  onChangeResultMode: (plugin: ContextMenuAction, mode: ContextMenuResultMode) => void
+  onChangeShortcut: (plugin: ContextMenuAction, shortcut: string) => void
 }
 
 const SelectedPluginItem: React.FC<SelectedPluginItemProps> = React.memo((props) => {
-  const { plugin, isDragging, onRemove } = props
+  const {
+    plugin,
+    siblings,
+    scene,
+    isDragging,
+    settingMenuOpen,
+    onSettingMenuOpenChange,
+    onRemove,
+    onChangeResultMode,
+    onChangeShortcut,
+  } = props
+  const { t, i18nRefresh } = useI18nNamespaces(['manageRightClickPlugins', 'shortcutKey'])
   /** 核心插件锁定，不可移除 */
   const locked = plugin.Locked || plugin.IsCorePlugin
+  /** codec 兼容类型不支持配置结果展示方式，沿用旧 CODEC 行为 */
+  const isLegacyCodec = plugin.PluginType === LEGACY_CONTEXT_MENU_PLUGIN_TYPE
+  /** 后端的 auto 在 UI 上不暴露，直接按 tab 展示 */
+  const resultMode = plugin.ResultMode === ContextMenuResultMode.Auto ? ContextMenuResultMode.Tab : plugin.ResultMode
+
+  const shortcutKeys = useMemo(() => parseContextMenuShortcut(plugin.Shortcut), [plugin.Shortcut])
+  const shortcutUI = useMemo(() => convertKeyboardToUIKey(shortcutKeys), [shortcutKeys])
+
+  const [keyShow, setKeyShow] = useState(false)
+  const [inputKeys, setInputKeys] = useState<YakitKeyBoard[]>([])
+  const [warnInfo, setWarnInfo] = useState<string>()
+
+  // #region 编辑插件抽屉
+  const [editPlugin, setEditPlugin] = useState<YakScript | null>(null)
+  const [editHint, setEditHint] = useState(false)
+  const [editLoading, setEditLoading] = useState(false)
+  const pageWrapperRef = useRef<HTMLElement>()
+
+  const handleOpenEdit = useMemoizedFn((e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (editHint || editLoading) return
+    setEditLoading(true)
+    grpcFetchLocalPluginDetailByUUID({ UUID: plugin.PluginUUID })
+      .then((res) => {
+        pageWrapperRef.current = getMainOperatorPageBodyContainer()
+        setEditPlugin(res)
+        setEditHint(true)
+      })
+      .catch(() => {})
+      .finally(() => setEditLoading(false))
+  })
+
+  const handleEditCallback = useMemoizedFn((isSuccess: boolean, data?: ModifyPluginCallback) => {
+    if (isSuccess && data) {
+      const { opType } = data
+      // 保存类操作后刷新本页列表（插件名/说明可能已变）
+      if (['save', 'saveAndExit', 'upload', 'submit'].includes(opType)) {
+        emiter.emit('refreshContextMenuPlugins')
+      }
+      if (opType !== 'save') setEditHint(false)
+    } else {
+      setEditHint(false)
+    }
+  })
+  // #endregion
+
+  const handleOpenKeyShow = useMemoizedFn(() => {
+    if (keyShow) return
+    onSettingMenuOpenChange(false)
+    setInputKeys(shortcutKeys as YakitKeyBoard[])
+    setWarnInfo(
+      shortcutKeys.length > 0
+        ? checkContextMenuShortcutConflict(shortcutKeys, {
+            scene,
+            siblings,
+            exclude: { PluginUUID: plugin.PluginUUID, ActionID: plugin.ActionID },
+          })
+        : undefined,
+    )
+    setIsActiveShortcutKeyPage(true)
+    setKeyShow(true)
+  })
+
+  const handleCallbackKeyShow = useMemoizedFn((show: boolean) => {
+    if (show && inputKeys.length > 0) {
+      onChangeShortcut(plugin, serializeContextMenuShortcut(inputKeys))
+    }
+    setIsActiveShortcutKeyPage(false)
+    setKeyShow(false)
+    setInputKeys([])
+    setWarnInfo(undefined)
+  })
+
+  const handleShortcutKey = useMemoizedFn((name: string) => {
+    if (!keyShow) return
+    if (name.indexOf('setShortcutKey') > -1) {
+      const regex = /\(([^)]+)\)/
+      const result = name.match(regex)
+      if (result && result[1]) {
+        if (result[1] === YakitKeyBoard.Escape) {
+          handleCallbackKeyShow(false)
+        } else if (result[1] === YakitKeyBoard.Enter) {
+          handleCallbackKeyShow(true)
+        } else {
+          const keys = result[1].split('|') as YakitKeyBoard[]
+          setWarnInfo(
+            checkContextMenuShortcutConflict(keys, {
+              scene,
+              siblings,
+              exclude: { PluginUUID: plugin.PluginUUID, ActionID: plugin.ActionID },
+            }),
+          )
+          setInputKeys(keys)
+        }
+      }
+    }
+  })
+  useEffect(() => {
+    if (!keyShow) return
+    emiter.on('onGlobalShortcutKey', handleShortcutKey)
+    return () => {
+      emiter.off('onGlobalShortcutKey', handleShortcutKey)
+      setIsActiveShortcutKeyPage(false)
+    }
+  }, [keyShow])
+
+  const resultModeMenuLabel = useMemoizedFn((mode: ContextMenuResultMode, label: string) => {
+    const checked = resultMode === mode
+    return (
+      <div className={styles['setting-menu-result-item']}>
+        <span>{label}</span>
+        {checked ? <span className={styles['setting-menu-check']}>✓</span> : <span />}
+      </div>
+    )
+  })
+
+  const settingMenuData = useMemo((): YakitMenuItemType[] => {
+    const resultChildren: YakitMenuItemProps[] = [
+      {
+        key: `result-${ContextMenuResultMode.Tab}`,
+        label: resultModeMenuLabel(ContextMenuResultMode.Tab, t('ManageRightClickPlugins.resultModeTab')),
+      },
+      {
+        key: `result-${ContextMenuResultMode.Dialog}`,
+        label: resultModeMenuLabel(ContextMenuResultMode.Dialog, t('ManageRightClickPlugins.resultModeDialog')),
+      },
+      {
+        key: `result-${ContextMenuResultMode.Drawer}`,
+        label: resultModeMenuLabel(ContextMenuResultMode.Drawer, t('ManageRightClickPlugins.resultModeDrawer')),
+      },
+    ]
+    return [
+      {
+        key: 'shortcut',
+        label: (
+          <div className={styles['setting-menu-shortcut-item']}>
+            <span>{t('ManageRightClickPlugins.setShortcutMenu')}</span>
+            <span className={styles['setting-menu-shortcut-keys']}>{shortcutUI}</span>
+          </div>
+        ),
+      },
+      {
+        key: 'result-mode',
+        label: t('ManageRightClickPlugins.setResultModeMenu'),
+        children: isLegacyCodec
+          ? [
+              {
+                key: `result-${ContextMenuResultMode.Tab}`,
+                label: resultModeMenuLabel(ContextMenuResultMode.Tab, t('ManageRightClickPlugins.resultModeTab')),
+              },
+            ]
+          : resultChildren,
+      },
+    ]
+  }, [shortcutUI, resultMode, isLegacyCodec, i18nRefresh])
+
+  const onSettingMenuClick = useMemoizedFn(({ key }: { key: string }) => {
+    if (key === 'shortcut') {
+      handleOpenKeyShow()
+      return
+    }
+    if (isLegacyCodec) return
+    if (key.startsWith('result-')) {
+      const mode = key.slice('result-'.length) as ContextMenuResultMode
+      if (
+        mode === ContextMenuResultMode.Tab ||
+        mode === ContextMenuResultMode.Dialog ||
+        mode === ContextMenuResultMode.Drawer
+      ) {
+        onChangeResultMode(plugin, mode)
+      }
+      onSettingMenuOpenChange(false)
+    }
+  })
+
   return (
     <div className={styles['selected-item-wrap']}>
       <div
@@ -458,30 +715,104 @@ const SelectedPluginItem: React.FC<SelectedPluginItemProps> = React.memo((props)
           [styles['selected-item-dragging']]: isDragging,
         })}
       >
-        <DragSortIcon
-          className={classNames({
-            [styles['drag-icon-active']]: isDragging,
-          })}
-        />
-        <Avatar
-          className={styles['plugin-avatar']}
-          src={plugin.HeadImg || ''}
-          icon={<PrivateOutlineDefaultPluginIcon />}
-        />
-        <div className={styles['selected-item-body']}>
-          <div className={styles['selected-item-name']}>{plugin.PluginName}</div>
-          <div className={styles['selected-item-desc']}>{plugin.Help || 'No Description about it.'}</div>
+        <div className={styles['selected-item-main']}>
+          <DragSortIcon
+            className={classNames({
+              [styles['drag-icon-active']]: isDragging,
+            })}
+          />
+          <Avatar
+            className={styles['plugin-avatar']}
+            src={plugin.HeadImg || ''}
+            icon={<PrivateOutlineDefaultPluginIcon />}
+          />
+          <div className={styles['selected-item-body']}>
+            <div className={styles['selected-item-name-row']}>
+              <div className={styles['selected-item-name']}>{plugin.PluginName}</div>
+              <div className={styles['selected-item-name-actions']} onMouseDown={(e) => e.stopPropagation()}>
+                <YakitButton
+                  size="small"
+                  type="text2"
+                  loading={editLoading}
+                  icon={<OutlinePencilaltIcon className={styles['setting-icon']} />}
+                  onClick={handleOpenEdit}
+                  style={{ marginRight: 4 }}
+                />
+                <YakitDropdownMenu
+                  menu={{
+                    data: settingMenuData,
+                    width: 180,
+                    onClick: onSettingMenuClick,
+                  }}
+                  dropdown={{
+                    trigger: ['click'],
+                    placement: 'bottomLeft',
+                    visible: settingMenuOpen,
+                    onVisibleChange: onSettingMenuOpenChange,
+                  }}
+                >
+                  <YakitButton
+                    size="small"
+                    type="text2"
+                    icon={<OutlineCogIcon className={styles['setting-icon']} />}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                    }}
+                  />
+                </YakitDropdownMenu>
+              </div>
+            </div>
+            <div className={styles['selected-item-desc']}>{plugin.Help || 'No Description about it.'}</div>
+          </div>
+          <YakitButton
+            size="small"
+            type="text2"
+            disabled={locked}
+            icon={
+              <OutlineXIcon
+                className={classNames(styles['remove-icon'], { [styles['remove-icon-disabled']]: locked })}
+              />
+            }
+            onClick={(e) => {
+              e.stopPropagation()
+              onRemove(plugin)
+            }}
+          />
         </div>
-        <YakitButton
-          size="small"
-          type="text2"
-          disabled={locked}
-          icon={
-            <OutlineXIcon className={classNames(styles['remove-icon'], { [styles['remove-icon-disabled']]: locked })} />
-          }
-          onClick={() => onRemove(plugin)}
-        />
       </div>
+
+      {editHint && editPlugin && (
+        <ModifyYakitPlugin
+          getContainer={pageWrapperRef.current || undefined}
+          plugin={editPlugin}
+          visible={editHint}
+          onCallback={handleEditCallback}
+        />
+      )}
+
+      <YakitModal
+        type="white"
+        title={t('ShortcutKey.editShortcut')}
+        centered={true}
+        keyboard={false}
+        footer={null}
+        maskClosable={false}
+        maskStyle={{ backgroundColor: 'transparent' }}
+        visible={keyShow}
+        width={600}
+        onCancel={() => handleCallbackKeyShow(false)}
+      >
+        <div className={styles['set-shortcut-key-wrapper']}>
+          <div className={styles['title']}>{t('ShortcutKey.hint')}</div>
+          <div className={classNames(styles['input'], { [styles['empty']]: inputKeys.length === 0 })}>
+            {inputKeys.join(' ')}
+          </div>
+          <div className={styles['keys-ui']}>
+            {convertKeyboardToUIKey(inputKeys)}
+            {warnInfo && <span className={styles['warn']}>（{warnInfo}）</span>}
+          </div>
+        </div>
+      </YakitModal>
     </div>
   )
 })
@@ -495,21 +826,10 @@ interface AvailablePluginListProps {
   selectedActions: ContextMenuAction[]
   onAddPlugin: (plugin: ContextMenuAction) => void
   onRemovePlugin: (plugin: ContextMenuAction) => void
-  getPluginVisible: boolean
-  setGetPluginVisible: (visible: boolean) => void
 }
 
 const AvailablePluginList: React.FC<AvailablePluginListProps> = React.memo((props) => {
-  const {
-    destinationDrag,
-    availableActions,
-    isFiltering,
-    selectedActions,
-    onAddPlugin,
-    onRemovePlugin,
-    getPluginVisible,
-    setGetPluginVisible,
-  } = props
+  const { destinationDrag, availableActions, isFiltering, selectedActions, onAddPlugin, onRemovePlugin } = props
   const { t } = useI18nNamespaces(['manageRightClickPlugins', 'yakitUi'])
 
   return (
@@ -524,8 +844,12 @@ const AvailablePluginList: React.FC<AvailablePluginListProps> = React.memo((prop
                 <YakitButton
                   type="outline1"
                   icon={<CloudDownloadIcon />}
-                  disabled={getPluginVisible}
-                  onClick={() => setGetPluginVisible(true)}
+                  onClick={() => {
+                    emiter.emit(
+                      'onOpenFuzzerModal',
+                      JSON.stringify({ isAiPlugin: 'isGetPlugin', pluginType: ['codec', 'context-menu'] }),
+                    )
+                  }}
                 >
                   {t('ManageRightClickPlugins.getPlugin')}
                 </YakitButton>

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.tsx
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.tsx
@@ -39,7 +39,7 @@ import type { ModifyPluginCallback } from '@/pages/pluginEditor/pluginEditor/Plu
 import { ModifyYakitPlugin } from '@/pages/pluginEditor/modifyYakitPlugin/ModifyYakitPlugin'
 import { getMainOperatorPageBodyContainer } from '@/utils/getMainOperatorPageBodyContainer'
 import { DROP_AVAILABLE, DROP_SELECTED, getGroupTabByKey, GroupTabList, UpperLimit } from './constants'
-import { fetchSceneActions } from './utils'
+import { fetchSceneActions, isSameAction, patchAction } from './utils'
 import { grpcSetContextMenuActionBinding, grpcFetchLocalPluginDetailByUUID } from './api'
 import type { ContextMenuAction } from './types'
 import { ContextMenuResultMode, LEGACY_CONTEXT_MENU_PLUGIN_TYPE, type ContextMenuScene } from './types'
@@ -53,6 +53,14 @@ const reorder = <T,>(list: T[], startIndex: number, endIndex: number) => {
   result.splice(endIndex, 0, removed)
   return result
 }
+
+/** 解绑请求视图：禁用并清空快捷键、结果展示重置为默认 Tab */
+const toUnboundAction = (action: ContextMenuAction): ContextMenuAction => ({
+  ...action,
+  Enabled: false,
+  Shortcut: '',
+  ResultMode: ContextMenuResultMode.Tab,
+})
 
 interface ManageRightClickPluginsProps {}
 const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
@@ -146,33 +154,29 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
   // #endregion
 
   // #region 保存
-  const requestBinding = useMemoizedFn(
-    async (action: ContextMenuAction, enabled: boolean, sort: number, shortcut = action.Shortcut || '') => {
-      try {
-        await grpcSetContextMenuActionBinding({
-          PluginUUID: action.PluginUUID,
-          ActionID: action.ActionID,
-          Enabled: enabled,
-          Sort: sort,
-          Shortcut: shortcut,
-          ResultMode: action.ResultMode,
-          AskBeforeRun: action.AskBeforeRun,
-        })
-        return true
-      } catch {
-        return false
-      }
-    },
-  )
-  const saveBinding = useMemoizedFn(
-    async (action: ContextMenuAction, enabled: boolean, sort: number, shortcut = action.Shortcut || '') => {
-      const ok = await requestBinding(action, enabled, sort, shortcut)
-      if (ok) {
-        emiter.emit('refreshContextMenuActions')
-      }
-      return ok
-    },
-  )
+  const requestBinding = useMemoizedFn(async (action: ContextMenuAction) => {
+    try {
+      await grpcSetContextMenuActionBinding({
+        PluginUUID: action.PluginUUID,
+        ActionID: action.ActionID,
+        Enabled: action.Enabled,
+        Sort: action.Sort,
+        Shortcut: action.Shortcut || '',
+        ResultMode: action.ResultMode,
+        AskBeforeRun: action.AskBeforeRun,
+      })
+      return true
+    } catch {
+      return false
+    }
+  })
+  const saveBinding = useMemoizedFn(async (action: ContextMenuAction) => {
+    const ok = await requestBinding(action)
+    if (ok) {
+      emiter.emit('refreshContextMenuActions')
+    }
+    return ok
+  })
   // #endregion
 
   // #region 已选插件的增删改操作
@@ -191,19 +195,20 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
       yakitNotify('error', t('ManageRightClickPlugins.maxAddLimit', { UpperLimit }))
       return
     }
-    if (currentList.some((i) => i.ActionID === action.ActionID && i.PluginUUID === action.PluginUUID)) return
+    if (currentList.some((i) => isSameAction(i, action))) return
 
     const insertPos = typeof insertIndex === 'number' ? Math.min(insertIndex, currentList.length) : currentList.length
     const next = [...currentList]
     next.splice(insertPos, 0, action)
-    // 新插入项（对象引用相等）必保存；其余仅保存 Sort 与新下标不同的项
-    const normalized = next.map((item, index) => ({ ...item, Sort: index }))
+    // 已选列表项均为启用态：归一 Enabled 与 Sort，只保存「新插入项 + Sort 变化的既有项」
+    const normalized = next.map((item, index) => ({ ...item, Enabled: true, Sort: index }))
     const changed = normalized.filter((_, index) => next[index] === action || next[index].Sort !== index)
     bindingSavingRef.current = true
     try {
       updateActionsByTab((prev) => ({ ...prev, [tabKey]: normalized }))
+      setAvailableActions((prev) => patchAction(prev, action, { Enabled: true }))
       for (const item of changed) {
-        const ok = await saveBinding(item, true, item.Sort)
+        const ok = await saveBinding(item)
         if (!ok) {
           refreshSelectedPlugins()
           return
@@ -226,17 +231,13 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
     const tabKey = currentTabKeyRef.current
     bindingSavingRef.current = true
     try {
-      const ok = await saveBinding({ ...action, ResultMode: mode }, true, action.Sort)
-      if (!ok) {
-        refreshSelectedPlugins()
-        return
-      }
+      const ok = await saveBinding({ ...action, ResultMode: mode })
+      if (!ok) return
       updateActionsByTab((prev) => ({
         ...prev,
-        [tabKey]: (prev[tabKey] || []).map((i) =>
-          i.ActionID === action.ActionID && i.PluginUUID === action.PluginUUID ? { ...i, ResultMode: mode } : i,
-        ),
+        [tabKey]: patchAction(prev[tabKey] || [], action, { ResultMode: mode }),
       }))
+      setAvailableActions((prev) => patchAction(prev, action, { ResultMode: mode }))
     } finally {
       bindingSavingRef.current = false
     }
@@ -248,17 +249,13 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
     const tabKey = currentTabKeyRef.current
     bindingSavingRef.current = true
     try {
-      const ok = await saveBinding(action, true, action.Sort, shortcut)
-      if (!ok) {
-        refreshSelectedPlugins()
-        return
-      }
+      const ok = await saveBinding({ ...action, Shortcut: shortcut })
+      if (!ok) return
       updateActionsByTab((prev) => ({
         ...prev,
-        [tabKey]: (prev[tabKey] || []).map((i) =>
-          i.ActionID === action.ActionID && i.PluginUUID === action.PluginUUID ? { ...i, Shortcut: shortcut } : i,
-        ),
+        [tabKey]: patchAction(prev[tabKey] || [], action, { Shortcut: shortcut }),
       }))
+      setAvailableActions((prev) => patchAction(prev, action, { Shortcut: shortcut }))
     } finally {
       bindingSavingRef.current = false
     }
@@ -271,14 +268,13 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
     const tabKey = currentTabKeyRef.current
     bindingSavingRef.current = true
     try {
-      const ok = await saveBinding(action, false, action.Sort, '')
+      const ok = await saveBinding(toUnboundAction(action))
       if (!ok) return
       updateActionsByTab((prev) => ({
         ...prev,
-        [tabKey]: (prev[tabKey] || []).filter(
-          (i) => !(i.ActionID === action.ActionID && i.PluginUUID === action.PluginUUID),
-        ),
+        [tabKey]: (prev[tabKey] || []).filter((i) => !isSameAction(i, action)),
       }))
+      setAvailableActions((prev) => prev.map((i) => (isSameAction(i, action) ? toUnboundAction(i) : i)))
     } finally {
       bindingSavingRef.current = false
     }
@@ -293,13 +289,19 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
     if (removable.length === 0) return
     bindingSavingRef.current = true
     try {
-      const results = await Promise.all(removable.map((action) => requestBinding(action, false, action.Sort, '')))
+      const results = await Promise.all(removable.map((action) => requestBinding(toUnboundAction(action))))
       emiter.emit('refreshContextMenuActions')
       const failed = removable.filter((_, index) => !results[index])
       updateActionsByTab((prev) => ({
         ...prev,
         [tabKey]: [...currentList.filter((action) => action.Locked || action.IsCorePlugin), ...failed],
       }))
+      const removedKeys = new Set(
+        removable.filter((_, index) => results[index]).map((a) => `${a.PluginUUID}:${a.ActionID}`),
+      )
+      setAvailableActions((prev) =>
+        prev.map((i) => (removedKeys.has(`${i.PluginUUID}:${i.ActionID}`) ? toUnboundAction(i) : i)),
+      )
     } finally {
       bindingSavingRef.current = false
     }
@@ -317,13 +319,14 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
       const tabKey = currentTabKeyRef.current
       const currentList = actionsByTabRef.current[tabKey] || []
       const reordered = reorder(currentList, result.source.index, result.destination.index)
-      const next = reordered.map((item, index) => ({ ...item, Sort: index }))
+      // 已选列表项均为启用态：归一 Enabled 与 Sort
+      const next = reordered.map((item, index) => ({ ...item, Enabled: true, Sort: index }))
       const changed = next.filter((_, index) => reordered[index].Sort !== index)
       bindingSavingRef.current = true
       try {
         updateActionsByTab((prev) => ({ ...prev, [tabKey]: next }))
         for (const item of changed) {
-          const ok = await saveBinding(item, true, item.Sort)
+          const ok = await saveBinding(item)
           if (!ok) {
             refreshSelectedPlugins()
             return
@@ -664,6 +667,21 @@ const SelectedPluginItem: React.FC<SelectedPluginItemProps> = React.memo((props)
         label: resultModeMenuLabel(ContextMenuResultMode.Drawer, t('ManageRightClickPlugins.resultModeDrawer')),
       },
     ]
+
+    if (isLegacyCodec) {
+      return [
+        {
+          key: 'shortcut',
+          label: (
+            <div className={styles['setting-menu-shortcut-item']}>
+              <span>{t('ManageRightClickPlugins.setShortcutMenu')}</span>
+              <span className={styles['setting-menu-shortcut-keys']}>{shortcutUI}</span>
+            </div>
+          ),
+        },
+      ]
+    }
+
     return [
       {
         key: 'shortcut',
@@ -677,14 +695,7 @@ const SelectedPluginItem: React.FC<SelectedPluginItemProps> = React.memo((props)
       {
         key: 'result-mode',
         label: t('ManageRightClickPlugins.setResultModeMenu'),
-        children: isLegacyCodec
-          ? [
-              {
-                key: `result-${ContextMenuResultMode.Tab}`,
-                label: resultModeMenuLabel(ContextMenuResultMode.Tab, t('ManageRightClickPlugins.resultModeTab')),
-              },
-            ]
-          : resultChildren,
+        children: resultChildren,
       },
     ]
   }, [shortcutUI, resultMode, isLegacyCodec, i18nRefresh])
@@ -729,12 +740,13 @@ const SelectedPluginItem: React.FC<SelectedPluginItemProps> = React.memo((props)
           <div className={styles['selected-item-body']}>
             <div className={styles['selected-item-name-row']}>
               <div className={styles['selected-item-name']}>{plugin.PluginName}</div>
+              {shortcutUI && <div className={styles['selected-item-name-shortcut']}>{shortcutUI}</div>}
               <div className={styles['selected-item-name-actions']} onMouseDown={(e) => e.stopPropagation()}>
                 <YakitButton
                   size="small"
-                  type="text2"
+                  type="text"
                   loading={editLoading}
-                  icon={<OutlinePencilaltIcon className={styles['setting-icon']} />}
+                  icon={<OutlinePencilaltIcon />}
                   onClick={handleOpenEdit}
                   style={{ marginRight: 4 }}
                 />
@@ -747,14 +759,16 @@ const SelectedPluginItem: React.FC<SelectedPluginItemProps> = React.memo((props)
                   dropdown={{
                     trigger: ['click'],
                     placement: 'bottomLeft',
-                    visible: settingMenuOpen,
-                    onVisibleChange: onSettingMenuOpenChange,
+                    open: settingMenuOpen,
+                    onOpenChange: onSettingMenuOpenChange,
                   }}
                 >
                   <YakitButton
                     size="small"
-                    type="text2"
-                    icon={<OutlineCogIcon className={styles['setting-icon']} />}
+                    type="text"
+                    icon={
+                      <OutlineCogIcon className={classNames({ [styles['setting-icon-active']]: settingMenuOpen })} />
+                    }
                     onClick={(e) => {
                       e.stopPropagation()
                     }}
@@ -766,7 +780,7 @@ const SelectedPluginItem: React.FC<SelectedPluginItemProps> = React.memo((props)
           </div>
           <YakitButton
             size="small"
-            type="text2"
+            type="text"
             disabled={locked}
             icon={
               <OutlineXIcon
@@ -797,8 +811,8 @@ const SelectedPluginItem: React.FC<SelectedPluginItemProps> = React.memo((props)
         keyboard={false}
         footer={null}
         maskClosable={false}
-        maskStyle={{ backgroundColor: 'transparent' }}
-        visible={keyShow}
+        styles={{ mask: { backgroundColor: 'transparent' } }}
+        open={keyShow}
         width={600}
         onCancel={() => handleCallbackKeyShow(false)}
       >
@@ -857,9 +871,7 @@ const AvailablePluginList: React.FC<AvailablePluginListProps> = React.memo((prop
             )
           ) : (
             availableActions.map((data, index) => {
-              const isAdded = selectedActions.some(
-                (i) => i.ActionID === data.ActionID && i.PluginUUID === data.PluginUUID,
-              )
+              const isAdded = selectedActions.some((i) => isSameAction(i, data))
               return (
                 <Draggable
                   key={`${data.PluginUUID}:${data.ActionID}`}

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.tsx
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.tsx
@@ -675,7 +675,6 @@ const SelectedPluginItem: React.FC<SelectedPluginItemProps> = React.memo((props)
           label: (
             <div className={styles['setting-menu-shortcut-item']}>
               <span>{t('ManageRightClickPlugins.setShortcutMenu')}</span>
-              <span className={styles['setting-menu-shortcut-keys']}>{shortcutUI}</span>
             </div>
           ),
         },
@@ -688,7 +687,6 @@ const SelectedPluginItem: React.FC<SelectedPluginItemProps> = React.memo((props)
         label: (
           <div className={styles['setting-menu-shortcut-item']}>
             <span>{t('ManageRightClickPlugins.setShortcutMenu')}</span>
-            <span className={styles['setting-menu-shortcut-keys']}>{shortcutUI}</span>
           </div>
         ),
       },
@@ -698,7 +696,7 @@ const SelectedPluginItem: React.FC<SelectedPluginItemProps> = React.memo((props)
         children: resultChildren,
       },
     ]
-  }, [shortcutUI, resultMode, isLegacyCodec, i18nRefresh])
+  }, [resultMode, isLegacyCodec, i18nRefresh])
 
   const onSettingMenuClick = useMemoizedFn(({ key }: { key: string }) => {
     if (key === 'shortcut') {

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/api.test.ts
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/api.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { ContextMenuExecutionType } from '../types'
+
+describe('manageRightClickPlugins api helpers', () => {
+  it('应过滤掉 ExecutionType 为 LegacyPacketMutate 的数据包变形插件', () => {
+    const actions = [
+      { ActionID: 'a1', ExecutionType: ContextMenuExecutionType.ContextMenu },
+      { ActionID: 'a2', ExecutionType: ContextMenuExecutionType.LegacyPacketMutate },
+      { ActionID: 'a3', ExecutionType: ContextMenuExecutionType.LegacyHistory },
+      { ActionID: 'a4', ExecutionType: ContextMenuExecutionType.LegacyPacketContext },
+    ] as any[]
+
+    const filtered = actions.filter((action) => action.ExecutionType !== ContextMenuExecutionType.LegacyPacketMutate)
+
+    expect(filtered.map((a) => a.ActionID)).toEqual(['a1', 'a3', 'a4'])
+  })
+})

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/constants.test.ts
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/constants.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DROP_AVAILABLE,
+  DROP_SELECTED,
+  getGroupTabByKey,
+  getSceneByTabKey,
+  GroupTabList,
+  ManageRightClickPluginsTabKey,
+  UpperLimit,
+} from '../constants'
+import { ContextMenuScene } from '../types'
+
+describe('manageRightClickPlugins constants', () => {
+  it('UpperLimit 为 15', () => {
+    expect(UpperLimit).toBe(15)
+  })
+
+  it('拖拽区域 id 常量互不重复', () => {
+    expect(DROP_SELECTED).not.toBe(DROP_AVAILABLE)
+  })
+
+  it('GroupTabList 包含全部三种场景', () => {
+    const scenes = GroupTabList.map((item) => item.scene)
+    expect(scenes).toContain(ContextMenuScene.HistorySingle)
+    expect(scenes).toContain(ContextMenuScene.HistoryMulti)
+    expect(scenes).toContain(ContextMenuScene.HTTPPacket)
+  })
+
+  it('getGroupTabByKey 能按 key 找到对应分组', () => {
+    expect(getGroupTabByKey(ManageRightClickPluginsTabKey.PluginExtensionSingle)?.scene).toBe(
+      ContextMenuScene.HistorySingle,
+    )
+    expect(getGroupTabByKey(ManageRightClickPluginsTabKey.PluginExtensionMultiple)?.scene).toBe(
+      ContextMenuScene.HistoryMulti,
+    )
+    expect(getGroupTabByKey(ManageRightClickPluginsTabKey.PacketContextMenu)?.scene).toBe(ContextMenuScene.HTTPPacket)
+  })
+
+  it('getGroupTabByKey 对未知 key 返回 undefined', () => {
+    expect(getGroupTabByKey('unknown-key')).toBeUndefined()
+  })
+
+  it('getSceneByTabKey 返回对应场景，未知 key 返回 undefined', () => {
+    expect(getSceneByTabKey(ManageRightClickPluginsTabKey.PluginExtensionSingle)).toBe(ContextMenuScene.HistorySingle)
+    expect(getSceneByTabKey(ManageRightClickPluginsTabKey.PacketContextMenu)).toBe(ContextMenuScene.HTTPPacket)
+    expect(getSceneByTabKey('not-exist')).toBeUndefined()
+  })
+})

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/shortcut.test.ts
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/shortcut.test.ts
@@ -1,0 +1,326 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ContextMenuExecutionType, ContextMenuScene, type ContextMenuAction } from '../types'
+
+vi.mock('@/i18n/i18n', () => ({
+  default: { getFixedT: () => (k: string, opts?: { name?: string }) => `${k}:${opts?.name || ''}` },
+}))
+vi.mock('@/utils/globalShortcutKey/events/page/yakEditor', () => ({
+  isConflictToYakEditor: vi.fn(() => ''),
+}))
+vi.mock('@/utils/envfile', () => ({
+  GetReleaseEdition: vi.fn(() => 0),
+  PRODUCT_RELEASE_EDITION: { Yakit: 0, EnpriTrace: 1, IRify: 2 },
+}))
+vi.mock('@/utils/globalShortcutKey/events/pageMaps', () => ({
+  ShortcutKeyPage: {
+    Global: 'global',
+    HTTPFuzzer: 'httpFuzzer',
+    PluginHub: 'plugin-hub',
+    YakRunner_Audit_Code: 'yakrunner-audit-code',
+    YakRunner: 'yakScript',
+    YakRunnerAiCodeAudit: 'irify-ai-code-audit',
+    Mitm: 'mitm-hijack',
+    ChatCS: 'chat-cs',
+    YakEditor: 'yak-editor',
+    YakitMultiple: 'yakit-multiple',
+    HotPatchManagement: 'hot-patch-management',
+  },
+  pageEventMaps: {
+    global: {
+      getEvents: () => ({
+        'sendAndJump*common': { name: 'ShortcutKey.sendAndJump', keys: ['Control', 'R'] },
+      }),
+    },
+    'yak-editor': {
+      getEvents: () => ({
+        'editorOnly*common': { name: 'ShortcutKey.editorOnly', keys: ['Control', 'E'] },
+      }),
+    },
+    'yakit-multiple': {
+      getEvents: () => ({
+        'tableOnly*common': { name: 'ShortcutKey.tableOnly', keys: ['Control', 'T'] },
+      }),
+    },
+  },
+}))
+vi.mock('../api', () => ({
+  grpcQueryContextMenuActions: vi.fn(),
+}))
+
+import { isConflictToYakEditor } from '@/utils/globalShortcutKey/events/page/yakEditor'
+import { grpcQueryContextMenuActions } from '../api'
+import {
+  checkContextMenuShortcutConflict,
+  findContextMenuPluginShortcutConflict,
+  getEnabledContextMenuShortcuts,
+  matchContextMenuShortcut,
+  parseContextMenuShortcut,
+  refreshContextMenuShortcutCache,
+  serializeContextMenuShortcut,
+} from '../shortcut'
+
+const mockIsConflict = isConflictToYakEditor as ReturnType<typeof vi.fn>
+const mockQuery = grpcQueryContextMenuActions as ReturnType<typeof vi.fn>
+
+const makeAction = (over: Partial<ContextMenuAction>): ContextMenuAction =>
+  ({
+    ActionID: 'a1',
+    PluginUUID: 'u1',
+    PluginName: 'PluginA',
+    Enabled: true,
+    Shortcut: '',
+    ExecutionType: ContextMenuExecutionType.ContextMenu,
+    ...over,
+  }) as ContextMenuAction
+
+beforeEach(() => {
+  mockIsConflict.mockReset()
+  mockIsConflict.mockReturnValue('')
+  mockQuery.mockReset()
+  mockQuery.mockResolvedValue({ Actions: [] })
+})
+
+describe('serializeContextMenuShortcut / parseContextMenuShortcut', () => {
+  it('空数组序列化为空字符串', () => {
+    expect(serializeContextMenuShortcut([])).toBe('')
+  })
+
+  it('序列化时按修饰键优先级排序', () => {
+    expect(serializeContextMenuShortcut(['R', 'Shift', 'Control'])).toBe('Control|Shift|R')
+  })
+
+  it('解析空或空白返回空数组', () => {
+    expect(parseContextMenuShortcut('')).toEqual([])
+    expect(parseContextMenuShortcut('   ')).toEqual([])
+    expect(parseContextMenuShortcut(undefined)).toEqual([])
+  })
+
+  it('解析管道分隔字符串', () => {
+    expect(parseContextMenuShortcut('Control|Shift|R')).toEqual(['Control', 'Shift', 'R'])
+  })
+})
+
+describe('checkContextMenuShortcutConflict', () => {
+  it('数据包场景才检测 Monaco 冲突', () => {
+    mockIsConflict.mockReturnValueOnce('editor conflict')
+    expect(checkContextMenuShortcutConflict(['Control', 'C'], { scene: ContextMenuScene.HTTPPacket })).toBe(
+      'editor conflict',
+    )
+  })
+
+  it('History 表格场景不检测 Monaco 冲突', () => {
+    mockIsConflict.mockReturnValueOnce('editor conflict')
+    const result = checkContextMenuShortcutConflict(['Control', 'C'], {
+      scene: ContextMenuScene.HistorySingle,
+    })
+    expect(mockIsConflict).not.toHaveBeenCalled()
+    expect(result).toBe('')
+  })
+
+  it('History 单选场景不比对编辑器页系统快捷键', () => {
+    const result = checkContextMenuShortcutConflict(['Control', 'E'], {
+      scene: ContextMenuScene.HistorySingle,
+    })
+    expect(result).toBe('')
+  })
+
+  it('数据包场景不比对多页面表格系统快捷键', () => {
+    const result = checkContextMenuShortcutConflict(['Control', 'T'], {
+      scene: ContextMenuScene.HTTPPacket,
+    })
+    expect(result).toBe('')
+  })
+
+  it('History 多选场景会比对多页面表格系统快捷键', () => {
+    const result = checkContextMenuShortcutConflict(['Control', 'T'], {
+      scene: ContextMenuScene.HistoryMulti,
+    })
+    expect(result).toContain('ManageRightClickPlugins.systemShortcutConflict')
+    expect(result).toContain('ShortcutKey.tableOnly')
+  })
+
+  it('与系统快捷键（如发送到 WebFuzzer）冲突时提示重新设置', () => {
+    const result = checkContextMenuShortcutConflict(['Control', 'R'], {
+      scene: ContextMenuScene.HistorySingle,
+    })
+    expect(result).toContain('ManageRightClickPlugins.systemShortcutConflict')
+    expect(result).toContain('ShortcutKey.sendAndJump')
+  })
+
+  it('同场景其他插件 Shortcut 冲突时返回提示', () => {
+    const siblings = [
+      makeAction({ PluginUUID: 'u2', ActionID: 'a2', PluginName: 'Other', Shortcut: 'Control|Shift|R' }),
+    ]
+    const result = checkContextMenuShortcutConflict(['Control', 'Shift', 'R'], {
+      siblings,
+      exclude: { PluginUUID: 'u1', ActionID: 'a1' },
+    })
+    expect(result).toContain('ManageRightClickPlugins.pluginShortcutConflict')
+    expect(result).toContain('Other')
+  })
+
+  it('比对时排除自身', () => {
+    const siblings = [makeAction({ Shortcut: 'Control|Shift|T' })]
+    const result = checkContextMenuShortcutConflict(['Control', 'Shift', 'T'], {
+      siblings,
+      exclude: { PluginUUID: 'u1', ActionID: 'a1' },
+    })
+    expect(result).toBe('')
+  })
+})
+
+describe('findContextMenuPluginShortcutConflict', () => {
+  it('编辑器页只比对数据包右键插件', async () => {
+    mockQuery.mockResolvedValueOnce({
+      Actions: [
+        makeAction({
+          PluginName: 'MyPlugin',
+          Shortcut: 'Control|Alt|P',
+          Enabled: true,
+          Scene: ContextMenuScene.HTTPPacket,
+        }),
+      ],
+    })
+    await refreshContextMenuShortcutCache()
+    const result = findContextMenuPluginShortcutConflict(['Control', 'Alt', 'P'], 'yak-editor')
+    expect(result).toContain('ShortcutKey.contextMenuPluginConflict')
+    expect(result).toContain('MyPlugin')
+  })
+
+  it('编辑器页不比对 History 表格插件', async () => {
+    mockQuery.mockResolvedValueOnce({
+      Actions: [
+        makeAction({
+          PluginName: 'TablePlugin',
+          Shortcut: 'Control|Alt|P',
+          Enabled: true,
+          Scene: ContextMenuScene.HistorySingle,
+        }),
+      ],
+    })
+    await refreshContextMenuShortcutCache()
+    expect(findContextMenuPluginShortcutConflict(['Control', 'Alt', 'P'], 'yak-editor')).toBe('')
+  })
+
+  it('全局页比对全部右键场景', async () => {
+    mockQuery.mockResolvedValueOnce({
+      Actions: [
+        makeAction({
+          PluginName: 'TablePlugin',
+          Shortcut: 'Control|Alt|G',
+          Enabled: true,
+          Scene: ContextMenuScene.HistorySingle,
+        }),
+      ],
+    })
+    await refreshContextMenuShortcutCache()
+    const result = findContextMenuPluginShortcutConflict(['Control', 'Alt', 'G'], 'global')
+    expect(result).toContain('TablePlugin')
+  })
+
+  it('多页面页只比对 History 单/多选插件', async () => {
+    mockQuery.mockResolvedValueOnce({
+      Actions: [
+        makeAction({
+          PluginName: 'TablePlugin',
+          Shortcut: 'Control|Alt|H',
+          Enabled: true,
+          Scene: ContextMenuScene.HistoryMulti,
+        }),
+        makeAction({
+          PluginName: 'PacketPlugin',
+          Shortcut: 'Control|Alt|P',
+          Enabled: true,
+          Scene: ContextMenuScene.HTTPPacket,
+        }),
+      ],
+    })
+    await refreshContextMenuShortcutCache()
+    expect(findContextMenuPluginShortcutConflict(['Control', 'Alt', 'H'], 'yakit-multiple')).toContain('TablePlugin')
+    expect(findContextMenuPluginShortcutConflict(['Control', 'Alt', 'P'], 'yakit-multiple')).toBe('')
+  })
+
+  it('MITM / WebFuzzer 页与右键插件无重叠，不比对', async () => {
+    mockQuery.mockResolvedValueOnce({
+      Actions: [
+        makeAction({
+          PluginName: 'PacketPlugin',
+          Shortcut: 'Control|Alt|M',
+          Enabled: true,
+          Scene: ContextMenuScene.HTTPPacket,
+        }),
+      ],
+    })
+    await refreshContextMenuShortcutCache()
+    expect(findContextMenuPluginShortcutConflict(['Control', 'Alt', 'M'], 'mitm-hijack')).toBe('')
+    expect(findContextMenuPluginShortcutConflict(['Control', 'Alt', 'M'], 'httpFuzzer')).toBe('')
+  })
+
+  it('与右键无重叠的页（如插件仓库）不比对', async () => {
+    mockQuery.mockResolvedValueOnce({
+      Actions: [
+        makeAction({
+          PluginName: 'AnyPlugin',
+          Shortcut: 'Control|Alt|P',
+          Enabled: true,
+          Scene: ContextMenuScene.HTTPPacket,
+        }),
+      ],
+    })
+    await refreshContextMenuShortcutCache()
+    expect(findContextMenuPluginShortcutConflict(['Control', 'Alt', 'P'], 'plugin-hub')).toBe('')
+  })
+
+  it('无匹配时返回空', async () => {
+    mockQuery.mockResolvedValueOnce({ Actions: [] })
+    await refreshContextMenuShortcutCache()
+    expect(findContextMenuPluginShortcutConflict(['Control', 'Alt', 'Z'])).toBe('')
+  })
+
+  it('grpc 失败时保留上一次缓存', async () => {
+    mockQuery.mockResolvedValueOnce({
+      Actions: [
+        makeAction({
+          PluginName: 'CachedPlugin',
+          Shortcut: 'Control|Alt|C',
+          Enabled: true,
+          Scene: ContextMenuScene.HTTPPacket,
+        }),
+      ],
+    })
+    await refreshContextMenuShortcutCache()
+    expect(findContextMenuPluginShortcutConflict(['Control', 'Alt', 'C'], 'yak-editor')).toContain('CachedPlugin')
+
+    mockQuery.mockRejectedValueOnce(new Error('network'))
+    await refreshContextMenuShortcutCache()
+    expect(findContextMenuPluginShortcutConflict(['Control', 'Alt', 'C'], 'yak-editor')).toContain('CachedPlugin')
+  })
+
+  it('refresh 返回刷新后的缓存条目数，grpc 失败时返回旧条目数', async () => {
+    mockQuery.mockResolvedValueOnce({
+      Actions: [
+        makeAction({ PluginName: 'P1', Shortcut: 'Control|Alt|1', Enabled: true }),
+        makeAction({ PluginName: 'P2', Shortcut: 'Control|Alt|2', Enabled: true }),
+        // 未启用 / 未绑定快捷键的项不计入缓存
+        makeAction({ PluginName: 'P3', Shortcut: 'Control|Alt|3', Enabled: false }),
+        makeAction({ PluginName: 'P4', Shortcut: '', Enabled: true }),
+      ],
+    })
+    await expect(refreshContextMenuShortcutCache()).resolves.toBe(2)
+    expect(getEnabledContextMenuShortcuts()).toHaveLength(2)
+
+    mockQuery.mockRejectedValueOnce(new Error('network'))
+    await expect(refreshContextMenuShortcutCache()).resolves.toBe(2)
+  })
+})
+
+describe('matchContextMenuShortcut', () => {
+  it('按键顺序无关仍可命中', () => {
+    expect(matchContextMenuShortcut(['R', 'Control'], 'Control|R')).toBe(true)
+  })
+
+  it('未绑定或按键不匹配时返回 false', () => {
+    expect(matchContextMenuShortcut(['Control', 'R'], '')).toBe(false)
+    expect(matchContextMenuShortcut(['Control', 'S'], 'Control|R')).toBe(false)
+  })
+})

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/utils.test.ts
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/utils.test.ts
@@ -10,7 +10,7 @@ vi.mock('@/i18n/i18n', () => ({ default: { getFixedT: () => (k: string) => k } }
 vi.mock('../api', () => ({ grpcQueryContextMenuActions: vi.fn() }))
 
 import { grpcQueryContextMenuActions } from '../api'
-import { getSceneTabActions } from '../utils'
+import { getSceneTabActions, isSameAction, patchAction } from '../utils'
 
 const mockQuery = grpcQueryContextMenuActions as ReturnType<typeof vi.fn>
 
@@ -71,5 +71,74 @@ describe('getSceneTabActions', () => {
     await getSceneTabActions(ManageRightClickPluginsTabKey.PluginExtensionSingle)
     expect(mockQuery).toHaveBeenCalledTimes(1)
     expect(mockQuery.mock.calls[0][0]).toMatchObject({ IncludeDisabled: true })
+  })
+})
+
+describe('isSameAction', () => {
+  it('PluginUUID 与 ActionID 均相同视为同一动作', () => {
+    const a = makeAction({ PluginUUID: 'p1', ActionID: 'a1' })
+    const b = makeAction({ PluginUUID: 'p1', ActionID: 'a1', Shortcut: 'ctrl|k' })
+    expect(isSameAction(a, b)).toBe(true)
+  })
+
+  it('PluginUUID 不同（跨插件同名动作）视为不同动作', () => {
+    const a = makeAction({ PluginUUID: 'p1', ActionID: 'a1' })
+    const b = makeAction({ PluginUUID: 'p2', ActionID: 'a1' })
+    expect(isSameAction(a, b)).toBe(false)
+  })
+
+  it('ActionID 不同（同插件多动作）视为不同动作', () => {
+    const a = makeAction({ PluginUUID: 'p1', ActionID: 'a1' })
+    const b = makeAction({ PluginUUID: 'p1', ActionID: 'a2' })
+    expect(isSameAction(a, b)).toBe(false)
+  })
+
+  it('与匹配无关的字段差异不影响判定', () => {
+    const a = makeAction({ PluginUUID: 'p1', ActionID: 'a1', Enabled: true, Sort: 0 })
+    const b = makeAction({ PluginUUID: 'p1', ActionID: 'a1', Enabled: false, Sort: 3 })
+    expect(isSameAction(a, b)).toBe(true)
+  })
+})
+
+describe('patchAction', () => {
+  it('按唯一标识命中时仅更新目标项的指定字段，其余字段与列表项保持不变', () => {
+    const list = [
+      makeAction({ PluginUUID: 'p1', ActionID: 'a1', Shortcut: '', Sort: 0 }),
+      makeAction({ PluginUUID: 'p1', ActionID: 'a2', Shortcut: 'ctrl|1', Sort: 1 }),
+    ]
+    const next = patchAction(list, { PluginUUID: 'p1', ActionID: 'a2' }, { Shortcut: 'ctrl|9' })
+    expect(next[1].Shortcut).toBe('ctrl|9')
+    expect(next[1].Sort).toBe(1)
+    expect(next[0]).toBe(list[0]) // 未命中项原样保留（引用不变）
+  })
+
+  it('命中项返回新对象，不 mutate 原列表', () => {
+    const list = [makeAction({ PluginUUID: 'p1', ActionID: 'a1', Enabled: false })]
+    const next = patchAction(list, { PluginUUID: 'p1', ActionID: 'a1' }, { Enabled: true })
+    expect(next[0]).not.toBe(list[0])
+    expect(next[0].Enabled).toBe(true)
+    expect(list[0].Enabled).toBe(false)
+  })
+
+  it('无匹配项时列表内容不变', () => {
+    const list = [makeAction({ PluginUUID: 'p1', ActionID: 'a1' })]
+    const next = patchAction(list, { PluginUUID: 'p9', ActionID: 'x9' }, { Enabled: true })
+    expect(next).toEqual(list)
+  })
+
+  it('支持同时补丁多个字段（模拟 toUnboundAction 场景）', () => {
+    const list = [
+      makeAction({ PluginUUID: 'p1', ActionID: 'a1', Enabled: true, Shortcut: 'ctrl|1', ResultMode: 'drawer' }),
+    ]
+    const next = patchAction(
+      list,
+      { PluginUUID: 'p1', ActionID: 'a1' },
+      {
+        Enabled: false,
+        Shortcut: '',
+        ResultMode: 'tab',
+      },
+    )
+    expect(next[0]).toMatchObject({ Enabled: false, Shortcut: '', ResultMode: 'tab' })
   })
 })

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/utils.test.ts
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/utils.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ManageRightClickPluginsTabKey } from '../constants'
+import { ContextMenuExecutionType, type ContextMenuAction } from '../types'
+
+// utils.ts 顶部引入了依赖 Electron bridge 的模块，测试中全部打桩，避免 window.require 报错
+vi.mock('@/apiUtils/grpc', () => ({ grpcFetchLocalYakVersion: vi.fn() }))
+vi.mock('@/utils/notification', () => ({ yakitFailed: vi.fn() }))
+vi.mock('@/constants/hardware', () => ({ SystemInfo: { mode: 'local' } }))
+vi.mock('@/i18n/i18n', () => ({ default: { getFixedT: () => (k: string) => k } }))
+vi.mock('../api', () => ({ grpcQueryContextMenuActions: vi.fn() }))
+
+import { grpcQueryContextMenuActions } from '../api'
+import { getSceneTabActions } from '../utils'
+
+const mockQuery = grpcQueryContextMenuActions as ReturnType<typeof vi.fn>
+
+const makeAction = (over: Partial<ContextMenuAction>): ContextMenuAction =>
+  ({
+    ActionID: 'a1',
+    Enabled: true,
+    ExecutionType: ContextMenuExecutionType.ContextMenu,
+    ...over,
+  }) as ContextMenuAction
+
+beforeEach(() => {
+  mockQuery.mockReset()
+})
+
+describe('getSceneTabActions', () => {
+  it('无效 tabKey 时返回空列表并标记 noData，且不调用 grpc', async () => {
+    const res = await getSceneTabActions('unknown-key')
+    expect(res).toEqual({ list: [], noData: true })
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+
+  it('引擎返回空 Actions 时为空态（noData: true）', async () => {
+    mockQuery.mockResolvedValueOnce({ Actions: [], EnabledCustomPluginCount: 0, MaxCustomPluginCount: 0 })
+    const res = await getSceneTabActions(ManageRightClickPluginsTabKey.PluginExtensionSingle)
+    expect(res).toEqual({ list: [], noData: true })
+  })
+
+  it('仅存在禁用项时 list 为空但 noData 为 false（区分“无数据”与“有数据全禁用”）', async () => {
+    const disabled = makeAction({ ActionID: 'd1', Enabled: false })
+    mockQuery.mockResolvedValueOnce({ Actions: [disabled], EnabledCustomPluginCount: 0, MaxCustomPluginCount: 0 })
+    const res = await getSceneTabActions(ManageRightClickPluginsTabKey.PluginExtensionSingle)
+    expect(res.list).toEqual([])
+    expect(res.noData).toBe(false)
+  })
+
+  it('含启用项时 list 仅保留启用项且 noData 为 false', async () => {
+    const enabled = makeAction({ ActionID: 'e1', Enabled: true })
+    const disabled = makeAction({ ActionID: 'd1', Enabled: false })
+    mockQuery.mockResolvedValueOnce({
+      Actions: [enabled, disabled],
+      EnabledCustomPluginCount: 1,
+      MaxCustomPluginCount: 0,
+    })
+    const res = await getSceneTabActions(ManageRightClickPluginsTabKey.PluginExtensionSingle)
+    expect(res.list.map((a) => a.ActionID)).toEqual(['e1'])
+    expect(res.noData).toBe(false)
+  })
+
+  it('grpc 抛错时回退到空态（noData: true）', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('network'))
+    const res = await getSceneTabActions(ManageRightClickPluginsTabKey.PluginExtensionSingle)
+    expect(res).toEqual({ list: [], noData: true })
+  })
+
+  it('查询参数携带 IncludeDisabled: true', async () => {
+    mockQuery.mockResolvedValueOnce({ Actions: [], EnabledCustomPluginCount: 0, MaxCustomPluginCount: 0 })
+    await getSceneTabActions(ManageRightClickPluginsTabKey.PluginExtensionSingle)
+    expect(mockQuery).toHaveBeenCalledTimes(1)
+    expect(mockQuery.mock.calls[0][0]).toMatchObject({ IncludeDisabled: true })
+  })
+})

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/api.ts
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/api.ts
@@ -1,6 +1,7 @@
 import i18n from '@/i18n/i18n'
 import type { APIFunc, APIOptionalFunc } from '@/apiUtils/type'
 import { yakitNotify } from '@/utils/notification'
+import type { YakScript } from '@/pages/invoker/schema'
 import type {
   ContextMenuAction,
   ExecuteContextMenuActionRequest,
@@ -49,6 +50,30 @@ export const grpcSetContextMenuActionBinding: APIFunc<SetContextMenuActionBindin
       .catch((e) => {
         if (!hiddenError)
           yakitNotify('error', tOriginal('grpc.setContextMenuActionBindingFailed', { error: String(e) }))
+        reject(e)
+      })
+  })
+}
+
+interface FetchLocalPluginDetailByUUIDRequest {
+  UUID: string
+}
+/** @name 通过 UUID 查询本地插件详情 */
+export const grpcFetchLocalPluginDetailByUUID: APIFunc<FetchLocalPluginDetailByUUIDRequest, YakScript> = (
+  request,
+  hiddenError,
+) => {
+  return new Promise(async (resolve, reject) => {
+    if (!request?.UUID) {
+      if (!hiddenError) yakitNotify('error', tOriginal('grpc.fetchPluginDetailFailedNoUUID'))
+      reject(tOriginal('grpc.fetchPluginDetailFailedNoUUID'))
+      return
+    }
+    ipcRenderer
+      .invoke('GetYakScriptByOnlineID', { UUID: request.UUID })
+      .then(resolve)
+      .catch((e) => {
+        if (!hiddenError) yakitNotify('error', tOriginal('grpc.fetchPluginDetailFailed', { error: String(e) }))
         reject(e)
       })
   })

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/shortcut.ts
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/shortcut.ts
@@ -1,0 +1,191 @@
+import i18n from '@/i18n/i18n'
+import { GetReleaseEdition } from '@/utils/envfile'
+import { pageEventMaps, ShortcutKeyPage, type ShortcutKeyPageName } from '@/utils/globalShortcutKey/events/pageMaps'
+import { isConflictToYakEditor } from '@/utils/globalShortcutKey/events/page/yakEditor'
+import { sortKeysCombination } from '@/utils/globalShortcutKey/shortcutKeyCore'
+import { grpcQueryContextMenuActions } from './api'
+import { ContextMenuScene, type ContextMenuAction, type ContextMenuScene as ContextMenuSceneType } from './types'
+
+const tOriginal = i18n.getFixedT(null, ['manageRightClickPlugins', 'shortcutKey', 'utils', 'yakitUi', 'history'])
+
+/** 将按键数组序列化为引擎 Shortcut 字符串（与全局快捷键录制格式一致） */
+export const serializeContextMenuShortcut = (keys: string[]): string => {
+  if (!keys.length) return ''
+  return sortKeysCombination(keys).join('|')
+}
+
+/** 解析引擎 Shortcut 字符串为按键数组 */
+export const parseContextMenuShortcut = (shortcut?: string): string[] => {
+  if (!shortcut || !shortcut.trim()) return []
+  return shortcut.split('|').filter(Boolean)
+}
+
+export interface CheckContextMenuShortcutConflictOptions {
+  /** 当前右键场景：仅数据包场景检测 Monaco 编辑器内置冲突 */
+  scene?: ContextMenuSceneType
+  /** 同场景其他已启用插件（用于插件间冲突） */
+  siblings?: ContextMenuAction[]
+  /** 当前正在编辑的插件，比对时排除自身 */
+  exclude?: Pick<ContextMenuAction, 'PluginUUID' | 'ActionID'>
+}
+
+interface CachedContextMenuShortcut {
+  PluginUUID: string
+  ActionID: string
+  PluginName: string
+  Shortcut: string
+  Scene: string
+}
+
+/** 已启用且已绑定 Shortcut 的右键插件缓存（供原快捷键设置页同步冲突检测） */
+let cachedEnabledShortcuts: CachedContextMenuShortcut[] = []
+
+/** 从引擎刷新右键插件快捷键缓存；返回刷新后的缓存条目数（grpc 失败保留旧缓存，返回旧条目数） */
+export const refreshContextMenuShortcutCache = async (): Promise<number> => {
+  try {
+    const res = await grpcQueryContextMenuActions({ IncludeDisabled: false }, true)
+    cachedEnabledShortcuts = (res.Actions || [])
+      .filter((action) => action.Enabled && !!action.Shortcut)
+      .map((action) => ({
+        PluginUUID: action.PluginUUID,
+        ActionID: action.ActionID,
+        PluginName: action.PluginName,
+        Shortcut: action.Shortcut,
+        Scene: action.Scene,
+      }))
+  } catch {
+    // 保留旧缓存，避免瞬时失败导致误报无冲突
+  }
+  return cachedEnabledShortcuts.length
+}
+
+/** 当前缓存快照（供录制比对前判断缓存是否已就绪，避免用空缓存漏报冲突） */
+export const getEnabledContextMenuShortcuts = (): CachedContextMenuShortcut[] => cachedEnabledShortcuts
+
+/** 原快捷键设置页与右键插件场景的运行时重叠（空数组表示无重叠、不比对） */
+const SHORTCUT_PAGE_CONTEXT_MENU_SCENES: Record<ShortcutKeyPageName, ContextMenuSceneType[]> = {
+  // 全局快捷键到处生效，与所有右键场景都可能冲突
+  [ShortcutKeyPage.Global]: [
+    ContextMenuScene.HTTPPacket,
+    ContextMenuScene.HistorySingle,
+    ContextMenuScene.HistoryMulti,
+  ],
+  // 编辑器快捷键 ↔ 数据包右键插件
+  [ShortcutKeyPage.YakEditor]: [ContextMenuScene.HTTPPacket],
+  // 多页面快捷键 ↔ History 单/多选右键插件
+  [ShortcutKeyPage.YakitMultiple]: [ContextMenuScene.HistorySingle, ContextMenuScene.HistoryMulti],
+  // 以下页面与右键插件无运行时触发重叠
+  [ShortcutKeyPage.HTTPFuzzer]: [],
+  [ShortcutKeyPage.Mitm]: [],
+  [ShortcutKeyPage.PluginHub]: [],
+  [ShortcutKeyPage.YakRunner]: [],
+  [ShortcutKeyPage.ChatCS]: [],
+  [ShortcutKeyPage.YakRunner_Audit_Code]: [],
+  [ShortcutKeyPage.YakRunnerAiCodeAudit]: [],
+  [ShortcutKeyPage.HotPatchManagement]: [],
+}
+
+/** 原快捷键页 → 需要比对的右键插件场景；未传 page 时比对全部场景 */
+const shortcutPageToContextMenuScenes = (page?: ShortcutKeyPageName): ContextMenuSceneType[] | undefined => {
+  if (!page) return undefined
+  return SHORTCUT_PAGE_CONTEXT_MENU_SCENES[page] ?? []
+}
+
+/**
+ * 原快捷键系统录制时：检测是否与已启用右键插件 Shortcut 冲突（依赖缓存，需先 refresh）
+ * @param page 当前快捷键设置页 tab，按运行时重叠场景过滤比对范围
+ */
+export const findContextMenuPluginShortcutConflict = (keys: string[], page?: ShortcutKeyPageName): string => {
+  if (!keys.length) return ''
+  const scenes = shortcutPageToContextMenuScenes(page)
+  // 显式空数组：当前页与右键插件无重叠，不比对
+  if (scenes && scenes.length === 0) return ''
+
+  const triggerKeys = sortKeysCombination(keys).join('')
+  for (const item of cachedEnabledShortcuts) {
+    if (scenes && !scenes.includes(item.Scene as ContextMenuSceneType)) continue
+    const bound = parseContextMenuShortcut(item.Shortcut)
+    if (!bound.length) continue
+    if (sortKeysCombination(bound).join('') === triggerKeys) {
+      return tOriginal('ShortcutKey.contextMenuPluginConflict', { name: item.PluginName })
+    }
+  }
+  return ''
+}
+
+/** 右键场景 → 原快捷键设置页：与 shouldCheckSystemPage 共用映射的反向判断 */
+const shouldCheckSystemPage = (page: ShortcutKeyPageName, scene?: ContextMenuSceneType): boolean => {
+  if (!scene) return true
+  const scenes = SHORTCUT_PAGE_CONTEXT_MENU_SCENES[page]
+  if (!scenes) return true
+  // 该系统页与当前右键场景无重叠则跳过
+  if (scenes.length === 0) return false
+  return scenes.includes(scene)
+}
+
+/** 与原快捷键系统比对冲突 */
+const findSystemShortcutConflict = (triggerKeys: string, scene?: ContextMenuSceneType): string => {
+  const edition = GetReleaseEdition()
+  for (const page of Object.keys(pageEventMaps) as ShortcutKeyPageName[]) {
+    if (!shouldCheckSystemPage(page, scene)) continue
+    const pageInfo = pageEventMaps[page]
+    if (pageInfo.scopeShow && !pageInfo.scopeShow.includes(edition)) continue
+
+    const events = pageInfo.getEvents()
+    for (const eventKey of Object.keys(events)) {
+      const event = events[eventKey]
+      if (!event?.keys?.length) continue
+      if (event.scopeShow && !event.scopeShow.includes(edition)) continue
+      if (sortKeysCombination(event.keys).join('') === triggerKeys) {
+        const name = tOriginal(event.name)
+        return tOriginal('ManageRightClickPlugins.systemShortcutConflict', { name })
+      }
+    }
+  }
+  return ''
+}
+
+/**
+ * 检测右键插件快捷键冲突（警告不拦截，提示重新设置）
+ * - 仅数据包场景：Monaco 编辑器内置快捷键（isConflictToYakEditor）
+ * - 原快捷键系统（按场景缩小范围）
+ * - 同场景其他已启用插件 Shortcut
+ */
+export const checkContextMenuShortcutConflict = (
+  keys: string[],
+  options: CheckContextMenuShortcutConflictOptions = {},
+): string => {
+  if (!keys.length) return ''
+
+  const { scene, siblings = [], exclude } = options
+
+  // 仅数据包右键（作用于编辑器）需要检测 Monaco 内置冲突；History 单/多选作用于表格，跳过
+  if (scene === ContextMenuScene.HTTPPacket) {
+    const editorConflict = isConflictToYakEditor(keys)
+    if (editorConflict) return editorConflict
+  }
+
+  const triggerKeys = sortKeysCombination(keys).join('')
+  const systemConflict = findSystemShortcutConflict(triggerKeys, scene)
+  if (systemConflict) return systemConflict
+
+  for (const action of siblings) {
+    if (!action.Enabled) continue
+    if (exclude && action.PluginUUID === exclude.PluginUUID && action.ActionID === exclude.ActionID) {
+      continue
+    }
+    const siblingKeys = parseContextMenuShortcut(action.Shortcut)
+    if (!siblingKeys.length) continue
+    if (sortKeysCombination(siblingKeys).join('') === triggerKeys) {
+      return tOriginal('ManageRightClickPlugins.pluginShortcutConflict', { name: action.PluginName })
+    }
+  }
+  return ''
+}
+
+/** 判断按键事件是否命中指定 Shortcut 字符串 */
+export const matchContextMenuShortcut = (eventKeys: string[], shortcut?: string): boolean => {
+  const bound = parseContextMenuShortcut(shortcut)
+  if (!bound.length || !eventKeys.length) return false
+  return sortKeysCombination(bound).join('') === sortKeysCombination(eventKeys).join('')
+}

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/types.ts
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/types.ts
@@ -2,6 +2,9 @@ import type { ExecResult } from '@/pages/invoker/schema'
 import type { YakExecutorParam } from '@/pages/invoker/YakExecutorParams'
 import type { YakParamProps } from '@/pages/plugins/pluginsType'
 
+/** codec 兼容插件类型：不支持配置结果展示方式，沿用旧 CODEC 行为 */
+export const LEGACY_CONTEXT_MENU_PLUGIN_TYPE = 'codec'
+
 export const ContextMenuScene = {
   HistorySingle: 'history-single',
   HistoryMulti: 'history-multi',
@@ -12,7 +15,7 @@ export type ContextMenuScene = (typeof ContextMenuScene)[keyof typeof ContextMen
 
 /** 执行结果展示方式 */
 export const ContextMenuResultMode = {
-  Auto: 'auto',
+  Auto: 'auto', // 默认新开tab展示
   Dialog: 'dialog',
   Drawer: 'drawer',
   Tab: 'tab',

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/utils.ts
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/utils.ts
@@ -43,6 +43,19 @@ export const fetchSceneActions = async (tabKey: string): Promise<ContextMenuActi
   return response.Actions
 }
 
+/** 动作唯一标识是否相同 */
+export const isSameAction = (
+  a: Pick<ContextMenuAction, 'PluginUUID' | 'ActionID'>,
+  b: Pick<ContextMenuAction, 'PluginUUID' | 'ActionID'>,
+) => a.PluginUUID === b.PluginUUID && a.ActionID === b.ActionID
+
+/** 按唯一标识给列表项打补丁（无匹配则原样返回） */
+export const patchAction = (
+  list: ContextMenuAction[],
+  target: Pick<ContextMenuAction, 'PluginUUID' | 'ActionID'>,
+  patch: Partial<ContextMenuAction>,
+) => list.map((i) => (isSameAction(i, target) ? { ...i, ...patch } : i))
+
 export const getSceneTabActions = async (tabKey: string): Promise<{ list: ContextMenuAction[]; noData: boolean }> => {
   const scene = getSceneByTabKey(tabKey)
   if (!scene) return { list: [], noData: true }

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/utils.ts
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/utils.ts
@@ -43,15 +43,16 @@ export const fetchSceneActions = async (tabKey: string): Promise<ContextMenuActi
   return response.Actions
 }
 
-export const getSceneTabActions = async (tabKey: string): Promise<{ list: ContextMenuAction[] }> => {
+export const getSceneTabActions = async (tabKey: string): Promise<{ list: ContextMenuAction[]; noData: boolean }> => {
   const scene = getSceneByTabKey(tabKey)
-  if (!scene) return { list: [] }
+  if (!scene) return { list: [], noData: true }
   try {
-    const response = await grpcQueryContextMenuActions({ Scene: scene }, true)
+    const response = await grpcQueryContextMenuActions({ Scene: scene, IncludeDisabled: true }, true)
     return {
       list: response.Actions.filter((action) => action.Enabled),
+      noData: response.Actions.length === 0,
     }
   } catch {
-    return { list: [] }
+    return { list: [], noData: true }
   }
 }

--- a/app/renderer/src/main/src/pages/pluginEditor/editorCode/EditorCode.tsx
+++ b/app/renderer/src/main/src/pages/pluginEditor/editorCode/EditorCode.tsx
@@ -545,6 +545,9 @@ export const EditorCode: React.FC<EditorCodeProps> = memo(
                 {pluginTypeToName[type]?.name || type}
               </YakitTag>
             )}
+            {type === 'context-menu' && (
+              <YakitTag color="blue">{t('pluginEditor.contextMenuSaveAndTriggerShort')}</YakitTag>
+            )}
             <div className={classNames(styles['title-style'], 'yakit-content-single-ellipsis')} title={name || ''}>
               {name || ''}
             </div>
@@ -633,7 +636,6 @@ export const EditorCode: React.FC<EditorCodeProps> = memo(
                       ))}
                   </div>
                 </div>
-                {type === 'context-menu' && <YakitTag color="blue">保存后从场景右键菜单执行</YakitTag>}
               </div>
               <div className={styles['container']}>
                 <div className={styles['form-wrapper']}>

--- a/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard.tsx
+++ b/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard.tsx
@@ -483,7 +483,7 @@ export const LocalPluginExecuteDetailHeard: React.FC<PluginExecuteDetailHeardPro
                   <>
                     {!isExpand &&
                       (isContextMenuPlugin ? (
-                        <YakitButton disabled>从右键菜单执行</YakitButton>
+                        <YakitButton disabled>{t('pluginEditor.executeFromRightClickMenu')}</YakitButton>
                       ) : (
                         <YakitButton onClick={onExecuteInTop}>执行</YakitButton>
                       ))}

--- a/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/PluginExecuteExtraParams.tsx
+++ b/app/renderer/src/main/src/pages/plugins/operator/localPluginExecuteDetailHeard/PluginExecuteExtraParams.tsx
@@ -43,6 +43,7 @@ interface PluginExecuteExtraParamsProps extends JsonFormSchemaListWrapper {
   setVisible: (b: boolean) => void
   onSave: (value: { customValue: CustomPluginExecuteFormValue; fixedValue: PluginExecuteExtraFormValue }) => void
   refreshValue?: number
+  getContainer?: HTMLElement
 }
 
 export interface PluginExecuteExtraParamsRefProps {
@@ -51,6 +52,7 @@ export interface PluginExecuteExtraParamsRefProps {
 const PluginExecuteExtraParams: React.FC<PluginExecuteExtraParamsProps> = React.memo(
   React.forwardRef((props, ref) => {
     const {
+      getContainer,
       pluginType,
       customPluginParams = [],
       hiddenFixedParams,
@@ -176,6 +178,7 @@ const PluginExecuteExtraParams: React.FC<PluginExecuteExtraParamsProps> = React.
         onClose={onClose}
         width="max(700px, 40%)"
         title="额外参数"
+        getContainer={getContainer}
       >
         {pluginParamsNodeByPluginType(pluginType)}
       </YakitDrawer>

--- a/app/renderer/src/main/src/pages/shortcutKey/ShortcutKey.tsx
+++ b/app/renderer/src/main/src/pages/shortcutKey/ShortcutKey.tsx
@@ -23,6 +23,10 @@ import { type GlobalShortcutKey } from '@/utils/globalShortcutKey/events/global'
 import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
 import { failed } from '@/utils/notification'
 import { type TFunction, useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import {
+  findContextMenuPluginShortcutConflict,
+  refreshContextMenuShortcutCache,
+} from '@/pages/manageRightClickPlugins/shortcut'
 
 const getShortcutPageName = (page, t: TFunction) => {
   if (page === 'global') {
@@ -78,8 +82,10 @@ export const ShortcutKey: React.FC<ShortcutKeyProps> = memo((props) => {
 
   const editInfo = useRef<string>('')
   const [keyShow, setKeyShow] = useState(false)
-  const handleOpenKeyShow = useMemoizedFn((key: string) => {
+  const handleOpenKeyShow = useMemoizedFn(async (key: string) => {
     if (keyShow) return
+    // 录制比对依赖右键插件快捷键缓存：先刷新完成再打开弹窗，避免 grpc 未返回时用旧缓存漏报冲突
+    await refreshContextMenuShortcutCache()
     setIsActiveShortcutKeyPage(true)
     editInfo.current = key
     setKeyShow(true)
@@ -115,9 +121,10 @@ export const ShortcutKey: React.FC<ShortcutKeyProps> = memo((props) => {
         } else if (result[1] === YakitKeyBoard.Enter) {
           handleCallbackKeyShow(true)
         } else {
-          const info = isConflictToYakEditor(result[1].split('|') as YakitKeyBoard[])
+          const keys = result[1].split('|') as YakitKeyBoard[]
+          const info = isConflictToYakEditor(keys) || findContextMenuPluginShortcutConflict(keys, page)
           setWarnInfo(info)
-          setInputKeys(result[1].split('|') as YakitKeyBoard[])
+          setInputKeys(keys)
         }
       }
     }

--- a/app/renderer/src/main/src/routes/newRoute.tsx
+++ b/app/renderer/src/main/src/routes/newRoute.tsx
@@ -1108,7 +1108,7 @@ export const RouteToPage: (props: PageItemProps) => ReactNode = (props) => {
       const pageInfo = params?.contextMenuResultPageInfo
       return pageInfo?.executionID ? (
         <Suspense fallback={<PageLoading />}>
-          <ContextMenuActionExecution pageId={params?.id || ''} mode="tab" />
+          <ContextMenuActionExecution executionID={pageInfo.executionID} mode="tab" />
         </Suspense>
       ) : (
         <div />

--- a/app/renderer/src/main/src/utils/globalShortcutKey/utils.ts
+++ b/app/renderer/src/main/src/utils/globalShortcutKey/utils.ts
@@ -25,6 +25,7 @@ export const registerShortcutFocusHandle = (page: string[]) => {
 export const unregisterShortcutFocusHandle = (page: string) => {
   if (currentFocus && currentFocus.includes(page)) currentFocus = currentFocus.filter((item) => item !== page)
 }
+export const getCurrentShortcutFocus = () => currentFocus
 
 /** 是否激活了快捷键设置页面 */
 let isActiveShortcutKeyPage = false
@@ -32,7 +33,7 @@ let isActiveShortcutKeyPage = false
 export const setIsActiveShortcutKeyPage = (flag: boolean) => {
   isActiveShortcutKeyPage = flag
 }
-const getIsActiveShortcutKeyPage = () => {
+export const getIsActiveShortcutKeyPage = () => {
   return isActiveShortcutKeyPage
 }
 


### PR DESCRIPTION
## PR 说明

**标题**：`feat: 右键插件结果支持弹窗、抽屉、新页签与快捷键执行`

### 改动说明

- **执行结果多模式展示**：右键插件执行结果支持「弹窗 / 右侧抽屉 / 新页签」三种展示方式，可在右键插件管理页按插件配置
- **快捷键执行**：右键插件支持绑定快捷键，History 表格与数据包编辑器内选中后可直接按键触发，无需右键
- **管理页增强**：已选插件新增编辑按钮，可直接打开插件编辑抽屉；菜单项展示已绑定的快捷键
- **空态引导**：未安装插件时右键菜单提供「获取插件」入口，直达插件市场
- **详情查询优化**：插件详情改用 UUID 通道查询，插件重命名后编辑与执行页仍可正常加载

### AI 代码审查修复

本分支代码经 AI 辅助代码审查，识别并修复了以下高风险问题：

1. **保存竞态**：清空 / 移除 / 快捷键 / 结果模式等保存入口在请求在途期间未持锁，与拖拽排序并发时会交叉写入，可能产生「UI 已移除但右键菜单仍可执行」的插件，或新配置被旧值静默覆盖。现所有保存入口统一在途持锁。
2. **快捷键吞输入**：插件快捷键的全局监听缺少输入框焦点守卫，焦点在搜索框 / 筛选框时按键会被拦截吞掉。现焦点位于输入框 / 文本域 / 下拉框时不再拦截。
3. **编辑器内置快捷键被覆盖**：插件快捷键与编辑器内置菜单快捷键同组合时，后注册者会静默覆盖内置行为。现注册时同组合先到先得，内置菜单快捷键天然优先。

### 测试

- 新增 shortcut / utils / constants / api / HTTPFlowTable.utils / menuHelpers 单测共 40+ 用例，全部通过；TypeScript 类型检查与 ESLint 通过

<img width="1140" height="814" alt="image" src="https://github.com/user-attachments/assets/e112b090-edbe-421c-aaec-825f531b5b72" />

### 合并方式二

---