### PR TITLE
refactor: 框选开关改为 TableVirtualResize 内部读取缓存

### DIFF
--- a/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.constants.ts
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.constants.ts
@@ -296,14 +296,12 @@ export interface ColumnAllInfoItem {
 
 export interface AdvancedSetSaveItem {
   backgroundRefresh: boolean
-  dragSelectEnabled: boolean
   binaryDisplayEnabled: boolean
   configColumnsAll: ColumnAllInfoItem[]
 }
 
 export interface AdvancedSetProps {
   showBackgroundRefresh?: boolean
-  dragSelectEnabled?: boolean
   binaryDisplayEnabled?: boolean
   columnsAllStr: string
   onCancel: () => void

--- a/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.tsx
@@ -352,7 +352,6 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
 
   /** ---------- 后台刷新 Start ---------- */
   const [backgroundRefresh, setBackgroundRefresh] = useState<boolean>(false)
-  const [dragSelectEnabled, setDragSelectEnabled] = useState<boolean>(true)
   const binaryDisplayEnabled = useBinaryDisplayEnabled()
   const isBackgroundRefresh = useMemo(() => {
     return backgroundRefresh && pageType !== 'MITM'
@@ -1493,11 +1492,6 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
     getRemoteValue(RemoteHistoryGV.BackgroundRefresh)
       .then((value) => {
         setBackgroundRefresh(!!value)
-      })
-      .catch(() => {})
-    getRemoteValue(RemoteHistoryGV.DragSelectEnabled)
-      .then((value) => {
-        setDragSelectEnabled(value !== 'false')
       })
       .catch(() => {})
   }, [inViewport])
@@ -3341,17 +3335,11 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
     setAdvancedSetVisible(false)
     const {
       backgroundRefresh: newBackgroundRefresh,
-      dragSelectEnabled: newDragSelectEnabled,
       binaryDisplayEnabled: newBinaryDisplayEnabled,
       configColumnsAll,
     } = setting
     // 后台刷新
     if (newBackgroundRefresh !== backgroundRefresh) setBackgroundRefresh(newBackgroundRefresh)
-    // 框选配置
-    if (newDragSelectEnabled !== dragSelectEnabled) {
-      setDragSelectEnabled(newDragSelectEnabled)
-      setRemoteValue(RemoteHistoryGV.DragSelectEnabled, newDragSelectEnabled ? 'true' : 'false')
-    }
     // 二进制展示配置
     if (newBinaryDisplayEnabled !== binaryDisplayEnabled) {
       binaryDisplayEnabledStore.setEnabled(newBinaryDisplayEnabled)
@@ -3403,7 +3391,6 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
           rowSelection={tableRowSelection}
           loading={loading}
           enableDrag={true}
-          enableDragSelection={dragSelectEnabled}
           columns={columns}
           onRowContextMenu={onRowContextMenu}
           pagination={tablePagination}
@@ -3439,7 +3426,6 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
       )}
       {advancedSetVisible && (
         <AdvancedSet
-          dragSelectEnabled={dragSelectEnabled}
           binaryDisplayEnabled={binaryDisplayEnabled}
           columnsAllStr={JSON.stringify(configColumnRef.current.filter((item) => !specialCustoms(item.dataKey)))}
           onCancel={onAdvancedSetCancel}

--- a/app/renderer/src/main/src/components/HTTPFlowTable/components/advancedSet.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/components/advancedSet.tsx
@@ -14,13 +14,13 @@ import { RemoteHistoryGV } from '@/enums/history'
 import { yakitNotify } from '@/utils/notification'
 import { JSONParseLog } from '@/utils/tool'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import emiter from '@/utils/eventBus/eventBus'
 import type { AdvancedSetProps, ColumnAllInfoItem } from '../HTTPFlowTable.constants'
 import style from '../HTTPFlowTable.module.scss'
 
 export const AdvancedSet: React.FC<AdvancedSetProps> = React.memo((props) => {
   const {
     showBackgroundRefresh = true,
-    dragSelectEnabled: propDragSelectEnabled = true,
     binaryDisplayEnabled: propBinaryDisplayEnabled = true,
     columnsAllStr,
     onCancel,
@@ -40,7 +40,17 @@ export const AdvancedSet: React.FC<AdvancedSetProps> = React.memo((props) => {
   /** ---------- 后台刷新 End ---------- */
 
   /** ---------- 框选配置 Start ---------- */
-  const [dragSelectEnabled, setDragSelectEnabled] = useState<boolean>(propDragSelectEnabled)
+  const [dragSelectEnabled, setDragSelectEnabled] = useState<boolean>(true)
+  const oldDragSelectEnabled = useRef<boolean>(true)
+  useEffect(() => {
+    getRemoteValue(RemoteHistoryGV.DragSelectEnabled)
+      .then((e) => {
+        const enabled = e !== 'false'
+        oldDragSelectEnabled.current = enabled
+        setDragSelectEnabled(enabled)
+      })
+      .catch(() => {})
+  }, [])
   /** ---------- 框选配置 End ---------- */
 
   /** ---------- 二进制展示配置 Start ---------- */
@@ -81,7 +91,11 @@ export const AdvancedSet: React.FC<AdvancedSetProps> = React.memo((props) => {
     if (oldBackgroundRefresh.current !== backgroundRefresh) {
       setRemoteValue(RemoteHistoryGV.BackgroundRefresh, backgroundRefresh ? 'true' : '')
     }
-    onSave({ backgroundRefresh, dragSelectEnabled, binaryDisplayEnabled, configColumnsAll: curColumnsAll })
+    if (oldDragSelectEnabled.current !== dragSelectEnabled) {
+      setRemoteValue(RemoteHistoryGV.DragSelectEnabled, dragSelectEnabled ? 'true' : 'false')
+      emiter.emit('onTableDragSelectEnabledChange', dragSelectEnabled ? 'true' : 'false')
+    }
+    onSave({ backgroundRefresh, binaryDisplayEnabled, configColumnsAll: curColumnsAll })
   })
 
   // 判断是否有修改
@@ -91,7 +105,7 @@ export const AdvancedSet: React.FC<AdvancedSetProps> = React.memo((props) => {
       let isModify: boolean = false
       if (
         oldBackgroundRefresh.current !== backgroundRefresh ||
-        propDragSelectEnabled !== dragSelectEnabled ||
+        oldDragSelectEnabled.current !== dragSelectEnabled ||
         propBinaryDisplayEnabled !== binaryDisplayEnabled ||
         columnsAllStr !== JSON.stringify(curColumnsAll)
       ) {

--- a/app/renderer/src/main/src/components/TableVirtualResize/TableVirtualResize.tsx
+++ b/app/renderer/src/main/src/components/TableVirtualResize/TableVirtualResize.tsx
@@ -63,6 +63,9 @@ import { v4 as uuidv4 } from 'uuid'
 import { ShortcutKeyFocusType } from '@/utils/globalShortcutKey/events/global'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { shouldRenderVirtualTableCellForHover } from './TableVirtualResize.memo'
+import { getRemoteValue } from '@/utils/kv'
+import { RemoteHistoryGV } from '@/enums/history'
+import emiter from '@/utils/eventBus/eventBus'
 const { RangePicker } = YakitDatePicker
 
 /**
@@ -207,7 +210,6 @@ const Table = <T extends any>(props: TableVirtualResizeProps<T>) => {
     onRowDoubleClick,
     lineHighlight,
     disableDeselect,
-    enableDragSelection = true,
   } = props
   const { t, i18n } = useI18nNamespaces(['yakitUi'])
   const defItemHeight = useCreation(() => {
@@ -248,6 +250,7 @@ const Table = <T extends any>(props: TableVirtualResizeProps<T>) => {
   const dragSelectionAutoScrollRef = useRef<number>()
   const dragSelectionBoxRef = useRef<DragSelectionBox | null>(null)
   const dragSelectionOverlayRef = useRef<HTMLDivElement>(null)
+  const dragSelectEnabledRef = useRef(true)
   const dragSelectionUserSelectRef = useRef<string | null>(null)
   const skipRowClickAfterDragRef = useRef<boolean>(false)
   const tablePosition = useRef<tablePosition>({
@@ -296,6 +299,20 @@ const Table = <T extends any>(props: TableVirtualResizeProps<T>) => {
   // 性能优化：Shift 多选/框选 batchActive 高亮，替代每 cell findIndex selectedRows
   const selectedRowsKeySet = useMemo(() => new Set(selectedRows.map((r) => r[renderKey])), [selectedRows, renderKey])
 
+  useEffect(() => {
+    getRemoteValue(RemoteHistoryGV.DragSelectEnabled)
+      .then((v) => {
+        dragSelectEnabledRef.current = v !== 'false'
+      })
+      .catch(() => {})
+    const onChange = (v: string) => {
+      dragSelectEnabledRef.current = v !== 'false'
+    }
+    emiter.on('onTableDragSelectEnabledChange', onChange)
+    return () => {
+      emiter.off('onTableDragSelectEnabledChange', onChange)
+    }
+  }, [])
   useEffect(() => {
     setCurrentRow(currentSelectItem)
   }, [currentSelectItem])
@@ -1044,7 +1061,7 @@ const Table = <T extends any>(props: TableVirtualResizeProps<T>) => {
   })
 
   const onMouseDownDragSelection = useMemoizedFn((event: React.MouseEvent<HTMLDivElement>) => {
-    if (!enableDragSelection) return
+    if (!dragSelectEnabledRef.current) return
 
     // 聚焦真实滚动容器，避免焦点在包装层时滚轮边界落到外层
     const focusTarget = (containerRef.current || shortcutFocusRef.current) as HTMLElement | null

--- a/app/renderer/src/main/src/components/TableVirtualResize/TableVirtualResizeType.d.ts
+++ b/app/renderer/src/main/src/components/TableVirtualResize/TableVirtualResizeType.d.ts
@@ -90,8 +90,6 @@ export interface TableVirtualResizeProps<T> {
   lineHighlight?: boolean
   // 禁用表格反选
   disableDeselect?: boolean
-  /** 禁用框选功能 */
-  enableDragSelection?: boolean
 }
 
 export interface SortProps {

--- a/app/renderer/src/main/src/utils/eventBus/events/history.ts
+++ b/app/renderer/src/main/src/utils/eventBus/events/history.ts
@@ -8,4 +8,6 @@ export type HistoryEventProps = {
   onRefreshImportHistoryTable?: string
   onGetAdvancedSearchDataEvent: string
   onGetOtherPageAdvancedSearchDataEvent: string
+  /** History 高级设置变更框选开关 */
+  onTableDragSelectEnabledChange: string
 }


### PR DESCRIPTION
第二个合并方式 P1已确定 用于所有表格
<img width="800" height="829" alt="image" src="https://github.com/user-attachments/assets/c35696ed-7605-4e60-a3c9-a68e37148569" />
