### PR TITLE
luoluo/fix/ai-input

### DIFF
--- a/app/renderer/src/main/src/pages/ai-agent/components/aiMilkdownInput/__test__/unescapeUnderscoreInPath.test.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiMilkdownInput/__test__/unescapeUnderscoreInPath.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// utils.ts 顶部经由 @/components/MilkdownEditor/utils/utils 间接引用了
+// window.require('electron')，与本次纯函数测试无关，桩掉以切断副作用导入链。
+vi.mock('@/components/MilkdownEditor/utils/utils', () => ({
+  imgTypes: ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'],
+}))
+
+import { unescapeUnderscoreInPath } from '../utils'
+
+describe('unescapeUnderscoreInPath', () => {
+  describe('路径上下文：应反转义 \\_ 为 _', () => {
+    it.each([
+      ['Windows 盘符路径', 'D:\\\\project\\_work\\_file.txt', 'D:\\\\project\\_work\\_file.txt'.replace(/\\_/g, '_')],
+      [
+        'Windows 盘符路径带转义下划线',
+        'C:\\\\my\\_folder\\_readme.md',
+        'C:\\\\my\\_folder\\_readme.md'.replace(/\\_/g, '_'),
+      ],
+      ['Unix 绝对路径', '/home/user/my\\_project', '/home/user/my_project'],
+      ['UNC 路径', '\\\\\\\\server\\\\share\\\\my\\_dir', '\\\\\\\\server\\\\share\\\\my_dir'],
+    ])('%s', (_label, input, expected) => {
+      expect(unescapeUnderscoreInPath(input)).toBe(expected)
+    })
+
+    it('Windows 路径 D:\\work\\_file.txt 反转义后下划线还原', () => {
+      // remark-stringify 把 D:\work\_file.txt 中的 _ 转义成 \_
+      const input = 'D:\\\\work\\_file.txt'
+      const output = unescapeUnderscoreInPath(input)
+      expect(output).toBe('D:\\\\work_file.txt')
+      expect(output).not.toContain('\\_')
+    })
+
+    it('Unix 路径 /var/log/my_app_log 反转义', () => {
+      const input = '/var/log/my\\_app\\_log'
+      expect(unescapeUnderscoreInPath(input)).toBe('/var/log/my_app_log')
+    })
+  })
+
+  describe('非路径文本：保持 \\_ 不变', () => {
+    it('普通变量名中的下划线不被处理（无转义）', () => {
+      // 无反斜杠转义的普通文本原样返回
+      expect(unescapeUnderscoreInPath('hello_world')).toBe('hello_world')
+    })
+
+    it('防强调转义 a\\_b 保持不变', () => {
+      expect(unescapeUnderscoreInPath('a\\_b')).toBe('a\\_b')
+    })
+
+    it('markdown 强调上下文中的转义保持不变', () => {
+      expect(unescapeUnderscoreInPath('foo\\_bar\\_baz')).toBe('foo\\_bar\\_baz')
+    })
+  })
+
+  describe('混合内容：仅路径片段被反转义', () => {
+    it('路径前有普通文本', () => {
+      const input = '文件位于 D:\\\\work\\_file.txt 请查看'
+      expect(unescapeUnderscoreInPath(input)).toBe('文件位于 D:\\\\work_file.txt 请查看')
+    })
+
+    it('路径与普通转义文本共存', () => {
+      const input = '路径 /home/my\\_dir 与变量 a\\_b'
+      expect(unescapeUnderscoreInPath(input)).toBe('路径 /home/my_dir 与变量 a\\_b')
+    })
+
+    it('多个路径片段各自反转义', () => {
+      const input = '源 C:\\\\src\\_a 备份 /bak\\_a'
+      expect(unescapeUnderscoreInPath(input)).toBe('源 C:\\\\src_a 备份 /bak_a')
+    })
+  })
+
+  describe('边界', () => {
+    it('空字符串原样返回', () => {
+      expect(unescapeUnderscoreInPath('')).toBe('')
+    })
+
+    it('纯空白原样返回', () => {
+      expect(unescapeUnderscoreInPath('   \t\n')).toBe('   \t\n')
+    })
+
+    it('无下划线转义的路径原样返回', () => {
+      expect(unescapeUnderscoreInPath('/usr/local/bin')).toBe('/usr/local/bin')
+    })
+
+    it('连续空白不丢失', () => {
+      const input = 'a\\_b   /path\\_x'
+      // a_b 片段非路径保持，/path_x 片段是 Unix 路径反转义
+      expect(unescapeUnderscoreInPath(input)).toBe('a\\_b   /path_x')
+    })
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiMilkdownInput/utils.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiMilkdownInput/utils.ts
@@ -141,3 +141,34 @@ ${JSON.stringify(data.param || {}, null, 2)}
 export const getAIImageSuffix = () => {
   return imgTypes.map((ext) => ext.slice(1))
 }
+
+/**
+ * 反转义 getMarkdown() 输出中被 remark-stringify 错误转义的下划线 `\_` → `_`。
+ *
+ * 仅对「路径上下文」的文本片段生效：Windows 盘符路径（D:\\...）、UNC 路径（\\\\server\\...）、
+ * Unix 绝对路径（/...）或包含反斜杠路径分隔符（\\ 后跟非下划线字符）的 token。
+ * 非路径文本（如变量名 hello_world、防强调转义 a\_b）中的 `\_` 保持不变。
+ */
+const isPathLikeToken = (token: string): boolean => {
+  // Windows drive path: D:\... or C:\...
+  if (/^[A-Za-z]:[\\/]/.test(token)) return true
+  // UNC path: \\server\...
+  if (/^\\\\/.test(token)) return true
+  // Unix absolute path: /...
+  if (/^\//.test(token)) return true
+  // Contains backslash path separator: \ followed by non-underscore
+  if (/\\[^_]/.test(token)) return true
+  return false
+}
+
+export const unescapeUnderscoreInPath = (markdown: string): string =>
+  markdown
+    .split(/(\s+)/)
+    .map((part) => {
+      if (/^\s*$/.test(part)) return part
+      if (isPathLikeToken(part)) {
+        return part.replace(/\\_/g, '_')
+      }
+      return part
+    })
+    .join('')

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiTriageChat/AITriageChat.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiTriageChat/AITriageChat.tsx
@@ -19,7 +19,7 @@ import useAIAgentStore from '../../useContext/useStore'
 import type { AIInputEvent } from '@/pages/ai-re-act/hooks/grpcApi'
 import type { AIChatTextareaSubmit } from '../../template/type'
 import { getAIReActRequestParams } from '../../utils'
-import { extractDataWithMilkdown } from '../aiMilkdownInput/utils'
+import { extractDataWithMilkdown, unescapeUnderscoreInPath } from '../aiMilkdownInput/utils'
 import useAIAgentDispatcher from '../../useContext/useDispatcher'
 
 export const AITriageChatContent: React.FC<AITriageChatContentProps> = memo((props) => {
@@ -166,7 +166,9 @@ const AITriageChatContentEdit: React.FC<AITriageChatContentEditProps> = React.me
   })
   const getMarkdownValue = useMemoizedFn(() => {
     const value = editorMilkdown.current?.action(getMarkdown()) || ''
-    return value.replace(/\n+$/, '')
+    // remark-stringify 会将下划线 _ 转义为 \_（强调字符），
+    // 导致路径等含下划线的纯文本被破坏，此处仅对路径上下文反转义还原
+    return unescapeUnderscoreInPath(value.replace(/\n+$/, ''))
   })
   const handleTextareaKeyDown = useMemoizedFn((e) => {
     const keys = convertKeyEventToKeyCombination(e)

--- a/app/renderer/src/main/src/pages/ai-agent/components/aiTriageChat/AITriageChat.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/components/aiTriageChat/AITriageChat.tsx
@@ -19,7 +19,7 @@ import useAIAgentStore from '../../useContext/useStore'
 import type { AIInputEvent } from '@/pages/ai-re-act/hooks/grpcApi'
 import type { AIChatTextareaSubmit } from '../../template/type'
 import { getAIReActRequestParams } from '../../utils'
-import { extractDataWithMilkdown } from '../aiMilkdownInput/utils'
+import { extractDataWithMilkdown, unescapeUnderscoreInPath } from '../aiMilkdownInput/utils'
 import useAIAgentDispatcher from '../../useContext/useDispatcher'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 
@@ -174,7 +174,9 @@ const AITriageChatContentEdit: React.FC<AITriageChatContentEditProps> = React.me
   })
   const getMarkdownValue = useMemoizedFn(() => {
     const value = editorMilkdown.current?.action(getMarkdown()) || ''
-    return value.replace(/\n+$/, '')
+    // remark-stringify 会将下划线 _ 转义为 \_（强调字符），
+    // 导致路径等含下划线的纯文本被破坏，此处仅对路径上下文反转义还原
+    return unescapeUnderscoreInPath(value.replace(/\n+$/, ''))
   })
   const handleTextareaKeyDown = useMemoizedFn((e) => {
     const keys = convertKeyEventToKeyCombination(e)

--- a/app/renderer/src/main/src/pages/ai-agent/template/template.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/template/template.tsx
@@ -37,7 +37,7 @@ import {
 } from '../components/aiMilkdownInput/aiMilkdownMention/aiMentionPlugin'
 import emiter from '@/utils/eventBus/eventBus'
 import type { AIAgentTriggerEventInfo } from '../aiAgentType'
-import { extractDataWithMilkdown, setEditorValue } from '../components/aiMilkdownInput/utils'
+import { extractDataWithMilkdown, setEditorValue, unescapeUnderscoreInPath } from '../components/aiMilkdownInput/utils'
 import { editorViewCtx } from '@milkdown/kit/core'
 import { convertKeyEventToKeyCombination } from '@/utils/globalShortcutKey/utils'
 import { YakitKeyBoard } from '@/utils/globalShortcutKey/keyboard'
@@ -269,7 +269,9 @@ export const AIChatTextarea: React.FC<AIChatTextareaProps> = memo(
     })
     const getMarkdownValue = useMemoizedFn(() => {
       const value = editorMilkdown.current?.action(getMarkdown()) || ''
-      return value.replace(/\n+$/, '')
+      // remark-stringify 会将下划线 _ 转义为 \_（强调字符），
+      // 导致路径等含下划线的纯文本被破坏，此处仅对路径上下文反转义还原
+      return unescapeUnderscoreInPath(value.replace(/\n+$/, ''))
     })
 
     const onUpdateContent = useMemoizedFn((value: string) => {


### PR DESCRIPTION
## 概述

修复 AI 对话输入框 `getMarkdown()` 在序列化 Markdown 时，`remark-stringify` 把路径等纯文本中的下划线 `_` 错误转义为 `\_` 的问题，并补充对应纯函数单测。

## 改动内容

### 新增路径下划线反转义工具函数
- 在 `aiMilkdownInput/utils.ts` 新增 `unescapeUnderscoreInPath` 与私有判定 `isPathLikeToken`：按空白分词，仅对「路径上下文」token（Windows 盘符路径、UNC 路径、Unix 绝对路径、含反斜杠路径分隔符的 token）将其中的 `\_` 反转义为 `_`；非路径文本（如 `hello_world`、防强调转义 `a\_b`）保持不变。

### 两处 `getMarkdownValue` 接入反转义
- `AITriageChat.tsx` 与 `template.tsx` 的 `getMarkdownValue` 在原有 `replace(/\n+$/, '')` 之后，包一层 `unescapeUnderscoreInPath`，确保提交给下游的 Markdown 文本中路径下划线不被破坏。

### 单测
- 新增 `unescapeUnderscoreInPath.test.ts`，覆盖路径上下文反转义、非路径文本保持不变、混合内容仅反转义路径片段、空串/纯空白/连续空白等边界，共 16 条用例。

## 影响范围

AI 对话输入框（AI Triage Chat、AI Chat Textarea）提交内容中包含下划线的路径文本不再被错误转义为 `\_`，其他含下划线的普通文本/变量名/防强调转义不受影响。

## 建议合并前修复的问题

本次评审未发现建议合并前修复的问题。

## 合并方式

请使用 **Squash and merge** 合并。