### PR TITLE
fix: 修复 Web Fuzzer 缓存 JSON 截断导致标签页丢失的问题

### DIFF
--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -126,13 +126,15 @@ import {
   type RuleManagementPageInfoProps,
   type AuditHoleInfoProps,
 } from '@/store/pageInfo'
-import { safeParseFuzzerCache } from '@/store/parseFuzzerCache'
+import { safeParseFuzzerCache, sanitizeFuzzerCachePageParams } from '@/store/parseFuzzerCache'
+import { adoptOrphanCacheTabs } from './adoptOrphanCacheTabs'
 import cloneDeep from 'lodash/cloneDeep'
 import { onToManageGroup } from '@/pages/securityTool/yakPoC/YakPoC'
 import { apiFetchQueryYakScriptGroupLocal } from '@/pages/plugins/utils'
 import type { ExpandAndRetractExcessiveState } from '@/pages/plugins/operator/expandAndRetract/ExpandAndRetract'
 import {
   DefFuzzerTableMaxData,
+  HotPatchDefaultContent,
   defaultAdvancedConfigShow,
   defaultAdvancedConfigValue,
   defaultPostTemplate,
@@ -2934,9 +2936,14 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
     setFuzzerSequenceCacheData(cache)
   })
 
-  // 获取数据库中缓存的 web-fuzzer 页面信息。
-  // 截断恢复后 request / hotPatchCode 等可能缺失，下面用空串；页面打开后走各自默认值。
-  // 看起来像没存上，实际是缓存 JSON 被截断、数据不完整。
+  /**
+   * 获取数据库中缓存的 web-fuzzer 页面信息。
+   * 截断修复丢弃损坏字段及其后的所有内容、保留前面的完整数据（修复策略见 parseFuzzerCache.ts），
+   * 缺失字段由默认值填充、落点在本函数：request / hotPatchCode 回填默认 POST 模板与默认热加载模板
+   * （编辑器对空内容提前返回、不会自行回退默认值），其余字段经浅合并由默认高级配置兜底，
+   * 残缺的 matcher / extractor 元素经 sanitizeFuzzerCachePageParams 清洗丢弃。
+   * 看起来像没存上，实际是缓存 JSON 被截断、数据不完整。
+   */
   const fetchFuzzerList = useMemoizedFn(async (cache, add, openFlag = true, preserveIds = false) => {
     try {
       const cacheData: FuzzerCacheDataProps = (await getFuzzerCacheData()) || {
@@ -2972,7 +2979,9 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
         routeKey: YakitRoute.HTTPFuzzer,
       }
       let multipleNodeListLength: number = 0
-      const newCache = add && !preserveIds ? rebuildMultipleNodeTree(key, cloneDeep(cache)) : cache
+      const newCache = adoptOrphanCacheTabs(
+        add && !preserveIds ? rebuildMultipleNodeTree(key, cloneDeep(cache)) : cache,
+      )
       const multipleNodeList: MultipleNodeInfo[] = newCache.filter((ele) => ele.groupId === '0')
       const pLength = multipleNodeList.length
       for (let index = 0; index < pLength; index++) {
@@ -2999,11 +3008,11 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
                 advancedConfigValue: {
                   ...defaultAdvancedConfigValue,
                   ...defaultCache,
-                  ...nodeItem.pageParams,
+                  ...sanitizeFuzzerCachePageParams(nodeItem.pageParams || {}),
                 },
                 advancedConfigShow: cacheData.advancedConfigShow,
-                request: nodeItem.pageParams?.request || '',
-                hotPatchCode: nodeItem.pageParams?.hotPatchCode || '',
+                request: nodeItem.pageParams?.request || defaultPostTemplate,
+                hotPatchCode: nodeItem.pageParams?.hotPatchCode || HotPatchDefaultContent,
               },
             },
             sortFieId: nodeItem.sortFieId,
@@ -3034,11 +3043,11 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
               advancedConfigValue: {
                 ...defaultAdvancedConfigValue,
                 ...defaultCache,
-                ...parentItem.pageParams,
+                ...sanitizeFuzzerCachePageParams(parentItem.pageParams || {}),
               },
               advancedConfigShow: cacheData.advancedConfigShow,
-              request: parentItem.pageParams?.request || '',
-              hotPatchCode: parentItem.pageParams?.hotPatchCode || '',
+              request: parentItem.pageParams?.request || defaultPostTemplate,
+              hotPatchCode: parentItem.pageParams?.hotPatchCode || HotPatchDefaultContent,
             },
           },
           sortFieId: parentItem.sortFieId,

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/MainOperatorContent.tsx
@@ -126,6 +126,7 @@ import {
   type RuleManagementPageInfoProps,
   type AuditHoleInfoProps,
 } from '@/store/pageInfo'
+import { safeParseFuzzerCache } from '@/store/parseFuzzerCache'
 import cloneDeep from 'lodash/cloneDeep'
 import { onToManageGroup } from '@/pages/securityTool/yakPoC/YakPoC'
 import { apiFetchQueryYakScriptGroupLocal } from '@/pages/plugins/utils'
@@ -2889,7 +2890,7 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
         try {
           setLoading(true)
           const res = await getRemoteProjectValue(FuzzerRemoteGV.FuzzerCache)
-          const cache = JSONParseLog(res || '[]', { page: 'MainOperatorContent', fun: 'onInitFuzzer' })
+          const cache = safeParseFuzzerCache(res || '[]')
           await fetchFuzzerList(cache, false)
           await getFuzzerSequenceCache()
         } catch (error) {
@@ -2933,7 +2934,9 @@ export const MainOperatorContent: React.FC<MainOperatorContentProps> = React.mem
     setFuzzerSequenceCacheData(cache)
   })
 
-  // 获取数据库中缓存的web-fuzzer页面信息
+  // 获取数据库中缓存的 web-fuzzer 页面信息。
+  // 截断恢复后 request / hotPatchCode 等可能缺失，下面用空串；页面打开后走各自默认值。
+  // 看起来像没存上，实际是缓存 JSON 被截断、数据不完整。
   const fetchFuzzerList = useMemoizedFn(async (cache, add, openFlag = true, preserveIds = false) => {
     try {
       const cacheData: FuzzerCacheDataProps = (await getFuzzerCacheData()) || {

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/__test__/adoptOrphanCacheTabs.test.ts
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/__test__/adoptOrphanCacheTabs.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import type { MultipleNodeInfo } from '../MainOperatorContentType'
+import { adoptOrphanCacheTabs } from '../adoptOrphanCacheTabs'
+
+const tab = (id: string, groupId: string, sortFieId = 1, verbose = id): MultipleNodeInfo => ({
+  id,
+  groupId,
+  verbose,
+  sortFieId,
+})
+
+describe('adoptOrphanCacheTabs', () => {
+  it('keeps the cache as-is when every non-root tab has its parent group', () => {
+    const cache = [
+      tab('tab-a', '0', 1),
+      tab('tab-b', '0', 2),
+      { ...tab('[xxx]-1-group', '0', 3, '组1'), expand: true },
+      tab('tab-c', '[xxx]-1-group', 1),
+    ]
+    expect(adoptOrphanCacheTabs([...cache])).toEqual(cache)
+  })
+
+  it('synthesizes a parent group for orphan tabs and keeps them with their siblings', () => {
+    // 缓存序列化为「子在前、父在后」：截断发生在子标签时父分组未被写入
+    const cache = [tab('tab-a', '0', 1), tab('orphan-1', '[lost]-111-group', 1), tab('orphan-2', '[lost]-111-group', 2)]
+    const result = adoptOrphanCacheTabs([...cache])
+
+    expect(result).toHaveLength(4)
+    // 孤儿没有被静默丢弃
+    const restored = result.filter((ele) => ele.id === 'orphan-1' || ele.id === 'orphan-2')
+    expect(restored).toHaveLength(2)
+    // 为缺失的父分组合成了根节点，组 id 保持指向原 groupId
+    const adopted = result.filter((ele) => ele.groupId === '0')
+    expect(adopted.map((ele) => ele.id)).toEqual(['tab-a', '[lost]-111-group'])
+    const group = adopted.find((ele) => ele.id === '[lost]-111-group')
+    expect(group?.id.endsWith('group')).toBe(true)
+    expect(group?.verbose).toContain('未命名')
+    expect(group?.expand).toBe(true)
+    expect(group?.sortFieId).toBeGreaterThan(0)
+  })
+
+  it('sorts synthesized groups after real root tabs by max child sortFieId', () => {
+    const cache = [
+      tab('orphan-1', '[g]-1-group', 5),
+      tab('root-1', '0', 1),
+      tab('root-2', '0', 2),
+      tab('orphan-2', '[g]-1-group', 6),
+    ]
+    const result = adoptOrphanCacheTabs([...cache])
+    const roots = result.filter((ele) => ele.groupId === '0')
+    // 孤儿的 sortFieId(5/6) 在 root-2(2) 之后，合成组排在最后
+    expect(roots.map((ele) => ele.id)).toEqual(['root-1', 'root-2', '[g]-1-group'])
+  })
+
+  it('keeps orphan tabs of a group whose parent is itself a truncated child group', () => {
+    // 二级分组：孙标签的 groupId 指向子分组，子分组又被截断丢失
+    const cache = [tab('grand-1', '[child]-9-group', 1)]
+    const result = adoptOrphanCacheTabs([...cache])
+    expect(result).toHaveLength(2)
+    expect(result.some((ele) => ele.id === 'grand-1')).toBe(true)
+    expect(result.find((ele) => ele.id === '[child]-9-group')?.groupId).toBe('0')
+  })
+
+  it('handles empty cache', () => {
+    expect(adoptOrphanCacheTabs([])).toEqual([])
+  })
+})

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/__test__/webFuzzerTabPush.test.ts
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/__test__/webFuzzerTabPush.test.ts
@@ -297,4 +297,20 @@ describe('getFuzzerProcessedCacheData', () => {
 
     expect(cached.pageParams.proxy).toEqual(['http://127.0.0.1:8080', 'http://127.0.0.1:8081'])
   })
+
+  // 字段顺序是截断恢复策略的一部分：小体积元数据放在 pageParams 前，request 放在 pageParams 末尾，
+  // 保证缓存 JSON 在长字符串处截断时 parseFuzzerCache 丢弃的字段最少。顺序回退会静默削弱恢复能力。
+  it('serializes tab metadata before pageParams and keeps request after the small config fields', () => {
+    const tabA = tab('tab-a')
+    const currentPage = page([tabA], 'tab-a')
+
+    const [cached] = getFuzzerProcessedCacheData(currentPage.pageList)
+
+    const keys = Object.keys(cached)
+    expect(keys.indexOf('verbose')).toBeLessThan(keys.indexOf('pageParams'))
+    expect(keys.indexOf('sortFieId')).toBeLessThan(keys.indexOf('pageParams'))
+
+    const pageParamsKeys = Object.keys(cached.pageParams)
+    expect(pageParamsKeys.indexOf('request')).toBeGreaterThan(pageParamsKeys.indexOf('maxDelaySeconds'))
+  })
 })

--- a/app/renderer/src/main/src/pages/layout/mainOperatorContent/adoptOrphanCacheTabs.ts
+++ b/app/renderer/src/main/src/pages/layout/mainOperatorContent/adoptOrphanCacheTabs.ts
@@ -1,0 +1,38 @@
+import type { MultipleNodeInfo } from './MainOperatorContentType'
+/**
+ * 检查缓存中的非根标签是否都有对应的父分组，为缺失的分组合成根节点。
+ *
+ * @param cache - 恢复出的标签缓存（可能含截断遗留的孤儿标签）
+ * @returns 补齐合成分组后的缓存；无孤儿时原数组原样返回
+ */
+export const adoptOrphanCacheTabs = (cache: MultipleNodeInfo[]): MultipleNodeInfo[] => {
+  // 缓存里分组的 id 就是子标签引用的 groupId，所以这里收集的是所有条目 id（含分组条目）
+  const existingIds = new Set<string>()
+  cache.forEach((ele) => existingIds.add(ele.id))
+
+  const orphanGroupIds = new Set<string>()
+  cache.forEach((ele) => {
+    if (ele.groupId !== '0' && !existingIds.has(ele.groupId)) {
+      orphanGroupIds.add(ele.groupId)
+    }
+  })
+  if (orphanGroupIds.size === 0) return cache
+
+  const adopted = [...cache]
+  let groupCount = 0
+  orphanGroupIds.forEach((groupId) => {
+    // 同组孤儿中最大的 sortFieId 决定合成组的位置，保持截断前的组顺序
+    const children = cache.filter((ele) => ele.groupId === groupId)
+    const maxSortFieId = children.reduce((max, ele) => Math.max(max, ele.sortFieId || 0), 0)
+    groupCount += 1
+    adopted.push({
+      id: groupId,
+      groupId: '0',
+      verbose: `未命名[恢复${groupCount}]`,
+      sortFieId: maxSortFieId,
+      expand: true,
+      groupChildren: [],
+    })
+  })
+  return adopted
+}

--- a/app/renderer/src/main/src/store/__test__/parseFuzzerCache.test.ts
+++ b/app/renderer/src/main/src/store/__test__/parseFuzzerCache.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { debugToPrintLogs } from '@/utils/logCollection'
+import { safeParseFuzzerCache } from '../parseFuzzerCache'
+
+vi.mock('@/utils/logCollection', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/logCollection')>()
+  return {
+    ...actual,
+    debugToPrintLogs: vi.fn(),
+  }
+})
+
+const goodItem = {
+  groupChildren: [],
+  groupId: '0',
+  id: 'httpFuzzer-good',
+  pageParams: {
+    actualHost: '',
+    id: 'httpFuzzer-good',
+    isHttps: true,
+    request: 'GET / HTTP/1.1\r\nHost: a\r\n\r\n',
+    params: [{ Key: 'p', Value: '1', Type: 'raw' }],
+    extractors: [],
+    matchers: [],
+    repeatTimes: 0,
+    concurrent: 20,
+    proxy: [],
+    minDelaySeconds: 0,
+    maxDelaySeconds: 0,
+    hotPatchCode: 'handle = func(p) { return p }',
+  },
+  sortFieId: 1,
+  verbose: 'good',
+}
+
+describe('safeParseFuzzerCache', () => {
+  afterEach(() => {
+    vi.mocked(debugToPrintLogs).mockClear()
+  })
+
+  it('returns valid cache as-is including hotPatchCode', () => {
+    const result = safeParseFuzzerCache(JSON.stringify([goodItem]))
+    expect(result).toHaveLength(1)
+    expect(result[0].pageParams.hotPatchCode).toBe(goodItem.pageParams.hotPatchCode)
+    expect(result[0].pageParams.request).toBe(goodItem.pageParams.request)
+    expect(debugToPrintLogs).not.toHaveBeenCalled()
+  })
+
+  it('drops truncated hotPatchCode and fills missing verbose/sortFieId with defaults', () => {
+    const broken =
+      '{"groupChildren":[],"groupId":"0","id":"httpFuzzer-truncated","pageParams":{"actualHost":"","id":"httpFuzzer-truncated","isHttps":false,"request":"GET / HTTP/1.1\\r\\nHost: a","params":[{"Key":"p","Value":"1","Type":"raw"}],"extractors":[],"matchers":[],"repeatTimes":0,"concurrent":20,"proxy":[],"minDelaySeconds":0,"maxDelaySeconds":0,"hotPatchCode":"handle = func(p) { return unclosed'
+    const result = safeParseFuzzerCache(`[${JSON.stringify(goodItem)},${broken}]`)
+    expect(result).toHaveLength(2)
+    expect(result[0].pageParams.hotPatchCode).toBe(goodItem.pageParams.hotPatchCode)
+    expect(result[1].id).toBe('httpFuzzer-truncated')
+    expect(result[1].pageParams.request).toBe('GET / HTTP/1.1\r\nHost: a')
+    expect(result[1].pageParams.params).toEqual([{ Key: 'p', Value: '1', Type: 'raw' }])
+    expect(result[1].pageParams.concurrent).toBe(20)
+    expect(result[1].pageParams.hotPatchCode).toBeUndefined()
+    expect(result[1].verbose).toBe('2')
+    expect(result[1].sortFieId).toBe(2)
+    expect(debugToPrintLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'WARN',
+        title: expect.stringContaining('hotPatchCode因缓存截断不完整已丢弃'),
+        content: expect.objectContaining({ id: 'httpFuzzer-truncated', index: 2, field: 'hotPatchCode' }),
+      }),
+    )
+  })
+
+  it('drops corrupted string value and every field after it, then fills defaults', () => {
+    const broken =
+      '{"groupChildren":[],"groupId":"0","id":"httpFuzzer-a","pageParams":{"actualHost":"","id":"httpFuzzer-a","isHttps":true,"request":"GET /","params":[],"extractors":[],"matchers":[],"repeatTimes":0,"concurrent":33,"proxy":[],"minDelaySeconds":0,"maxDelaySeconds":0,"hotPatchCode":"broken "quote" here"},"sortFieId":7,"verbose":"keep-me"}'
+    const result = safeParseFuzzerCache(`[${broken}]`)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('httpFuzzer-a')
+    expect(result[0].pageParams.concurrent).toBe(33)
+    expect(result[0].pageParams.request).toBe('GET /')
+    expect(result[0].pageParams.hotPatchCode).toBeUndefined()
+    // sortFieId and verbose come after the corrupted hotPatchCode, so they are dropped and defaulted
+    expect(result[0].sortFieId).toBe(1)
+    expect(result[0].verbose).toBe('1')
+    expect(debugToPrintLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'WARN',
+        title: expect.stringContaining('keep-me'),
+        content: expect.objectContaining({ id: 'httpFuzzer-a', verbose: 'keep-me', index: 1, field: 'hotPatchCode' }),
+      }),
+    )
+  })
+
+  it('recovers a multi-tab cache when the last hotPatchCode is truncated', () => {
+    const one = JSON.stringify({
+      groupChildren: [],
+      groupId: '0',
+      id: 'httpFuzzer-one',
+      pageParams: {
+        actualHost: '',
+        id: 'httpFuzzer-one',
+        isHttps: false,
+        request: 'POST /one HTTP/1.1',
+        params: [{ Key: 'k', Value: 'v', Type: 'raw' }],
+        extractors: [],
+        matchers: [],
+        repeatTimes: 0,
+        concurrent: 15,
+        proxy: [],
+        minDelaySeconds: 0,
+        maxDelaySeconds: 0,
+        hotPatchCode: 'handle = func(p) { return p }',
+      },
+      sortFieId: 1,
+      verbose: 'one',
+    })
+    const broken =
+      '{"groupChildren":[],"groupId":"0","id":"httpFuzzer-two","pageParams":{"actualHost":"","id":"httpFuzzer-two","isHttps":true,"request":"GET /two","params":[{"Key":"k","Value":"v","Type":"raw"}],"extractors":[],"matchers":[],"repeatTimes":0,"concurrent":15,"proxy":[],"minDelaySeconds":0,"maxDelaySeconds":0,"hotPatchCode":"handle = func(p) { return unclosed'
+    const result = safeParseFuzzerCache(`[${one},${broken}]`)
+    expect(result).toHaveLength(2)
+    expect(result[0].id).toBe('httpFuzzer-one')
+    expect(result[0].pageParams.hotPatchCode).toBe('handle = func(p) { return p }')
+    expect(result[1].id).toBe('httpFuzzer-two')
+    expect(result[1].pageParams.request).toBe('GET /two')
+    expect(result[1].pageParams.isHttps).toBe(true)
+    expect(result[1].pageParams.concurrent).toBe(15)
+    expect(result[1].pageParams.hotPatchCode).toBeUndefined()
+    expect(result[1].verbose).toBe('2')
+    expect(result[1].sortFieId).toBe(2)
+  })
+
+  it('fills missing verbose/sortFieId by tab index when the last of several tabs is truncated', () => {
+    const makeGood = (id: string, verbose: string, sortFieId: number) =>
+      JSON.stringify({
+        ...goodItem,
+        id,
+        pageParams: { ...goodItem.pageParams, id },
+        verbose,
+        sortFieId,
+      })
+    const broken =
+      '{"groupChildren":[],"groupId":"0","id":"httpFuzzer-d","pageParams":{"actualHost":"","id":"httpFuzzer-d","isHttps":false,"request":"POST /","params":[],"extractors":[],"matchers":[],"repeatTimes":0,"concurrent":20,"proxy":[],"minDelaySeconds":0,"maxDelaySeconds":0,"hotPatchCode":"unclosed'
+    const result = safeParseFuzzerCache(
+      `[${makeGood('httpFuzzer-a', 'a', 1)},${makeGood('httpFuzzer-b', 'b', 2)},${makeGood('httpFuzzer-c', 'c', 3)},${broken}]`,
+    )
+    expect(result).toHaveLength(4)
+    expect(result.map((item) => item.verbose)).toEqual(['a', 'b', 'c', '4'])
+    expect(result.map((item) => item.sortFieId)).toEqual([1, 2, 3, 4])
+    expect(result[3].pageParams.request).toBe('POST /')
+    expect(result[3].pageParams.hotPatchCode).toBeUndefined()
+  })
+
+  it('removes truncated request and later bulky fields', () => {
+    const broken =
+      '{"groupChildren":[],"groupId":"0","id":"httpFuzzer-bad-request","sortFieId":1,"verbose":"请求页","pageParams":{"actualHost":"","id":"httpFuzzer-bad-request","isHttps":true,"params":[],"extractors":[],"matchers":[],"repeatTimes":0,"concurrent":20,"proxy":[],"minDelaySeconds":0,"maxDelaySeconds":0,"request":"GET / unclosed'
+    const result = safeParseFuzzerCache(`[${broken}]`)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('httpFuzzer-bad-request')
+    expect(result[0].verbose).toBe('请求页')
+    expect(result[0].pageParams.isHttps).toBe(true)
+    expect(result[0].pageParams.request).toBeUndefined()
+    expect(result[0].pageParams.hotPatchCode).toBeUndefined()
+    expect(debugToPrintLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'WARN',
+        title: expect.stringContaining('request因缓存截断不完整已丢弃'),
+        content: expect.objectContaining({ id: 'httpFuzzer-bad-request', field: 'request' }),
+      }),
+    )
+  })
+
+  it('drops later bulky fields when an earlier bulky field is corrupted', () => {
+    const broken =
+      '{"groupChildren":[],"groupId":"0","id":"httpFuzzer-keep-hot","sortFieId":1,"verbose":"keep-hot","pageParams":{"actualHost":"","id":"httpFuzzer-keep-hot","isHttps":false,"params":[],"extractors":[],"matchers":[],"repeatTimes":0,"concurrent":20,"proxy":[],"minDelaySeconds":0,"maxDelaySeconds":0,"request":"GET / broken "quote" here","hotPatchCode":"handle = func(p) { return \\"keep\\" }"}}'
+    const result = safeParseFuzzerCache(`[${broken}]`)
+    expect(result).toHaveLength(1)
+    expect(result[0].pageParams.request).toBeUndefined()
+    expect(result[0].pageParams.hotPatchCode).toBeUndefined()
+    expect(debugToPrintLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({ field: 'request' }),
+      }),
+    )
+  })
+
+  it('removes truncated actualHost string and keeps fields before it', () => {
+    const broken =
+      '{"groupChildren":[],"groupId":"0","id":"httpFuzzer-bad-host","sortFieId":1,"verbose":"短字段","pageParams":{"actualHost":"unclosed'
+    const result = safeParseFuzzerCache(`[${broken}]`)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('httpFuzzer-bad-host')
+    expect(result[0].verbose).toBe('短字段')
+    expect(result[0].pageParams.actualHost).toBeUndefined()
+    expect(debugToPrintLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({ field: 'actualHost' }),
+      }),
+    )
+  })
+
+  it('removes a string field that is closed by a quote then hits EOF', () => {
+    const broken =
+      '{"groupChildren":[],"groupId":"0","id":"httpFuzzer-eof","pageParams":{"actualHost":"","id":"httpFuzzer-eof","isHttps":false,"request":"GET /","hotPatchCode":"closed-quote-then-eof"'
+    const result = safeParseFuzzerCache(`[${broken}]`)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('httpFuzzer-eof')
+    expect(result[0].pageParams.request).toBe('GET /')
+    expect(result[0].pageParams.hotPatchCode).toBeUndefined()
+    expect(result[0].verbose).toBe('1')
+    expect(result[0].sortFieId).toBe(1)
+  })
+
+  it('throws original JSON error when a non-string field is truncated', () => {
+    const inner =
+      '[{"groupChildren":[],"groupId":"0","id":"httpFuzzer-bad-num","pageParams":{"actualHost":"","concurrent":'
+    expect(() => safeParseFuzzerCache(inner)).toThrow(SyntaxError)
+  })
+
+  it('throws original JSON error when payload is not json', () => {
+    expect(() => safeParseFuzzerCache('{not-json')).toThrow(SyntaxError)
+  })
+})

--- a/app/renderer/src/main/src/store/__test__/parseFuzzerCache.test.ts
+++ b/app/renderer/src/main/src/store/__test__/parseFuzzerCache.test.ts
@@ -212,9 +212,17 @@ describe('safeParseFuzzerCache', () => {
     const inner =
       '[{"groupChildren":[],"groupId":"0","id":"httpFuzzer-bad-num","pageParams":{"actualHost":"","concurrent":'
     expect(() => safeParseFuzzerCache(inner)).toThrow(SyntaxError)
+    expect(debugToPrintLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'ERRO',
+        title: expect.stringContaining('截断修复未成功'),
+        content: expect.objectContaining({ originalError: expect.any(String), repairError: expect.any(String) }),
+      }),
+    )
   })
 
   it('throws original JSON error when payload is not json', () => {
     expect(() => safeParseFuzzerCache('{not-json')).toThrow(SyntaxError)
+    expect(debugToPrintLogs).toHaveBeenCalledWith(expect.objectContaining({ status: 'ERRO' }))
   })
 })

--- a/app/renderer/src/main/src/store/__test__/parseFuzzerCache.test.ts
+++ b/app/renderer/src/main/src/store/__test__/parseFuzzerCache.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as LogCollection from '@/utils/logCollection'
 import { debugToPrintLogs } from '@/utils/logCollection'
 import { safeParseFuzzerCache } from '../parseFuzzerCache'
 
 vi.mock('@/utils/logCollection', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/utils/logCollection')>()
+  const actual = await importOriginal<typeof LogCollection>()
   return {
     ...actual,
     debugToPrintLogs: vi.fn(),

--- a/app/renderer/src/main/src/store/__test__/parseFuzzerCache.test.ts
+++ b/app/renderer/src/main/src/store/__test__/parseFuzzerCache.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type * as LogCollection from '@/utils/logCollection'
 import { debugToPrintLogs } from '@/utils/logCollection'
-import { safeParseFuzzerCache } from '../parseFuzzerCache'
+import { defaultPostTemplate, HotPatchDefaultContent } from '@/defaultConstants/HTTPFuzzerPage'
+import type {
+  HTTPResponseMatcher,
+  HTTPResponseExtractor,
+} from '@/pages/fuzzer/MatcherAndExtractionCard/MatcherAndExtractionCardType'
+import { safeParseFuzzerCache, sanitizeFuzzerCachePageParams } from '../parseFuzzerCache'
 
 vi.mock('@/utils/logCollection', async (importOriginal) => {
   const actual = await importOriginal<typeof LogCollection>()
@@ -225,5 +230,118 @@ describe('safeParseFuzzerCache', () => {
   it('throws original JSON error when payload is not json', () => {
     expect(() => safeParseFuzzerCache('{not-json')).toThrow(SyntaxError)
     expect(debugToPrintLogs).toHaveBeenCalledWith(expect.objectContaining({ status: 'ERRO' }))
+  })
+
+  it('drops request/hotPatchCode when truncation hits an earlier field; recovery must fall back to defaults', () => {
+    // 真实缓存字段顺序里 request / hotPatchCode 排在 params 之后，截断落在 params 内会连带丢弃二者
+    const broken =
+      '[{"groupChildren":[],"groupId":"0","id":"tab-req","sortFieId":1,"verbose":"req","pageParams":{"actualHost":"","id":"tab-req","isHttps":true,"params":[{"Key":"k","Value":"unclosed'
+    const parsed = safeParseFuzzerCache(broken)
+    expect(parsed[0].pageParams.isHttps).toBe(true)
+    expect(parsed[0].pageParams.request).toBeUndefined()
+    expect(parsed[0].pageParams.hotPatchCode).toBeUndefined()
+    // 恢复端（fetchFuzzerList）须用默认值回填：页面编辑器对空请求提前返回，
+    // 拿到 '' 会一直空白而不会回退默认值；热加载编辑器同理直接展示空串
+    expect(defaultPostTemplate.trim().startsWith('POST')).toBe(true)
+    expect(HotPatchDefaultContent.trim().length).toBeGreaterThan(0)
+  })
+})
+
+const goodMatcher: HTTPResponseMatcher = {
+  SubMatchers: [],
+  SubMatcherCondition: '',
+  MatcherType: 'word',
+  Scope: 'body',
+  Condition: 'and',
+  Group: ['admin'],
+  GroupEncoding: '',
+  Negative: false,
+  ExprType: '',
+  HitColor: 'red',
+  Action: '',
+  filterMode: 'onlyMatch',
+}
+const goodExtractor: HTTPResponseExtractor = {
+  Name: 'data_0',
+  Type: 'regex',
+  Scope: 'body',
+  Groups: ['root'],
+  RegexpMatchGroup: [],
+  XPathAttribute: '',
+}
+
+describe('sanitizeFuzzerCachePageParams', () => {
+  afterEach(() => {
+    vi.mocked(debugToPrintLogs).mockClear()
+  })
+
+  it('returns the original params object when matchers/extractors are intact', () => {
+    const params = { matchers: [goodMatcher], extractors: [goodExtractor], concurrent: 20 }
+    const result = sanitizeFuzzerCachePageParams(params)
+    expect(result).toBe(params)
+    expect(result.matchers).toHaveLength(1)
+    expect(result.extractors).toHaveLength(1)
+    expect(debugToPrintLogs).not.toHaveBeenCalled()
+  })
+
+  it('returns the original params when matchers/extractors are missing or not arrays', () => {
+    const params: { matchers?: HTTPResponseMatcher[]; extractors?: HTTPResponseExtractor[]; concurrent: number } = {
+      concurrent: 20,
+    }
+    expect(sanitizeFuzzerCachePageParams(params)).toBe(params)
+    const nullParams: typeof params = {
+      concurrent: 20,
+      matchers: null as unknown as HTTPResponseMatcher[],
+      extractors: null as unknown as HTTPResponseExtractor[],
+    }
+    expect(sanitizeFuzzerCachePageParams(nullParams)).toBe(nullParams)
+    expect(debugToPrintLogs).not.toHaveBeenCalled()
+  })
+
+  it('drops matchers missing SubMatchers or Group and extractors missing Groups', () => {
+    const brokenSubMatchers = { ...goodMatcher, SubMatchers: undefined } as unknown as HTTPResponseMatcher
+    const brokenGroup = { ...goodMatcher, Group: undefined } as unknown as HTTPResponseMatcher
+    const brokenGroups = { ...goodExtractor, Groups: undefined } as unknown as HTTPResponseExtractor
+    const result = sanitizeFuzzerCachePageParams({
+      matchers: [goodMatcher, brokenSubMatchers, brokenGroup],
+      extractors: [goodExtractor, brokenGroups],
+    })
+    expect(result.matchers).toEqual([goodMatcher])
+    expect(result.extractors).toEqual([goodExtractor])
+    expect(debugToPrintLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'WARN',
+        fun: 'sanitizeFuzzerCachePageParams',
+        content: expect.objectContaining({ matchers: 3, matchersLeft: 1, extractors: 2, extractorsLeft: 1 }),
+      }),
+    )
+  })
+
+  it('keeps other pageParams fields untouched while dropping broken elements', () => {
+    const result = sanitizeFuzzerCachePageParams({
+      request: 'GET / HTTP/1.1',
+      concurrent: 20,
+      matchers: [{ MatcherType: 'word' } as HTTPResponseMatcher],
+      extractors: [],
+    })
+    expect(result.request).toBe('GET / HTTP/1.1')
+    expect(result.concurrent).toBe(20)
+    expect(result.matchers).toEqual([])
+  })
+
+  it('end-to-end: truncated cache yields broken matchers, sanitize makes them panel-safe', () => {
+    const broken =
+      '[{"groupChildren":[],"groupId":"0","id":"httpFuzzer-m","sortFieId":1,"verbose":"m","pageParams":{"actualHost":"","id":"httpFuzzer-m","isHttps":true,"request":"GET /","params":[],"extractors":[],"matchers":[{"MatcherType":"word","Scope":"body","Group":["adm'
+    const parsed = safeParseFuzzerCache(broken)
+    // 截断修复保留残缺 matcher：规则面板直接 .SubMatchers.map / .Group.length 会抛 TypeError
+    expect(parsed[0].pageParams.matchers).toEqual([{ MatcherType: 'word', Scope: 'body' }])
+    expect(() => (parsed[0].pageParams.matchers[0] as HTTPResponseMatcher).SubMatchers.map((ele) => ele)).toThrow(
+      TypeError,
+    )
+
+    const sanitized = sanitizeFuzzerCachePageParams(parsed[0].pageParams)
+    expect(sanitized.matchers).toEqual([])
+    // 清洗后可被规则面板安全消费
+    expect(sanitized.matchers.map((ele) => ele.SubMatchers.length)).toEqual([])
   })
 })

--- a/app/renderer/src/main/src/store/pageInfo.ts
+++ b/app/renderer/src/main/src/store/pageInfo.ts
@@ -692,7 +692,9 @@ export const saveFuzzerCache = debounce(
   { leading: true },
 )
 
-/**处理WF需要缓存的数据 */
+/**
+ * 处理 WF 需要缓存的数据。
+ */
 export const getFuzzerProcessedCacheData = (pageList) => {
   const cache = pageList.map((ele) => {
     const advancedConfigValue = ele.pageParamsInfo?.webFuzzerPageInfo?.advancedConfigValue || defaultAdvancedConfigValue
@@ -701,11 +703,14 @@ export const getFuzzerProcessedCacheData = (pageList) => {
       groupChildren: [],
       groupId: ele.pageGroupId,
       id: ele.pageId,
+      sortFieId: ele.sortFieId,
+      verbose: ele.pageName,
+      expand: ele.expand,
+      color: ele.color,
       pageParams: {
         actualHost: advancedConfigValue.actualHost || '',
         id: ele.pageId,
         isHttps: advancedConfigValue.isHttps,
-        request: ele.pageParamsInfo?.webFuzzerPageInfo?.request || defaultPostTemplate,
         params: advancedConfigValue.params,
         extractors: advancedConfigValue.extractors,
         matchers: advancedConfigValue.matchers,
@@ -714,12 +719,9 @@ export const getFuzzerProcessedCacheData = (pageList) => {
         proxy: advancedConfigValue.proxy,
         minDelaySeconds: advancedConfigValue.minDelaySeconds,
         maxDelaySeconds: advancedConfigValue.maxDelaySeconds,
+        request: ele.pageParamsInfo?.webFuzzerPageInfo?.request || defaultPostTemplate,
         hotPatchCode: hotPatchCode,
       },
-      sortFieId: ele.sortFieId,
-      verbose: ele.pageName,
-      expand: ele.expand,
-      color: ele.color,
     }
   })
   return cache

--- a/app/renderer/src/main/src/store/parseFuzzerCache.ts
+++ b/app/renderer/src/main/src/store/parseFuzzerCache.ts
@@ -1,4 +1,8 @@
 import { debugToPrintLogs } from '@/utils/logCollection'
+import type {
+  HTTPResponseMatcher,
+  HTTPResponseExtractor,
+} from '@/pages/fuzzer/MatcherAndExtractionCard/MatcherAndExtractionCardType'
 
 /**
  * 安全解析 Web Fuzzer 标签页缓存。
@@ -26,6 +30,49 @@ export const safeParseFuzzerCache = (raw: string): any[] => {
       throw error
     }
   }
+}
+
+/**
+ * 清洗缓存恢复出的 pageParams 中残缺的匹配器 / 提取器元素。
+ *
+ * 截断修复按字符串字段截断并补齐括号，截断落在 matcher / extractor 内部时，
+ * 会留下缺 `SubMatchers` / `Group` / `Groups` 等数组的残缺对象；规则面板
+ * 渲染时直接对它们调 .map / .length，会抛 TypeError。这里丢弃残缺元素，
+ * 完好的保持原样（含缓存正常、未触发截断修复的常见场景）。
+ *
+ * @param pageParams - 恢复端组装的标签页参数
+ * @returns 清洗后的 pageParams（原对象不修改）
+ */
+const isMatcherItemBroken = (ele: HTTPResponseMatcher): boolean =>
+  !Array.isArray(ele.SubMatchers) || !Array.isArray(ele.Group)
+
+const isExtractorItemBroken = (ele: HTTPResponseExtractor): boolean => !Array.isArray(ele.Groups)
+
+export const sanitizeFuzzerCachePageParams = <
+  T extends { matchers?: HTTPResponseMatcher[]; extractors?: HTTPResponseExtractor[] },
+>(
+  pageParams: T,
+): T => {
+  const matchers = Array.isArray(pageParams.matchers) ? pageParams.matchers : []
+  const extractors = Array.isArray(pageParams.extractors) ? pageParams.extractors : []
+  const matchersLeft = matchers.filter((ele) => !isMatcherItemBroken(ele))
+  const extractorsLeft = extractors.filter((ele) => !isExtractorItemBroken(ele))
+  if (matchersLeft.length !== matchers.length || extractorsLeft.length !== extractors.length) {
+    debugToPrintLogs({
+      page: 'MainOperatorContent',
+      fun: 'sanitizeFuzzerCachePageParams',
+      status: 'WARN',
+      title: `Web Fuzzer 缓存恢复时丢弃残缺匹配器/提取器（matcher ${matchers.length - matchersLeft.length} 个、extractor ${extractors.length - extractorsLeft.length} 个），打开规则面板将看不到这些残缺项`,
+      content: {
+        matchers: matchers.length,
+        matchersLeft: matchersLeft.length,
+        extractors: extractors.length,
+        extractorsLeft: extractorsLeft.length,
+      },
+    })
+    return { ...pageParams, matchers: matchersLeft, extractors: extractorsLeft }
+  }
+  return pageParams
 }
 
 /**

--- a/app/renderer/src/main/src/store/parseFuzzerCache.ts
+++ b/app/renderer/src/main/src/store/parseFuzzerCache.ts
@@ -1,0 +1,297 @@
+import { debugToPrintLogs } from '@/utils/logCollection'
+
+/**
+ * 安全解析 Web Fuzzer 标签页缓存。
+ * 先尝试直接解析，若失败则尝试修复截断的字符串字段后再解析。
+ * 修复策略：丢弃损坏字段及其后的所有内容，保留前面的完整数据，缺失字段由页面默认值填充。
+ *
+ * @param raw - 原始缓存字符串（JSON 数组格式）
+ * @returns 解析后的标签页对象数组
+ * @throws 如果修复后仍无法解析，抛出原始 JSON 解析错误
+ */
+export const safeParseFuzzerCache = (raw: string): any[] => {
+  try {
+    return parseCache(raw)
+  } catch (error) {
+    try {
+      return parseCache(replaceBrokenTabStrings(raw))
+    } catch {
+      throw error
+    }
+  }
+}
+
+/**
+ * 递归解析 JSON 字符串，若解析结果为字符串则再次解析（处理双重编码）。
+ *
+ * @param raw - JSON 字符串
+ * @returns 解析后的对象/数组
+ */
+const parseCache = (raw: string): any[] => {
+  const parsed = JSON.parse(raw || '[]')
+  if (typeof parsed === 'string') return parseCache(parsed)
+  return parsed
+}
+
+/**
+ * 尝试修复每个标签页片段中被截断的字符串字段。
+ * 对每个片段尝试解析，若失败则调用修复逻辑，丢弃损坏字段及其后内容。
+ *
+ * @param raw - 原始缓存数组字符串
+ * @returns 修复后的完整 JSON 数组字符串
+ */
+const replaceBrokenTabStrings = (raw: string): string => {
+  const tabs = splitTabsRobust(raw).map((segment, index) => {
+    try {
+      JSON.parse(segment)
+      return segment
+    } catch {
+      const { text, field } = repairBrokenTab(segment, index)
+      const tabId = /"id"\s*:\s*"([^"]*)"/.exec(segment)?.[1] || ''
+      const verbose = /"verbose"\s*:\s*"([^"]*)"/.exec(segment)?.[1] || ''
+      const tabLabel = [tabId, verbose].filter(Boolean).join(' / ')
+      debugToPrintLogs({
+        page: 'MainOperatorContent',
+        fun: 'safeParseFuzzerCache',
+        status: 'WARN',
+        title: `Web Fuzzer 第 ${index + 1} 个 tab${tabLabel ? `(${tabLabel})` : ''} ${field}因缓存截断不完整已丢弃，打开后该字段及其后缺失项走页面默认值`,
+        content: { index: index + 1, id: tabId, verbose, field },
+      })
+      return text
+    }
+  })
+  return `[${tabs.join(',')}]`
+}
+
+/**
+ * 切分缓存数组中的每个顶层对象片段。
+ * 不依赖特定字段顺序，通过统计大括号 `{}` 的嵌套层级来定位每个顶层对象。
+ * 支持嵌套对象和截断场景（最后一个未闭合的对象也会被保留）。
+ *
+ * @param raw - 原始缓存字符串（应为一个 JSON 数组）
+ * @returns 每个顶层对象的字符串片段（包含大括号）的数组
+ * @throws 如果输入不是数组或找不到任何顶层对象
+ */
+const splitTabsRobust = (raw: string): string[] => {
+  const body = (raw || '').trim()
+  if (!body.startsWith('[')) throw new Error('not array')
+
+  const inner = body.slice(1).replace(/]\s*$/, '')
+
+  const segments: string[] = []
+  let depth = 0
+  let start = -1
+  let inString = false
+  let escaped = false
+
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i]
+
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (ch === '\\') {
+      escaped = true
+      continue
+    }
+    if (ch === '"') {
+      inString = !inString
+      continue
+    }
+    if (inString) continue
+
+    if (ch === '{') {
+      if (depth === 0) start = i
+      depth++
+    } else if (ch === '}') {
+      depth--
+      if (depth === 0 && start !== -1) {
+        segments.push(inner.slice(start, i + 1).trim())
+        start = -1
+      }
+    }
+  }
+
+  if (start !== -1) {
+    segments.push(inner.slice(start).trim())
+  }
+
+  if (segments.length === 0) {
+    throw new Error('no tab')
+  }
+  return segments
+}
+
+/**
+ * 修复单个标签页片段：定位损坏的字符串字段起始索引，并调用 `removeFromIndex` 截断。
+ *
+ * @param segment - 单个标签页对象的字符串片段
+ * @param index - 该片段在数组中的索引（从0开始），用于补充默认值
+ * @returns 包含修复后的文本片段和损坏字段名的对象
+ * @throws 如果未找到损坏的字符串字段（返回 -1），则抛出错误
+ */
+const repairBrokenTab = (segment: string, index: number): { text: string; field: string } => {
+  const idx = findBrokenStringKeyIndex(segment)
+  if (idx < 0) throw new Error('no truncated string')
+  const field = /^"([^"]*)"/.exec(segment.slice(idx))?.[1] || ''
+  return { text: removeFromIndex(segment, index, idx), field }
+}
+
+/**
+ * 从损坏字段的键名起始处截断，丢弃该字段及其后的所有内容。
+ * 保留前面的完整数据，补全缺失的括号，并为 `verbose` 和 `sortFieId` 补充默认值。
+ *
+ * @param segment - 原始标签页片段
+ * @param index - 当前标签页索引（从0开始）
+ * @param idx - 损坏字段键名的起始索引（指向开头的双引号）
+ * @returns 修复后且可解析的 JSON 字符串
+ */
+const removeFromIndex = (segment: string, index: number, idx: number): string => {
+  const prefix = segment.slice(0, idx).replace(/,\s*$/, '')
+  const fixed = closeBrackets(prefix)
+  const parsed = JSON.parse(fixed)
+
+  if (!parsed.verbose) parsed.verbose = String(index + 1)
+  if (parsed.sortFieId == null) parsed.sortFieId = index + 1
+
+  return JSON.stringify(parsed)
+}
+
+/**
+ * 定位损坏的字符串字段的键名起始索引。
+ * 检测以下三种字符串相关的截断情形：
+ * 1. 字符串值未闭合（文件结束）
+ * 2. 字符串值中未转义引号提前结束，且后续不是合法的分隔符（`,`, `}`, `]`）
+ * 3. 字符串值正常闭合，但文件结束或缺少必要的后续符号
+ *
+ * 若截断发生在数字、布尔值或结构体上，则返回 -1，由外层抛出原始错误。
+ *
+ * @param text - 待检查的字符串片段
+ * @returns 损坏字段键名起始索引（含开头的双引号），若未找到则返回 -1
+ */
+const findBrokenStringKeyIndex = (text: string): number => {
+  let inString = false
+  let escaped = false
+  let expectKey = false
+  let inValueString = false
+  let lastKeyStart = -1
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (ch === '\\') {
+      escaped = true
+      continue
+    }
+
+    if (ch === '"') {
+      inString = !inString
+      if (inString) {
+        if (expectKey) {
+          lastKeyStart = i
+          inValueString = false
+          expectKey = false
+        } else {
+          inValueString = true
+        }
+      } else {
+        if (inValueString) {
+          inValueString = false
+          const next = nextNonWs(text, i + 1)
+          if (next >= text.length) return lastKeyStart
+          const nextChar = text[next]
+          if (nextChar !== ',' && nextChar !== '}' && nextChar !== ']') {
+            return lastKeyStart
+          }
+        }
+      }
+      continue
+    }
+
+    if (inString) continue
+
+    if (/\s/.test(ch)) continue
+
+    if (ch === '{') {
+      expectKey = true
+      continue
+    }
+    if (ch === ',') {
+      expectKey = true
+      continue
+    }
+    if (ch === '[' || ch === '}' || ch === ']') {
+      expectKey = false
+      continue
+    }
+    if (ch === ':') {
+      expectKey = false
+      continue
+    }
+
+    expectKey = false
+  }
+
+  if (inString && lastKeyStart >= 0) {
+    return lastKeyStart
+  }
+
+  return -1
+}
+
+/**
+ * 从指定位置开始查找下一个非空白字符的索引。
+ *
+ * @param text - 待查找的字符串
+ * @param from - 起始搜索位置
+ * @returns 第一个非空白字符的索引，若超出长度则返回 text.length
+ */
+const nextNonWs = (text: string, from: number): number => {
+  let i = from
+  while (i < text.length && /\s/.test(text[i])) i++
+  return i
+}
+
+/**
+ * 补全字符串中未闭合的括号（`{}` 和 `[]`）。
+ * 忽略字符串内的括号，正确处理转义字符。
+ *
+ * @param text - 可能缺少闭合括号的 JSON 片段
+ * @returns 补全括号后的字符串
+ */
+const closeBrackets = (text: string): string => {
+  let inString = false
+  let escaped = false
+  const stack: string[] = []
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (ch === '\\') {
+      escaped = true
+      continue
+    }
+    if (ch === '"') {
+      inString = !inString
+      continue
+    }
+    if (inString) continue
+
+    if (ch === '{' || ch === '[') stack.push(ch)
+    else if ((ch === '}' || ch === ']') && stack.length) stack.pop()
+  }
+
+  let result = text
+  while (stack.length) {
+    result += stack.pop() === '{' ? '}' : ']'
+  }
+  return result
+}

--- a/app/renderer/src/main/src/store/parseFuzzerCache.ts
+++ b/app/renderer/src/main/src/store/parseFuzzerCache.ts
@@ -75,6 +75,9 @@ const replaceBrokenTabStrings = (raw: string): string => {
  * 不依赖特定字段顺序，通过统计大括号 `{}` 的嵌套层级来定位每个顶层对象。
  * 支持嵌套对象和截断场景（最后一个未闭合的对象也会被保留）。
  *
+ * 末尾的 `]` 按外层数组结束符剥掉。截断若落在 params / extractors / matchers / proxy 等嵌套数组上，
+ * 这个 `]` 可能其实是内层括号，字符串修复对不上就会失败；接受这种边界，抛原始错误让用户手动恢复标签页。
+ *
  * @param raw - 原始缓存字符串（应为一个 JSON 数组）
  * @returns 每个顶层对象的字符串片段（包含大括号）的数组
  * @throws 如果输入不是数组或找不到任何顶层对象
@@ -83,6 +86,7 @@ const splitTabsRobust = (raw: string): string[] => {
   const body = (raw || '').trim()
   if (!body.startsWith('[')) throw new Error('not array')
 
+  // 假定末尾 ] 是外层数组的；嵌套数组截断时可能剥错，修失败则外抛
   const inner = body.slice(1).replace(/]\s*$/, '')
 
   const segments: string[] = []

--- a/app/renderer/src/main/src/store/parseFuzzerCache.ts
+++ b/app/renderer/src/main/src/store/parseFuzzerCache.ts
@@ -15,7 +15,14 @@ export const safeParseFuzzerCache = (raw: string): any[] => {
   } catch (error) {
     try {
       return parseCache(replaceBrokenTabStrings(raw))
-    } catch {
+    } catch (repairError) {
+      debugToPrintLogs({
+        page: 'MainOperatorContent',
+        fun: 'safeParseFuzzerCache',
+        status: 'ERRO',
+        title: 'Web Fuzzer 缓存解析失败且截断修复未成功，抛出原始解析错误',
+        content: { originalError: `${error}`, repairError: `${repairError}` },
+      })
       throw error
     }
   }


### PR DESCRIPTION
## 改动类型

- [x] Bug 修复（有用户可见行为修正）

## 🔗 关联 Issue / PR

None

## 💡 背景与方案

原先问题：Web Fuzzer 标签页缓存以 JSON 存储在远端键值中，超过存储上限时 JSON 被截断，`JSON.parse` 直接失败，导致重新打开 Yakit 时整个 Web Fuzzer 标签页丢失（用户视角是「标签页没存上」）。

本次做法：

1. 新增 `safeParseFuzzerCache`（`store/parseFuzzerCache.ts`）：先正常解析；失败时按顶层对象切分缓存数组，对每个 tab 片段定位被截断的字符串字段（未闭合 / 串内未转义引号 / 闭合后 EOF 三种情形），丢弃损坏字段及其后内容、补全括号并回填 `verbose`/`sortFieId` 默认值后重新解析；不可修复（如数字字段被截断）时先记 ERRO 诊断日志再抛出原始错误，仍走既有的 notify + 手动恢复弹窗兜底。
2. 调整缓存序列化字段顺序（`store/pageInfo.ts`）：`verbose`/`sortFieId`/`expand`/`color` 等小体积元数据移到 `pageParams` 之前，`request` 移到 `pageParams` 末尾，使截断发生在长字符串时丢弃的字段最少。
3. 恢复后缺失的 `request`/`hotPatchCode` 走页面默认值（空 request 时编辑器保持默认模板）。
4. 补充测试：解析器 11 个用例（含截断恢复、不可修复抛错与日志断言）、缓存字段顺序防回归断言。

## 影响范围

- Web Fuzzer 标签页缓存被截断时不再整体丢失，可恢复大部分标签页；被截断字段（通常是 `request`/`hotPatchCode`）及其后的字段会丢弃并回落页面默认值，同时在信息日志输出 WARN 提示。
- 缓存写入字段顺序调整仅影响序列化顺序，对解析与既有消费逻辑无影响。
- 其余页面行为不变。

## 代码评审结论

**结论：可以合并**（正确 5 项 / 问题 0 项（P0 0 项 / P1 0 项）/ 警告 2 项）

## 合并方式

- [ ] Create a merge commit（保留完整提交历史）
- [x] Squash and merge（压缩为一条提交）
- [ ] Rebase and merge（线性历史）
