### PR TITLE
fix(i18n): 预加载 apiUtils namespace 避免模块顶层 getFixedT 翻译时返回 key

### DIFF
--- a/app/renderer/src/main/src/i18n/i18n.ts
+++ b/app/renderer/src/main/src/i18n/i18n.ts
@@ -34,6 +34,7 @@ i18n
       'aiAgent',
       'projectManage',
       'irifyHome',
+      'apiUtils',
     ] satisfies I18nNamespace[], // 这几个需要预加载
     load: 'currentOnly',
     defaultNS: '',


### PR DESCRIPTION
### 问题

`app/renderer/src/main/src/apiUtils/grpc.ts` 与 `app/renderer/src/main/src/apiUtils/http.ts` 在模块顶层调用了 `i18n.getFixedT`：

```ts
// apiUtils/grpc.ts:8
const tOriginal = i18n.getFixedT(null, 'apiUtils')
// apiUtils/http.ts:8
const tOriginal = i18n.getFixedT(null, ['apiUtils', 'yakitUi'])
```

而翻译资源经 `resourcesToBackend` 按 (语言, namespace) 动态 import 懒加载，`apiUtils` 此前不在 `i18n.init` 的 `ns` 预加载列表中。这两个模块在对应 JSON chunk 加载完成前就执行了 `getFixedT`，启动早期触发的翻译调用（如 API 调用失败时 `yakitNotify` 弹出的错误提示）会直接返回原始 key（例如 `grpc.fetchLatestYakitVersionFailed`）而非翻译后的文案。

### 修复

在 `app/renderer/src/main/src/i18n/i18n.ts` 的 `ns` 预加载数组中加入 `'apiUtils'`，使其随 i18n 初始化一起加载，模块顶层的 `getFixedT` 即可正常取到翻译资源。

### 验证

- 启动应用后触发 apiUtils 相关的错误提示，确认显示翻译文案而非 key
- 切换语言（zh / en / zh-TW）后再次触发，翻译正常

### 合并方式二