### PR TITLE
feat(ai-agent): 新增 DisableMemoryTriage 开关，支持禁用智能记忆处理

### DIFF
--- a/app/protos/grpc.proto
+++ b/app/protos/grpc.proto
@@ -2320,6 +2320,10 @@ message AIStartParams {
 
   // 执行策略集合。用于承载 multi-agent / goal mode 等顶层运行策略。
   AIExecutionStrategy Strategy = 48;
+
+  // 为 true 时禁用 Memory Triage（智能记忆处理），不创建 AIMemory 实例，
+  // 跳过 embedding/DB/AI 调用。适用于轻量级或无状态会话。
+  bool DisableMemoryTriage = 49;
 }
 
 message AIExecutionStrategy {

--- a/app/renderer/src/main/src/components/withHistoryAIReActChat.tsx
+++ b/app/renderer/src/main/src/components/withHistoryAIReActChat.tsx
@@ -447,6 +447,7 @@ export const HistoryAIReActChatProvider = memo(function HistoryAIReActChatProvid
       TimelineSessionID: createActiveChatSessionId(),
       SyncPerceptionTrigger: false,
       EnablePlan: false,
+      DisableMemoryTriage: AIAgentSettingDefault.DisableMemoryTriage,
       Strategy: {
         EnableMultiAgent: false,
         EnableGoalMode: false,

--- a/app/renderer/src/main/src/pages/ai-agent/AIAgent.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/AIAgent.tsx
@@ -112,6 +112,7 @@ export const AIAgent: React.FC<AIAgentProps> = (props) => {
         ...newCache,
         SyncPerceptionTrigger: false,
         EnablePlan: false,
+        DisableMemoryTriage: newCache?.DisableMemoryTriage ?? AIAgentSettingDefault.DisableMemoryTriage,
         Strategy: {
           EnableMultiAgent: false,
           EnableGoalMode: false,

--- a/app/renderer/src/main/src/pages/ai-agent/AIAgent.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/AIAgent.tsx
@@ -112,7 +112,7 @@ export const AIAgent: React.FC<AIAgentProps> = (props) => {
         ...newCache,
         SyncPerceptionTrigger: false,
         EnablePlan: false,
-        DisableMemoryTriage: newCache?.DisableMemoryTriage ?? AIAgentSettingDefault.DisableMemoryTriage,
+        DisableMemoryTriage: AIAgentSettingDefault.DisableMemoryTriage,
         Strategy: {
           EnableMultiAgent: false,
           EnableGoalMode: false,

--- a/app/renderer/src/main/src/pages/ai-agent/AIChatSetting/AIChatSetting.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/AIChatSetting/AIChatSetting.tsx
@@ -241,6 +241,7 @@ const AIChatSetting: React.FC<AIChatSettingProps> = memo((props) => {
                     UseDefaultAIConfig: AIAgentSettingDefault.UseDefaultAIConfig,
                     EnableAISearchTool: AIAgentSettingDefault.EnableAISearchTool,
                     DisableToolUse: AIAgentSettingDefault.DisableToolUse,
+                    DisableMemoryTriage: AIAgentSettingDefault.DisableMemoryTriage,
                     AICallAutoRetry: AIAgentSettingDefault.AICallAutoRetry,
                     AITransactionRetry: AIAgentSettingDefault.AITransactionRetry,
                   }
@@ -272,6 +273,24 @@ const AIChatSetting: React.FC<AIChatSettingProps> = memo((props) => {
                 </>
               }
               name="DisableToolUse"
+              valuePropName="checked"
+            >
+              <YakitSwitch />
+            </Form.Item>
+
+            <Form.Item
+              label={
+                <>
+                  禁用智能记忆处理
+                  <Tooltip
+                    classNames={{ root: styles['form-info-icon-tooltip'] }}
+                    title={'开启后不创建 AIMemory 实例，跳过 embedding/DB/AI 调用，适用于轻量级或无状态会话'}
+                  >
+                    <OutlineInformationcircleIcon className={styles['info-icon']} />
+                  </Tooltip>
+                </>
+              }
+              name="DisableMemoryTriage"
               valuePropName="checked"
             >
               <YakitSwitch />

--- a/app/renderer/src/main/src/pages/ai-agent/ChatSessionPane/ChatSessionPane.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/ChatSessionPane/ChatSessionPane.tsx
@@ -26,6 +26,7 @@ const ChatSessionPane: React.FC = memo(() => {
       ...old,
       SyncPerceptionTrigger: info?.StartParams?.SyncPerceptionTrigger ?? false,
       EnablePlan: info?.StartParams?.EnablePlan ?? false,
+      DisableMemoryTriage: info?.StartParams?.DisableMemoryTriage ?? false,
       Strategy: {
         EnableMultiAgent: info?.StartParams?.Strategy?.EnableMultiAgent ?? false,
         EnableGoalMode: info?.StartParams?.Strategy?.EnableGoalMode ?? false,

--- a/app/renderer/src/main/src/pages/ai-agent/aiAgentChat/AIAgentChat.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiAgentChat/AIAgentChat.tsx
@@ -144,6 +144,7 @@ export const AIAgentChat: React.FC<AIAgentChatProps> = memo((props) => {
             ...old,
             SyncPerceptionTrigger: false,
             EnablePlan: false,
+            DisableMemoryTriage: AIAgentSettingDefault.DisableMemoryTriage,
             Strategy: {
               EnableMultiAgent: false,
               EnableGoalMode: false,

--- a/app/renderer/src/main/src/pages/ai-agent/aiScheduledTasks/aiScheduledTasksDetail/AIScheduledTasksDetail.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiScheduledTasks/aiScheduledTasksDetail/AIScheduledTasksDetail.tsx
@@ -199,6 +199,7 @@ const AIScheduledTasksDetail: React.FC<AIScheduledTasksDetailProps> = React.memo
       ...old,
       SyncPerceptionTrigger: relatedSession.StartParams?.SyncPerceptionTrigger ?? false,
       EnablePlan: relatedSession.StartParams?.EnablePlan ?? false,
+      DisableMemoryTriage: relatedSession.StartParams?.DisableMemoryTriage ?? false,
       Strategy: {
         EnableMultiAgent: relatedSession.StartParams?.Strategy?.EnableMultiAgent ?? false,
         EnableGoalMode: relatedSession.StartParams?.Strategy?.EnableGoalMode ?? false,

--- a/app/renderer/src/main/src/pages/ai-agent/defaultConstant.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/defaultConstant.tsx
@@ -122,6 +122,7 @@ export const AIAgentSettingDefault: AIAgentSetting = {
     GoalMinIterations: 0,
     MaxSubAgents: 0,
   },
+  DisableMemoryTriage: false,
   Source: AISourceEnum.aiAgent,
 }
 

--- a/app/renderer/src/main/src/pages/ai-agent/historyChat/HistoryChatList/HistoryChatList.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/historyChat/HistoryChatList/HistoryChatList.tsx
@@ -251,6 +251,7 @@ const HistoryChatList: FC<{
       ...old,
       SyncPerceptionTrigger: info?.StartParams?.SyncPerceptionTrigger ?? false,
       EnablePlan: info?.StartParams?.EnablePlan ?? false,
+      DisableMemoryTriage: info?.StartParams?.DisableMemoryTriage ?? false,
       Strategy: {
         EnableMultiAgent: info?.StartParams?.Strategy?.EnableMultiAgent ?? false,
         EnableGoalMode: info?.StartParams?.Strategy?.EnableGoalMode ?? false,

--- a/app/renderer/src/main/src/pages/ai-agent/utils/__test__/formatAIAgentSetting.test.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/utils/__test__/formatAIAgentSetting.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+// 先于 utils/index 注册 electron stub：index 会拉 ChatMultiSessionController / yakRunner.utils，顶层 window.require('electron')
+import '../../../ai-re-act/hooks/__test__/setupElectron'
+// 导入链会经过 aiGlobalLoading → lottie-web，模块加载期探测 canvas，jsdom 不支持
+vi.mock('lottie-web', () => ({ default: vi.fn() }))
+import { formatAIAgentSetting } from '..'
+import { AIAgentSettingDefault } from '../../defaultConstant'
+
+describe('formatAIAgentSetting', () => {
+  it('DisableMemoryTriage 缺字段时回退默认 false，避免旧缓存漏传', () => {
+    const { DisableMemoryTriage: _omit, ...rest } = AIAgentSettingDefault
+    const result = formatAIAgentSetting(rest)
+    expect(result.DisableMemoryTriage).toBe(AIAgentSettingDefault.DisableMemoryTriage)
+    expect(result.DisableMemoryTriage).toBe(false)
+  })
+
+  it('DisableMemoryTriage 显式 true 原样透传到请求参数', () => {
+    const result = formatAIAgentSetting({ ...AIAgentSettingDefault, DisableMemoryTriage: true })
+    expect(result.DisableMemoryTriage).toBe(true)
+  })
+
+  it('DisableMemoryTriage 显式 false 不被默认值改写', () => {
+    const result = formatAIAgentSetting({ ...AIAgentSettingDefault, DisableMemoryTriage: false })
+    expect(result.DisableMemoryTriage).toBe(false)
+  })
+
+  it('Strategy.GoalMinIterations 缺字段时回退默认 0', () => {
+    const result = formatAIAgentSetting({
+      ...AIAgentSettingDefault,
+      Strategy: { EnableGoalMode: true },
+    })
+    expect(result.Strategy?.GoalMinIterations).toBe(AIAgentSettingDefault.Strategy?.GoalMinIterations)
+    expect(result.Strategy?.GoalMinIterations).toBe(0)
+  })
+
+  it('Strategy.GoalMinIterations 显式值原样透传', () => {
+    const result = formatAIAgentSetting({
+      ...AIAgentSettingDefault,
+      Strategy: { ...AIAgentSettingDefault.Strategy, GoalMinIterations: 5 },
+    })
+    expect(result.Strategy?.GoalMinIterations).toBe(5)
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-agent/utils/index.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/utils/index.ts
@@ -140,6 +140,7 @@ export const formatAIAgentSetting = (setting: AIAgentSetting): AIAgentSetting =>
     }
     data.DisableToolIntervalReview =
       setting.DisableToolIntervalReview ?? AIAgentSettingDefault.DisableToolIntervalReview
+    data.DisableMemoryTriage = setting.DisableMemoryTriage ?? AIAgentSettingDefault.DisableMemoryTriage
   } catch (error) {}
   return { ...data }
 }

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcApi.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcApi.ts
@@ -171,6 +171,13 @@ export interface AIStartParams {
    * 与 EnablePlan 可同时勾选；目前策略侧不支持热更新，变更需下次启动生效。
    */
   Strategy?: AIExecutionStrategy
+
+  /**
+   * 为 true 时禁用 Memory Triage（智能记忆处理），不创建 AIMemory 实例，
+   * 跳过 embedding/DB/AI 调用。适用于轻量级或无状态会话。
+   * @default false
+   */
+  DisableMemoryTriage?: boolean
 }
 
 /** 执行策略，对应后端 AIExecutionStrategy */


### PR DESCRIPTION
## 改动说明

对应 proto `AIStartParams` 新增字段 `DisableMemoryTriage`（field 49），前端配置面板增加「禁用智能记忆处理」开关按钮。

开启后不创建 AIMemory 实例，跳过 embedding/DB/AI 调用，适用于轻量级或无状态会话。

> **关联后端 PR**：https://github.com/yaklang/yaklang/pull/4996

### 改动文件

| 文件 | 改动内容 |
|---|---|
| `protos/grpc.proto` | proto 新增 `DisableMemoryTriage` 字段（已有改动） |
| `hooks/grpcApi.ts` | TypeScript 接口新增 `DisableMemoryTriage` |
| `defaultConstant.tsx` | 默认值 `DisableMemoryTriage: false` |
| `AIChatSetting.tsx` | 自动化面板新增开关及重置逻辑 |
| `utils/index.ts` | `formatAIAgentSetting` 补充默认值回退 |
| `ChatSessionPane.tsx` | 切换会话恢复字段 |
| `HistoryChatList.tsx` | 历史聊天恢复字段 |
| `AIScheduledTasksDetail.tsx` | 定时任务跳转恢复字段 |
| `AIAgentChat.tsx` | 新建会话重置字段 |
| `AIAgent.tsx` | 初始化缓存恢复字段 |