### PR TITLE
fix: 右键菜单三级子菜单右侧空间不足时优先向左展开，简化批量解绑并清理冗余代码

### DIFF
--- a/app/renderer/src/main/src/components/HTTPFlowTable/__test__/useHTTPFlowTableShortcutKeys.test.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/__test__/useHTTPFlowTableShortcutKeys.test.tsx
@@ -1,0 +1,183 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { codecHistoryPluginProps, HTTPFlow } from '../HTTPFlowTable.constants'
+import {
+  ContextMenuExecutionType,
+  ContextMenuResultMode,
+  ContextMenuScene,
+  type ContextMenuAction,
+} from '@/pages/manageRightClickPlugins/types'
+
+const mocks = vi.hoisted(() => ({
+  runContextMenuAction: vi.fn(),
+  emit: vi.fn(),
+  getCurrentShortcutFocus: vi.fn(() => null),
+  getIsActiveShortcutKeyPage: vi.fn(() => false),
+  callbacks: new Map<string, (focus?: string[] | null) => void>(),
+}))
+
+vi.mock('@/pages/manageRightClickPlugins/runContextMenuAction', () => ({
+  runContextMenuAction: mocks.runContextMenuAction,
+}))
+vi.mock('@/pages/manageRightClickPlugins/shortcut', () => ({
+  matchContextMenuShortcut: (eventKeys: string[], shortcut?: string) => shortcut === eventKeys.join('|'),
+}))
+vi.mock('@/utils/eventBus/eventBus', () => ({ default: { emit: mocks.emit } }))
+vi.mock('@/utils/globalShortcutKey/utils', () => ({
+  convertKeyEventToKeyCombination: (event: KeyboardEvent) => {
+    if (event.key.toLowerCase() !== 'k' || !event.ctrlKey) return undefined
+    return ['Ctrl', 'K']
+  },
+  getCurrentShortcutFocus: mocks.getCurrentShortcutFocus,
+  getIsActiveShortcutKeyPage: mocks.getIsActiveShortcutKeyPage,
+}))
+vi.mock('@/utils/notification', () => ({ yakitNotify: vi.fn() }))
+vi.mock('@/utils/openWebsite', () => ({ openExternalWebsite: vi.fn() }))
+vi.mock('@/utils/clipboard', () => ({ setClipboardText: vi.fn() }))
+vi.mock('@/components/ShowInBrowser', () => ({ showResponseViaHTTPFlowID: vi.fn() }))
+vi.mock('@/pages/invoker/fromPacketToYakCode', () => ({ generateCSRFPocByRequest: vi.fn() }))
+vi.mock('@/pages/websocket/WebsocketFuzzer', () => ({ newWebsocketFuzzerTab: vi.fn() }))
+vi.mock('@/utils/yakQueryHTTPFlow', () => ({
+  hydrateHTTPFlowRequest: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@/utils/globalShortcutKey/events/useShortcutKeyTrigger', () => ({
+  default: (name: string, callback: (focus?: string[] | null) => void) => {
+    mocks.callbacks.set(name, callback)
+  },
+}))
+
+import { useHTTPFlowTableShortcutKeys } from '../useHTTPFlowTableShortcutKeys'
+
+const makeFlow = (id: number): HTTPFlow =>
+  ({
+    Id: id,
+    IsHTTPS: true,
+    Request: new Uint8Array(),
+    Response: new Uint8Array(),
+  }) as HTTPFlow
+
+const makeAction = (): ContextMenuAction => ({
+  PluginUUID: 'plugin-1',
+  PluginName: 'Plugin',
+  ActionID: 'action-1',
+  HookName: 'hook',
+  Enabled: true,
+  Locked: false,
+  Sort: 0,
+  Shortcut: 'Ctrl|K',
+  ResultMode: ContextMenuResultMode.Tab,
+  AskBeforeRun: false,
+  Params: [],
+  IsCorePlugin: false,
+  Scene: ContextMenuScene.HistorySingle,
+  PluginType: 'context-menu',
+  ExecutionType: ContextMenuExecutionType.ContextMenu,
+  Help: '',
+  HeadImg: '',
+  SupportsResultMode: true,
+  IsAIPlugin: false,
+})
+
+const makePlugin = (action = makeAction()): codecHistoryPluginProps => ({
+  key: 'plugin-1',
+  label: 'Plugin',
+  params: [],
+  isAiPlugin: false,
+  executionType: ContextMenuExecutionType.ContextMenu,
+  action,
+  shortcut: 'Ctrl|K',
+})
+
+const makeOptions = (overrides: Partial<Parameters<typeof useHTTPFlowTableShortcutKeys>[0]> = {}) => ({
+  inViewport: true,
+  getSelected: () => makeFlow(7),
+  getData: () => [makeFlow(7), makeFlow(8)],
+  getSelectedRows: () => [makeFlow(7), makeFlow(8)],
+  getSelectedRowKeys: () => ['7'],
+  getIsAllSelect: () => false,
+  getTotal: () => 2,
+  onClearSelection: vi.fn(),
+  singlePlugins: [],
+  multiplePlugins: [],
+  downstreamProxyStr: '',
+  fromMITM: false,
+  t: vi.fn((key: string) => key),
+  getUrlWithoutQuery: (url?: string) => url || '',
+  onSendToTab: vi.fn(async () => {}),
+  onShieldRecord: vi.fn(),
+  onShieldURL: vi.fn(),
+  onShieldDomain: vi.fn(),
+  onRemoveHttpHistory: vi.fn(),
+  ...overrides,
+})
+
+describe('useHTTPFlowTableShortcutKeys context-menu shortcuts', () => {
+  beforeEach(() => {
+    mocks.runContextMenuAction.mockReset()
+    mocks.emit.mockReset()
+    mocks.callbacks.clear()
+    mocks.getCurrentShortcutFocus.mockReturnValue(null)
+    mocks.getIsActiveShortcutKeyPage.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('passes numeric HTTP flow IDs when a single shortcut runs a context-menu action', () => {
+    const action = makeAction()
+    const plugin = makePlugin(action)
+
+    renderHook(() => useHTTPFlowTableShortcutKeys(makeOptions({ singlePlugins: [plugin] })))
+    const event = new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true, cancelable: true })
+    document.dispatchEvent(event)
+
+    expect(mocks.runContextMenuAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action,
+        request: expect.objectContaining({ HTTPFlowIDs: [7] }),
+      }),
+    )
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('passes all selected flow IDs and clears a multiple selection', () => {
+    const action = makeAction()
+    action.Scene = ContextMenuScene.HistoryMulti
+    const plugin = makePlugin(action)
+    const onClearSelection = vi.fn()
+
+    renderHook(() =>
+      useHTTPFlowTableShortcutKeys(
+        makeOptions({
+          getSelectedRowKeys: () => ['7', '8'],
+          multiplePlugins: [plugin],
+          onClearSelection,
+        }),
+      ),
+    )
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true, cancelable: true }))
+
+    expect(mocks.runContextMenuAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action,
+        request: expect.objectContaining({ HTTPFlowIDs: [7, 8] }),
+      }),
+    )
+    expect(onClearSelection).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not run a plugin shortcut while an input is focused', () => {
+    const plugin = makePlugin()
+    const { unmount } = renderHook(() => useHTTPFlowTableShortcutKeys(makeOptions({ singlePlugins: [plugin] })))
+    const input = document.body.appendChild(document.createElement('input'))
+    input.focus()
+
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true, cancelable: true }))
+    })
+
+    expect(mocks.runContextMenuAction).not.toHaveBeenCalled()
+    unmount()
+  })
+})

--- a/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableShortcutKeys.ts
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableShortcutKeys.ts
@@ -27,7 +27,7 @@ import { HTTP_FLOW_TABLE_BATCH_MAX_ROWS, resolveHTTPFlowTableBatchSelection } fr
 const isMonacoFocused = (focus?: string[] | null) =>
   (focus || []).some((item) => item.startsWith(ShortcutKeyFocusType.Monaco))
 
-/** 焦点在输入框/文本域/富文本等可编辑元素时，不拦截插件快捷键 */
+/** 焦点在输入框/文本域/富文本等可编辑元素时跳过插件快捷键，避免劫持正常输入 */
 const isEditableTarget = (target: EventTarget | null) => {
   if (!target) return false
   const el = target as HTMLElement
@@ -94,7 +94,7 @@ export const useHTTPFlowTableShortcutKeys = (options: UseHTTPFlowTableShortcutKe
   }
 
   const runPluginByShortcut = useMemoizedFn((plugin: codecHistoryPluginProps, rows: HTTPFlow[]) => {
-    const ids = rows.map((item) => item.Id)
+    const ids = rows.map((item) => Number(item.Id))
     if (plugin.executionType === ContextMenuExecutionType.ContextMenu && plugin.action) {
       const httpsValues = new Set(rows.map((item) => !!item.IsHTTPS))
       let httpsState: ContextMenuHttpsState = 'unknown'
@@ -108,7 +108,7 @@ export const useHTTPFlowTableShortcutKeys = (options: UseHTTPFlowTableShortcutKe
           Source: pageType || 'History',
           Trigger: 'shortcut',
           HttpsState: httpsState,
-          HTTPFlowIDs: ids.map((item) => Number(item)),
+          HTTPFlowIDs: ids,
           HasRequest: false,
           HasResponse: false,
           PacketRevision: '',

--- a/app/renderer/src/main/src/components/yakitUI/YakitMenu/__test__/showByRightContext.test.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitMenu/__test__/showByRightContext.test.tsx
@@ -1,12 +1,13 @@
 import { act } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as AntdModule from 'antd'
 
 /**
  * 以 antd Menu 桩捕获 builtinPlacements：注入 rightTop/rightBottom 左偏锚点即为「子菜单向左展开」。
  * jsdom 无真实布局（getBoundingClientRect / clientWidth 恒为 0），布局测量均需打桩。
  */
 vi.mock('antd', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('antd')>()
+  const actual = await importOriginal<typeof AntdModule>()
   const MenuStub = (props: { builtinPlacements?: Record<string, { points: string[] }> }) => (
     <div
       data-testid="yakit-menu"

--- a/app/renderer/src/main/src/components/yakitUI/YakitMenu/__test__/showByRightContext.test.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitMenu/__test__/showByRightContext.test.tsx
@@ -1,0 +1,106 @@
+import { act } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * 以 antd Menu 桩捕获 builtinPlacements：注入 rightTop/rightBottom 左偏锚点即为「子菜单向左展开」。
+ * jsdom 无真实布局（getBoundingClientRect / clientWidth 恒为 0），布局测量均需打桩。
+ */
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>()
+  const MenuStub = (props: { builtinPlacements?: Record<string, { points: string[] }> }) => (
+    <div
+      data-testid="yakit-menu"
+      data-builtin-placements={props.builtinPlacements ? JSON.stringify(props.builtinPlacements) : ''}
+    />
+  )
+  return { ...actual, Menu: MenuStub }
+})
+
+import { showByRightContext } from '../showByRightContext'
+import type { YakitMenuProp } from '../YakitMenu'
+
+const menuProps: YakitMenuProp = { data: [{ key: 'item', label: '菜单项' }], width: 128 }
+
+interface LayoutStub {
+  /** 视口宽度 */
+  innerWidth: number
+  /** 右键弹层根节点的位置与宽度（left/right/width） */
+  left: number
+  right: number
+  width: number
+}
+
+const stubLayout = ({ innerWidth, left, right, width }: LayoutStub) => {
+  vi.stubGlobal('innerWidth', innerWidth)
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    x: left,
+    y: 0,
+    top: 0,
+    bottom: 0,
+    left,
+    right,
+    width,
+    height: 0,
+    toJSON: () => ({}),
+  } as DOMRect)
+  // wrapper 无布局时 clientWidth/Height 恒为 0，方向判定会提前返回，须补非零尺寸
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => width })
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 100 })
+}
+
+describe('showByRightContext 三级子菜单展开方向', () => {
+  let originalClientWidth: PropertyDescriptor | undefined
+  let originalClientHeight: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth')
+    originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight')
+  })
+
+  afterEach(() => {
+    const contextRoot = document.getElementById('yakit-right-context')
+    if (contextRoot) act(() => contextRoot.remove())
+    if (originalClientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth)
+    if (originalClientHeight) Object.defineProperty(HTMLElement.prototype, 'clientHeight', originalClientHeight)
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  const renderMenu = async (layout: LayoutStub) => {
+    stubLayout(layout)
+    showByRightContext(menuProps, 300, 300)
+    // showByRightContext 内部经 setTimeout 渲染，等一拍让 useLayoutEffect 完成测量与方向判定
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+  }
+
+  /** 注入的子菜单 placements；null 表示未注入（保持向右展开） */
+  const submenuPlacements = (): Record<string, { points: string[] }> | null => {
+    const raw = document.querySelector('[data-testid="yakit-menu"]')?.getAttribute('data-builtin-placements') || ''
+    return raw ? JSON.parse(raw) : null
+  }
+
+  it('右侧空间充足时保持向右展开', async () => {
+    await renderMenu({ innerWidth: 1920, left: 100, right: 300, width: 200 })
+    expect(submenuPlacements()).toBeNull()
+  })
+
+  it('右侧不足且左侧充足时子菜单优先向左展开', async () => {
+    await renderMenu({ innerWidth: 1000, left: 800, right: 1000, width: 200 })
+    const placements = submenuPlacements()
+    expect(placements?.rightTop?.points).toEqual(['tr', 'tl'])
+    expect(placements?.rightBottom?.points).toEqual(['br', 'bl'])
+  })
+
+  it('两侧都不足时选剩余空间更大的一侧：左侧大则向左', async () => {
+    await renderMenu({ innerWidth: 500, left: 300, right: 500, width: 400 })
+    expect(submenuPlacements()?.rightTop?.points).toEqual(['tr', 'tl'])
+  })
+
+  it('两侧都不足时选剩余空间更大的一侧：右侧大则保持向右', async () => {
+    await renderMenu({ innerWidth: 500, left: 10, right: 410, width: 400 })
+    expect(submenuPlacements()).toBeNull()
+  })
+})

--- a/app/renderer/src/main/src/components/yakitUI/YakitMenu/showByRightContext.tsx
+++ b/app/renderer/src/main/src/components/yakitUI/YakitMenu/showByRightContext.tsx
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom'
-import React, { memo, type ReactNode, useEffect, useRef } from 'react'
+import React, { memo, type ReactNode, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import classNames from 'classnames'
 import { coordinate } from '@/pages/globalVariable'
 import emiter from '@/utils/eventBus/eventBus'
@@ -8,6 +8,23 @@ import styles from './showByRightContext.module.scss'
 
 const roundDown = (value: number) => {
   return Math.floor(value)
+}
+
+/**
+ * antd/rc-menu 垂直子菜单默认 placement 为 rightTop（向右展开）。
+ * 右侧放得下时保持向右；右侧不够且左侧放得下时，把 right* 锚点改成向左优先。
+ * 两侧都不够时再选剩余空间更大的一侧。adjustX 只会平移、不会切换 placement。
+ * 各级实际宽度并不一致，这里用根菜单宽度估算子菜单所需空间，再决定整棵往哪边展开。
+ */
+const preferLeftSubmenuPlacements: NonNullable<YakitMenuProp['builtinPlacements']> = {
+  rightTop: {
+    points: ['tr', 'tl'],
+    overflow: { adjustX: true, adjustY: true },
+  },
+  rightBottom: {
+    points: ['br', 'bl'],
+    overflow: { adjustX: true, adjustY: true },
+  },
 }
 
 const genX = (client, coordinate, target) => {
@@ -132,14 +149,41 @@ const RightContext: React.FC<RightContextProp> = memo((props) => {
   const { data, callback } = props
 
   const wrapperRef = useRef<HTMLDivElement>(null)
+  /** 右侧放不下且左侧放得下时，子菜单优先向左展开 */
+  const [preferSubmenuLeft, setPreferSubmenuLeft] = useState(false)
 
-  useEffect(() => {
-    if ((wrapperRef.current?.clientWidth || 0) > 0 && (wrapperRef.current?.clientHeight || 0) > 0) {
-      if (callback) callback(wrapperRef.current?.clientWidth || 0, wrapperRef.current?.clientHeight || 0)
+  useLayoutEffect(() => {
+    const width = wrapperRef.current?.clientWidth || 0
+    const height = wrapperRef.current?.clientHeight || 0
+    if (width <= 0 || height <= 0) return
+
+    callback?.(width, height)
+
+    const root = document.getElementById(ContextMenuId)
+    if (!root) return
+    const rect = root.getBoundingClientRect()
+    const spaceLeft = rect.left
+    const spaceRight = window.innerWidth - rect.right
+    // 各级宽度不一致，用根菜单宽度估算子菜单能否放下
+    const needWidth = rect.width
+    if (spaceRight >= needWidth) {
+      setPreferSubmenuLeft(false)
+    } else if (spaceLeft >= needWidth) {
+      setPreferSubmenuLeft(true)
+    } else {
+      setPreferSubmenuLeft(spaceLeft > spaceRight)
     }
   }, [wrapperRef])
 
   const menuProps = data as YakitMenuProp
+
+  const builtinPlacements = useMemo(() => {
+    if (!preferSubmenuLeft) return menuProps.builtinPlacements
+    return {
+      ...menuProps.builtinPlacements,
+      ...preferLeftSubmenuPlacements,
+    }
+  }, [menuProps.builtinPlacements, preferSubmenuLeft])
 
   return (
     <div className={styles['show-by-right-context-wrapper']} ref={wrapperRef}>
@@ -149,6 +193,7 @@ const RightContext: React.FC<RightContextProp> = memo((props) => {
         <YakitMenu
           {...menuProps}
           popupClassName={classNames(styles['show-by-right-context-submenu'], menuProps.popupClassName)}
+          builtinPlacements={builtinPlacements}
         />
       )}
     </div>

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.tsx
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/ManageRightClickPlugins.tsx
@@ -203,7 +203,7 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
     next.splice(insertPos, 0, action)
     // 已选列表项均为启用态：归一 Enabled 与 Sort，只保存「新插入项 + Sort 变化的既有项」
     const normalized = next.map((item, index) => ({ ...item, Enabled: true, Sort: index }))
-    const changed = normalized.filter((_, index) => next[index] === action || next[index].Sort !== index)
+    const changed = normalized.filter((_, index) => next[index] === action || Number(next[index].Sort) !== index)
     bindingSavingRef.current = true
     try {
       updateActionsByTab((prev) => ({ ...prev, [tabKey]: normalized }))
@@ -290,20 +290,10 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
     if (removable.length === 0) return
     bindingSavingRef.current = true
     try {
-      const results = await Promise.all(removable.map((action) => requestBinding(toUnboundAction(action))))
-      emiter.emit('refreshContextMenuActions')
-      const failed = removable.filter((_, index) => !results[index])
-      updateActionsByTab((prev) => ({
-        ...prev,
-        [tabKey]: [...currentList.filter((action) => action.Locked || action.IsCorePlugin), ...failed],
-      }))
-      const removedKeys = new Set(
-        removable.filter((_, index) => results[index]).map((a) => `${a.PluginUUID}:${a.ActionID}`),
-      )
-      setAvailableActions((prev) =>
-        prev.map((i) => (removedKeys.has(`${i.PluginUUID}:${i.ActionID}`) ? toUnboundAction(i) : i)),
-      )
+      await Promise.allSettled(removable.map((action) => requestBinding(toUnboundAction(action))))
     } finally {
+      await refreshSelectedPlugins()
+      emiter.emit('refreshContextMenuActions')
       bindingSavingRef.current = false
     }
   })
@@ -322,7 +312,7 @@ const ManageRightClickPlugins: React.FC<ManageRightClickPluginsProps> = () => {
       const reordered = reorder(currentList, result.source.index, result.destination.index)
       // 已选列表项均为启用态：归一 Enabled 与 Sort
       const next = reordered.map((item, index) => ({ ...item, Enabled: true, Sort: index }))
-      const changed = next.filter((_, index) => reordered[index].Sort !== index)
+      const changed = next.filter((_, index) => Number(reordered[index].Sort) !== index)
       bindingSavingRef.current = true
       try {
         updateActionsByTab((prev) => ({ ...prev, [tabKey]: next }))

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/ManageRightClickPlugins.test.tsx
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/ManageRightClickPlugins.test.tsx
@@ -1,0 +1,245 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+vi.mock('antd', () => ({
+  Avatar: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+  notification: { config: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}))
+import type { ContextMenuAction } from '../types'
+import { ContextMenuResultMode, ContextMenuScene, ContextMenuExecutionType } from '../types'
+
+const mocks = vi.hoisted(() => ({
+  fetchSceneActions: vi.fn(),
+  grpcSetContextMenuActionBinding: vi.fn(),
+  emit: vi.fn(),
+  /** 由 DragDropContext mock 捕获的组件 onDragEnd，供拖拽用例直接调用 */
+  dragEndHandler: null as ((result: unknown) => void) | null,
+}))
+
+vi.mock('@/utils/notification', () => ({
+  yakitNotify: vi.fn(),
+  yakitFailed: vi.fn(),
+}))
+vi.mock('../utils', () => ({
+  fetchSceneActions: mocks.fetchSceneActions,
+  isSameAction: (a: ContextMenuAction, b: ContextMenuAction) =>
+    a.PluginUUID === b.PluginUUID && a.ActionID === b.ActionID,
+  patchAction: (list: ContextMenuAction[], target: ContextMenuAction, patch: Partial<ContextMenuAction>) =>
+    list.map((item) =>
+      item.PluginUUID === target.PluginUUID && item.ActionID === target.ActionID ? { ...item, ...patch } : item,
+    ),
+}))
+vi.mock('../api', () => ({ grpcSetContextMenuActionBinding: mocks.grpcSetContextMenuActionBinding }))
+vi.mock('@/utils/eventBus/eventBus', () => ({ default: { on: vi.fn(), off: vi.fn(), emit: mocks.emit } }))
+vi.mock('@/store/pageInfo', () => ({ usePageInfo: () => undefined }))
+vi.mock('ahooks', async () => {
+  const actual = await vi.importActual<typeof import('ahooks')>('ahooks')
+  return {
+    ...actual,
+    useInViewport: () => [true],
+    useHover: () => false,
+    useThrottleFn: (fn: unknown) => ({ run: fn }),
+  }
+})
+vi.mock('@/i18n/useI18nNamespaces', () => ({
+  useI18nNamespaces: () => ({
+    t: (key: string) => key,
+    i18nRefresh: 0,
+  }),
+}))
+vi.mock('@hello-pangea/dnd', () => ({
+  DragDropContext: ({ children, onDragEnd }: { children: React.ReactNode; onDragEnd: (result: unknown) => void }) => {
+    mocks.dragEndHandler = onDragEnd
+    return <>{children}</>
+  },
+  Droppable: ({
+    children,
+  }: {
+    children: (provided: { droppableProps: {}; innerRef: () => void; placeholder: null }) => React.ReactNode
+  }) => children({ droppableProps: {}, innerRef: () => {}, placeholder: null }),
+  Draggable: ({
+    children,
+  }: {
+    children: (
+      provided: { draggableProps: { style: {} }; dragHandleProps: {}; innerRef: () => void },
+      snapshot: { isDragging: boolean },
+    ) => React.ReactNode
+  }) => children({ draggableProps: { style: {} }, dragHandleProps: {}, innerRef: () => {} }, { isDragging: false }),
+}))
+vi.mock('@/components/yakitUI/YakitButton/YakitButton', () => ({
+  YakitButton: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children?: React.ReactNode
+    onClick?: () => void
+    disabled?: boolean
+  }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}))
+vi.mock('@/components/yakitUI/YakitInput/YakitInput', () => ({
+  YakitInput: { Search: () => <input aria-label="search" /> },
+}))
+vi.mock('@/components/yakitUI/YakitPopconfirm/YakitPopconfirm', () => ({
+  YakitPopconfirm: ({ children, onConfirm }: { children: React.ReactNode; onConfirm: () => void }) => (
+    <div>
+      {children}
+      <button onClick={onConfirm}>confirm-clear</button>
+    </div>
+  ),
+}))
+vi.mock('@/components/yakitUI/YakitEmpty/YakitEmpty', () => ({
+  YakitEmpty: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}))
+vi.mock('@/components/yakitUI/YakitModal/YakitModal', () => ({ YakitModal: () => null }))
+vi.mock('@/components/yakitUI/YakitDropdownMenu/YakitDropdownMenu', () => ({
+  YakitDropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+vi.mock('@/utils/getMainOperatorPageBodyContainer', () => ({ getMainOperatorPageBodyContainer: () => document.body }))
+vi.mock('@/pages/pluginEditor/modifyYakitPlugin/ModifyYakitPlugin', () => ({ ModifyYakitPlugin: () => null }))
+
+import ManageRightClickPlugins from '../ManageRightClickPlugins'
+
+const action = (id: string, overrides: Partial<ContextMenuAction> = {}): ContextMenuAction => ({
+  PluginUUID: `plugin-${id}`,
+  PluginName: `Plugin ${id}`,
+  ActionID: `action-${id}`,
+  HookName: 'hook',
+  Enabled: true,
+  Locked: false,
+  Sort: 0,
+  Shortcut: '',
+  ResultMode: ContextMenuResultMode.Tab,
+  AskBeforeRun: false,
+  Params: [],
+  IsCorePlugin: false,
+  Scene: ContextMenuScene.HistorySingle,
+  PluginType: 'context-menu',
+  ExecutionType: ContextMenuExecutionType.ContextMenu,
+  Help: '',
+  HeadImg: '',
+  SupportsResultMode: true,
+  IsAIPlugin: false,
+  ...overrides,
+})
+
+/** 引擎可能返回字符串 Sort，绕开接口类型构造该形态数据 */
+const actionWithStringSort = (id: string, sort: number) =>
+  action(id, { Sort: String(sort) as unknown as ContextMenuAction['Sort'] })
+
+describe('ManageRightClickPlugins clear action', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    mocks.fetchSceneActions.mockReset()
+    mocks.grpcSetContextMenuActionBinding.mockReset()
+    mocks.emit.mockReset()
+  })
+
+  it('unbinds removable actions and refreshes after all requests settle', async () => {
+    const removable = action('one')
+    const core = action('core', { IsCorePlugin: true, Locked: true })
+    mocks.fetchSceneActions.mockResolvedValueOnce([removable, core]).mockResolvedValueOnce([core])
+    mocks.grpcSetContextMenuActionBinding.mockResolvedValue(true)
+
+    render(<ManageRightClickPlugins />)
+    await waitFor(() => expect(screen.getAllByText('Plugin one').length).toBeGreaterThan(0))
+    fireEvent.click(screen.getByText('confirm-clear'))
+
+    await waitFor(() => expect(mocks.grpcSetContextMenuActionBinding).toHaveBeenCalledTimes(1))
+    expect(mocks.grpcSetContextMenuActionBinding).toHaveBeenCalledWith(
+      expect.objectContaining({ PluginUUID: removable.PluginUUID, Enabled: false, Shortcut: '', ResultMode: 'tab' }),
+    )
+    await waitFor(() => expect(mocks.fetchSceneActions).toHaveBeenCalledTimes(2))
+    expect(mocks.emit).toHaveBeenCalledWith('refreshContextMenuActions')
+  })
+
+  it('still refreshes when one unbind request fails', async () => {
+    const first = action('first')
+    const second = action('second')
+    mocks.fetchSceneActions.mockResolvedValueOnce([first, second]).mockResolvedValueOnce([])
+    mocks.grpcSetContextMenuActionBinding.mockResolvedValueOnce(true).mockRejectedValueOnce(new Error('failed'))
+
+    render(<ManageRightClickPlugins />)
+    await waitFor(() => expect(screen.getAllByText('Plugin first').length).toBeGreaterThan(0))
+    fireEvent.click(screen.getByText('confirm-clear'))
+
+    await waitFor(() => expect(mocks.grpcSetContextMenuActionBinding).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(mocks.fetchSceneActions).toHaveBeenCalledTimes(2))
+    expect(mocks.emit).toHaveBeenCalledWith('refreshContextMenuActions')
+  })
+})
+
+describe('ManageRightClickPlugins string Sort regression', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    mocks.fetchSceneActions.mockReset()
+    mocks.grpcSetContextMenuActionBinding.mockReset()
+    mocks.emit.mockReset()
+    mocks.dragEndHandler = null
+  })
+
+  /**
+   * 引擎可能返回字符串 Sort：插入新项时，仅「新插入项 + Number(Sort) 变化的既有项」应被保存。
+   * 旧实现的严格 !== 比较会把字符串 Sort 全量误判为变化，多保存既有项；此处回归该修复。
+   */
+  it('only saves the new action when existing numeric-string Sorts match their indices', async () => {
+    // 既有两项：字符串 Sort 恰好等于当前下标（'0' / '1'），插入新项后位置不变、Sort 不应变
+    const existingA = actionWithStringSort('a', 0)
+    const existingB = actionWithStringSort('b', 1)
+    // 新项初始为未启用（在右侧可用列表中），模拟真实从右侧添加
+    const incoming = action('c', { Enabled: false })
+    mocks.fetchSceneActions.mockResolvedValueOnce([existingA, existingB, incoming])
+    mocks.grpcSetContextMenuActionBinding.mockResolvedValue(true)
+
+    render(<ManageRightClickPlugins />)
+    await waitFor(() => expect(screen.getAllByText('Plugin a').length).toBeGreaterThan(0))
+
+    // 右侧可用列表中点击新项的「添加」按钮（已选列表无添加按钮，取最后一个即可）
+    fireEvent.click(screen.getAllByText('YakitButton.add').at(-1) as HTMLElement)
+
+    // 等保存循环走完（新项保存一次），再冲刷一轮微任务：若旧代码误判 Sort 变化，多余的保存会在此后发生
+    await waitFor(() => expect(mocks.grpcSetContextMenuActionBinding).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    // 冲刷后总数仍必须是 1：既有项字符串 Sort 归一后与下标一致，不应触发保存
+    expect(mocks.grpcSetContextMenuActionBinding).toHaveBeenCalledTimes(1)
+    expect(mocks.grpcSetContextMenuActionBinding).toHaveBeenCalledWith(
+      expect.objectContaining({ PluginUUID: incoming.PluginUUID, Enabled: true, Sort: 2 }),
+    )
+  })
+
+  it('saves only reordered items when existing Sorts are numeric strings', async () => {
+    // 4 项字符串 Sort：把第 2 项拖到开头，仅前 3 项 Sort 变化；末项（'3'）不变、不应保存
+    const items = [0, 1, 2, 3].map((i) => actionWithStringSort(`item-${i}`, i))
+    mocks.fetchSceneActions.mockResolvedValueOnce(items)
+    mocks.grpcSetContextMenuActionBinding.mockResolvedValue(true)
+
+    render(<ManageRightClickPlugins />)
+    await waitFor(() => expect(screen.getAllByText('Plugin item-0').length).toBeGreaterThan(0))
+
+    act(() => {
+      mocks.dragEndHandler?.({
+        source: { droppableId: 'droppable-selected', index: 2 },
+        destination: { droppableId: 'droppable-selected', index: 0 },
+      })
+    })
+
+    await waitFor(() => expect(mocks.grpcSetContextMenuActionBinding).toHaveBeenCalledTimes(3))
+    const savedUUIDs = mocks.grpcSetContextMenuActionBinding.mock.calls.map(
+      ([req]) => (req as { PluginUUID: string }).PluginUUID,
+    )
+    // 重排后顺序 [i2, i0, i1, i3]，按新下标顺序保存前三个
+    expect(savedUUIDs).toEqual([items[2].PluginUUID, items[0].PluginUUID, items[1].PluginUUID])
+  })
+})

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/ManageRightClickPlugins.test.tsx
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/ManageRightClickPlugins.test.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import type React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type * as AhooksModule from 'ahooks'
 vi.mock('antd', () => ({
   Avatar: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
   notification: { config: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
@@ -33,7 +34,7 @@ vi.mock('../api', () => ({ grpcSetContextMenuActionBinding: mocks.grpcSetContext
 vi.mock('@/utils/eventBus/eventBus', () => ({ default: { on: vi.fn(), off: vi.fn(), emit: mocks.emit } }))
 vi.mock('@/store/pageInfo', () => ({ usePageInfo: () => undefined }))
 vi.mock('ahooks', async () => {
-  const actual = await vi.importActual<typeof import('ahooks')>('ahooks')
+  const actual = await vi.importActual<typeof AhooksModule>('ahooks')
   return {
     ...actual,
     useInViewport: () => [true],

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/shortcut.test.ts
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/__test__/shortcut.test.ts
@@ -52,7 +52,6 @@ import { grpcQueryContextMenuActions } from '../api'
 import {
   checkContextMenuShortcutConflict,
   findContextMenuPluginShortcutConflict,
-  getEnabledContextMenuShortcuts,
   matchContextMenuShortcut,
   parseContextMenuShortcut,
   refreshContextMenuShortcutCache,
@@ -307,7 +306,6 @@ describe('findContextMenuPluginShortcutConflict', () => {
       ],
     })
     await expect(refreshContextMenuShortcutCache()).resolves.toBe(2)
-    expect(getEnabledContextMenuShortcuts()).toHaveLength(2)
 
     mockQuery.mockRejectedValueOnce(new Error('network'))
     await expect(refreshContextMenuShortcutCache()).resolves.toBe(2)

--- a/app/renderer/src/main/src/pages/manageRightClickPlugins/shortcut.ts
+++ b/app/renderer/src/main/src/pages/manageRightClickPlugins/shortcut.ts
@@ -59,9 +59,6 @@ export const refreshContextMenuShortcutCache = async (): Promise<number> => {
   return cachedEnabledShortcuts.length
 }
 
-/** 当前缓存快照（供录制比对前判断缓存是否已就绪，避免用空缓存漏报冲突） */
-export const getEnabledContextMenuShortcuts = (): CachedContextMenuShortcut[] => cachedEnabledShortcuts
-
 /** 原快捷键设置页与右键插件场景的运行时重叠（空数组表示无重叠、不比对） */
 const SHORTCUT_PAGE_CONTEXT_MENU_SCENES: Record<ShortcutKeyPageName, ContextMenuSceneType[]> = {
   // 全局快捷键到处生效，与所有右键场景都可能冲突


### PR DESCRIPTION
## 改动类型

- [ ] 新功能（新页面 / 新选项 / 新能力）
- [x] Bug 修复（有用户可见行为修正）
- [ ] 文档改动
- [ ] 样式 / UI 调整（无逻辑变化）
- [ ] 性能优化
- [ ] 重构（不改变外部行为）
- [ ] 测试改动
- [ ] 构建 / 依赖 / 打包配置
- [ ] CI 流程改动
- [ ] 杂项（脚本 / 工程化 / 版本号）
- [ ] 其他

## 🔗 关联 Issue / PR

None

## 💡 背景与方案

右键菜单贴近屏幕右缘时，三级子菜单仍按 antd 默认 placement 向右展开，导致子菜单溢出屏幕不可见（adjustX 只平移不切换方向）。本次在菜单渲染后用根菜单宽度估算左右剩余空间：右侧充足保持向右；右侧不足且左侧放得下时注入 `rightTop`/`rightBottom` 的左偏锚点（`['tr','tl']` / `['br','bl']`）让子菜单优先向左展开；两侧都不足时选剩余空间更大的一侧。

同分支顺带修复与清理：

- 插件管理页「清空」批量解绑改用 `Promise.allSettled` + 统一 `refreshSelectedPlugins` 服务端刷新回显，替换原先本地拼装失败列表的竞态逻辑，单个请求失败也不再阻塞刷新。
- 引擎可能返回字符串形态的 Sort，原先严格不等比较会把所有既有项误判为「Sort 变化」而全量重发保存；改为 `Number(Sort)` 归一后再比较，插入与拖拽均只保存真正变化的项。
- 快捷键执行路径将 `HTTPFlowIDs` 在源头统一 `Number` 归一，去掉二次转换冗余。
- 删除全仓库无引用的 `getEnabledContextMenuShortcuts` 及其测试断言。

## 影响范围

右键菜单贴近屏幕右缘时三级子菜单不再溢出屏幕；插件管理页批量解绑部分失败时也能正确刷新列表；快捷键触发插件时传递数值型 HTTPFlowIDs。新增 3 组回归测试覆盖子菜单展开方向、批量解绑失败刷新与字符串 Sort 保存行为。

## 代码评审结论

**结论：可以合并**（正确 6 项 / 问题 0 项 / 警告 3 项）

## 合并方式

- [ ] Create a merge commit（保留完整提交历史）
- [x] Squash and merge（压缩为一条提交）
- [ ] Rebase and merge（线性历史）