### PR TITLE
fix: 修复 Progress 百分比数字与进度条紧贴的问题

### DIFF
--- a/app/renderer/engine-link-startup/src/theme/componentsTheme/progress.scss
+++ b/app/renderer/engine-link-startup/src/theme/componentsTheme/progress.scss
@@ -77,7 +77,7 @@
 .yakit-modal-wrapper-progress {
   .ant-progress-text {
     display: block;
-    margin-left: 0;
+    margin-left: 8px;
     margin-top: 2px;
   }
 }

--- a/app/renderer/src/main/src/theme/componentsTheme/progress.scss
+++ b/app/renderer/src/main/src/theme/componentsTheme/progress.scss
@@ -77,7 +77,7 @@
 .yakit-modal-wrapper-progress {
   .ant-progress-text {
     display: block;
-    margin-left: 0;
+    margin-left: 8px;
     margin-top: 2px;
   }
 }


### PR DESCRIPTION
## 改动类型

- [ ] 新功能（新页面 / 新选项 / 新能力）
- [x] Bug 修复（有用户可见行为修正）
- [ ] 文档改动
- [ ] 样式 / UI 调整（无逻辑变化）
- [ ] 性能优化
- [ ] 重构（不改变外部行为）
- [ ] 测试改动
- [ ] 构建 / 依赖 / 打包配置
- [ ] CI 流程改动
- [ ] 杂项（脚本 / 工程化 / 版本号）
- [ ] 其他

## 🔗 关联 Issue / PR

None

## 💡 背景与方案

antd 5 中 line 型 Progress 的百分比文字节点被移入 `.ant-progress-outer`（flex 容器）内、紧跟 `flex:1` 的进度条，默认依靠 `margin-inline-start: 8px`（marginXS）留出间隔；而项目主题 `componentsTheme/progress.scss` 中针对 `yakit-progress-wrapper` 等三个类写的 `margin-left: 0`（antd 4 时代用于把数字换行到进度条下方的规则，antd 5 结构变化后 `display: block` 已不再生效）把这个默认间隔抹掉，导致百分比数字紧贴进度条。

本次将主渲染端与 Link 渲染端两份 `componentsTheme/progress.scss` 中的 `margin-left: 0` 恢复为 `8px`（与 antd 默认 marginXS 一致，无论层叠时主题规则还是 antd 注入规则生效，间距都稳定为 8px）。

## 影响范围

- Link 渲染端引擎下载弹窗（DownloadYaklang）的下载进度条
- 主渲染端使用 `yakit-progress-wrapper` / `yakit-hint-progress-wrapper` / `yakit-modal-wrapper-progress` 三个类的组件（DownloadYakit、DownloadYaklang、YakitHint、YakitModal、插件上传、payloadManager 等）中带百分比文字的 line Progress

以上场景的百分比数字与进度条之间恢复 8px 间距；纯样式改动，无逻辑变化。

## 代码评审结论

**结论：可以合并**（正确 3 项 / 问题 0 项（P0 0 项 / P1 0 项）/ 警告 1 项）

## 合并方式

- [ ] Create a merge commit（保留完整提交历史）
- [ ] Squash and merge（压缩为一条提交）
- [x] Rebase and merge（线性历史）
