### PR TITLE
feat: 企业版内联打包中文 i18n 资源并移除语言切换

### DIFF
--- a/app/renderer/engine-link-startup/src/i18n/i18n.ts
+++ b/app/renderer/engine-link-startup/src/i18n/i18n.ts
@@ -1,30 +1,34 @@
 import i18n from 'i18next'
+import type { Resource, ResourceKey } from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import resourcesToBackend from 'i18next-resources-to-backend'
-import { ALL_I18N_NAMESPACES, type I18nNamespace } from './namespaces'
+import { type I18nNamespace } from './namespaces'
 import { __PLATFORM__ } from '@/utils/envfile'
 
 const useI18nInline = __PLATFORM__ ? ['yakitEE', 'irifyEE'].includes(__PLATFORM__) : false
+
 if (useI18nInline) {
-  const loadAllZhResources = async () => {
-    const resources: any = { zh: {} }
-    for (const ns of ALL_I18N_NAMESPACES) {
-      // 静态 import，Vite 会将这些 JSON 打包进主 chunk
-      const mod = await import(`../locales/zh/${ns}.json`)
-      resources.zh[ns] = mod.default
-    }
-    return resources
+  // eager glob 在构建期展开为静态 import，中文资源随本模块同步可用（不产运行时懒 chunk）
+  const modules = import.meta.glob('../locales/zh/*.json', { eager: true, import: 'default' })
+
+  const resources: Resource = { zh: {} }
+  for (const [path, mod] of Object.entries(modules)) {
+    const ns = path
+      .split('/')
+      .pop()!
+      .replace(/\.json$/, '')
+    resources.zh[ns] = mod as ResourceKey
   }
 
-  const resources = await loadAllZhResources()
-  await i18n.use(initReactI18next).init({
+  i18n.use(initReactI18next).init({
     resources, // 仅含中文
     lng: 'zh',
     fallbackLng: false,
-    ns: ALL_I18N_NAMESPACES,
+    initAsync: false,
+    ns: Object.keys(resources.zh) as I18nNamespace[],
     defaultNS: '',
     interpolation: { escapeValue: false },
-    react: { useSuspense: false }, // 同步就绪，无需 fallback
+    react: { useSuspense: false }, // 同步就绪，无需 Suspense fallback
   })
 } else {
   i18n

--- a/app/renderer/engine-link-startup/src/i18n/i18n.ts
+++ b/app/renderer/engine-link-startup/src/i18n/i18n.ts
@@ -1,28 +1,53 @@
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import resourcesToBackend from 'i18next-resources-to-backend'
-import type { I18nNamespace } from './namespaces'
+import { ALL_I18N_NAMESPACES, type I18nNamespace } from './namespaces'
+import { __PLATFORM__ } from '@/utils/envfile'
 
-i18n
-  .use(
-    resourcesToBackend((lng: string, ns: string) => {
-      // 动态 import 让 vite 把每个 (lng, ns) 切成独立 chunk，
-      // 既保留 useI18nNamespaces 的按需懒加载，又让 JSON 经压缩随 JS chunk 一起进入 dist。
-      return import(`../locales/${lng}/${ns}.json`)
-    }),
-  )
-  .use(initReactI18next)
-  .init({
+const useI18nInline = __PLATFORM__ ? ['yakitEE', 'irifyEE'].includes(__PLATFORM__) : false
+if (useI18nInline) {
+  const loadAllZhResources = async () => {
+    const resources: any = { zh: {} }
+    for (const ns of ALL_I18N_NAMESPACES) {
+      // 静态 import，Vite 会将这些 JSON 打包进主 chunk
+      const mod = await import(`../locales/zh/${ns}.json`)
+      resources.zh[ns] = mod.default
+    }
+    return resources
+  }
+
+  const resources = await loadAllZhResources()
+  await i18n.use(initReactI18next).init({
+    resources, // 仅含中文
     lng: 'zh',
     fallbackLng: false,
-    supportedLngs: ['zh', 'en', 'zh-TW'],
-    load: 'currentOnly',
-    ns: ['link', 'yakitUi'] satisfies I18nNamespace[], // 需要预加载
+    ns: ALL_I18N_NAMESPACES,
     defaultNS: '',
-    interpolation: {
-      escapeValue: false,
-    },
-    react: { useSuspense: true },
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false }, // 同步就绪，无需 fallback
   })
+} else {
+  i18n
+    .use(
+      resourcesToBackend((lng: string, ns: string) => {
+        // 动态 import 让 vite 把每个 (lng, ns) 切成独立 chunk，
+        // 既保留 useI18nNamespaces 的按需懒加载，又让 JSON 经压缩随 JS chunk 一起进入 dist。
+        return import(`../locales/${lng}/${ns}.json`)
+      }),
+    )
+    .use(initReactI18next)
+    .init({
+      lng: 'zh',
+      fallbackLng: false,
+      supportedLngs: ['zh', 'en', 'zh-TW'],
+      load: 'currentOnly',
+      ns: ['link', 'yakitUi'] satisfies I18nNamespace[], // 需要预加载
+      defaultNS: '',
+      interpolation: {
+        escapeValue: false,
+      },
+      react: { useSuspense: true },
+    })
+}
 
 export default i18n

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/SoftwareBasics/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/SoftwareBasics/index.tsx
@@ -12,7 +12,7 @@ import { Tooltip } from 'antd'
 import { yakitApp, yakitShell } from '@/utils/electronBridge'
 import { useCountDown, useInViewport, useMemoizedFn } from 'ahooks'
 import { showYakitModal } from '@/components/yakitUI/YakitModal/YakitModalConfirm'
-import { isCommunityYakit } from '@/utils/envfile'
+import { isCommunityYakit, isEnpriTrace } from '@/utils/envfile'
 import { type Lange, normalizeLang, useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import classNames from 'classnames'
 import styles from './SoftwareBasics.module.scss'
@@ -65,7 +65,9 @@ export const SoftwareBasics: React.FC<SoftwareBasicsProps> = React.memo((props) 
       if (isCommunityYakit()) {
         await yakitApp.setYakitHomeConfig('yakitMode', softMode)
       }
-      await yakitApp.setYakitHomeConfig('softLange', softLang)
+      if (!isEnpriTrace()) {
+        await yakitApp.setYakitHomeConfig('softLange', softLang)
+      }
       if (currentPath !== originalHome) {
         await yakitApp.setYakitHomeConfig('YAKIT_HOME', currentPath)
         yakitApp.relaunchApp()
@@ -106,9 +108,11 @@ export const SoftwareBasics: React.FC<SoftwareBasicsProps> = React.memo((props) 
         const mode = config.yakitMode || 'classic'
         setSoftMode(mode as YakitSoftMode)
       }
-      const lang = normalizeLang(config.softLange as Lange)
-      i18n.changeLanguage(lang)
-      setSoftLang(lang)
+      if (!isEnpriTrace()) {
+        const lang = normalizeLang(config.softLange as Lange)
+        i18n.changeLanguage(lang)
+        setSoftLang(lang)
+      }
       setAutoStart(config.autoStart || false)
       const allPaths = [...new Set([home, ...(config.workspaceHistory || [])].filter(Boolean))]
       pendingFetchPathsRef.current = allPaths
@@ -347,29 +351,31 @@ export const SoftwareBasics: React.FC<SoftwareBasicsProps> = React.memo((props) 
           </div>
         </div>
       )}
-      <div className={styles['softwareBasics-item']} style={{ marginBottom: 10 }}>
-        <div className={styles['softwareBasics-item-title']}>{t('SoftwareBasics.langTitle')}</div>
-        <div className={styles['softwareBasics-item-cont']}>
-          <YakitSelect
-            value={softLang}
-            options={[
-              {
-                label: t('SoftwareBasics.langZh'),
-                value: 'zh',
-              },
-              {
-                label: t('SoftwareBasics.langZhTW'),
-                value: 'zh-TW',
-              },
-              {
-                label: t('SoftwareBasics.langEn'),
-                value: 'en',
-              },
-            ]}
-            onChange={handleLangChange}
-          ></YakitSelect>
+      {!isEnpriTrace() && (
+        <div className={styles['softwareBasics-item']} style={{ marginBottom: 10 }}>
+          <div className={styles['softwareBasics-item-title']}>{t('SoftwareBasics.langTitle')}</div>
+          <div className={styles['softwareBasics-item-cont']}>
+            <YakitSelect
+              value={softLang}
+              options={[
+                {
+                  label: t('SoftwareBasics.langZh'),
+                  value: 'zh',
+                },
+                {
+                  label: t('SoftwareBasics.langZhTW'),
+                  value: 'zh-TW',
+                },
+                {
+                  label: t('SoftwareBasics.langEn'),
+                  value: 'en',
+                },
+              ]}
+              onChange={handleLangChange}
+            ></YakitSelect>
+          </div>
         </div>
-      </div>
+      )}
       <div className={styles['footer-btn']}>
         <YakitButton
           data-testid="startup-confirm"

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/index.tsx
@@ -1147,11 +1147,13 @@ export const StartupPage: React.FC = () => {
     const offFromMainWindow = yakitApp.onFromMainWindow((data) => {
       const type = data.yakitStatus
       if (type) {
-        // 重新获取语言
-        yakitApp.getYakitHomeConfig().then((config) => {
-          const lang = normalizeLang(config.softLange as Lange)
-          i18n.changeLanguage(lang)
-        })
+        if (!isEnpriTrace()) {
+          // 重新获取语言
+          yakitApp.getYakitHomeConfig().then((config) => {
+            const lang = normalizeLang(config.softLange as Lange)
+            i18n.changeLanguage(lang)
+          })
+        }
         handleOperations(type, data)
       }
     })

--- a/app/renderer/engine-link-startup/vite.config.ts
+++ b/app/renderer/engine-link-startup/vite.config.ts
@@ -44,4 +44,7 @@ export default defineConfig({
     esbuildOptions: { target: 'esnext' },
     include: ['react', 'react-dom', 'antd', 'monaco-editor'],
   },
+  json: {
+    stringify: true,
+  },
 })

--- a/app/renderer/src/main/src/components/layout/FuncDomain.tsx
+++ b/app/renderer/src/main/src/components/layout/FuncDomain.tsx
@@ -679,6 +679,29 @@ const DBCacheManager = () => {
   }
 }
 
+const LangSwitchMenu = () => {
+  if (!isEnpriTrace()) {
+    return {
+      key: 'i18nSwitching',
+      label: '语言切换',
+      children: [
+        {
+          key: 'zh',
+          label: '简体中文',
+        },
+        {
+          key: 'en',
+          label: '英文',
+        },
+        {
+          key: 'zh-TW',
+          label: '繁体中文',
+        },
+      ],
+    }
+  }
+}
+
 const GetUIOpSettingMenu = (t: (key: string) => string) => {
   // 便携版
   if (isEnpriTraceAgent()) {
@@ -704,24 +727,7 @@ const GetUIOpSettingMenu = (t: (key: string) => string) => {
           { label: '远程', key: 'remote' },
         ],
       },
-      {
-        key: 'i18nSwitching',
-        label: '语言切换',
-        children: [
-          {
-            key: 'zh',
-            label: '简体中文',
-          },
-          {
-            key: 'en',
-            label: '英文',
-          },
-          {
-            key: 'zh-TW',
-            label: '繁体中文',
-          },
-        ],
-      },
+      LangSwitchMenu(),
       { type: 'divider' },
       {
         key: 'logs',
@@ -808,24 +814,7 @@ const GetUIOpSettingMenu = (t: (key: string) => string) => {
         },
       ],
     },
-    {
-      key: 'i18nSwitching',
-      label: '语言切换',
-      children: [
-        {
-          key: 'zh',
-          label: '简体中文',
-        },
-        {
-          key: 'en',
-          label: '英文',
-        },
-        {
-          key: 'zh-TW',
-          label: '繁体中文',
-        },
-      ],
-    },
+    LangSwitchMenu(),
     { type: 'divider' },
     DBCacheManager(),
     {

--- a/app/renderer/src/main/src/components/layout/UILayout.tsx
+++ b/app/renderer/src/main/src/components/layout/UILayout.tsx
@@ -25,6 +25,7 @@ import {
   GetConnectPort,
   getReleaseEditionName,
   isCommunityYakit,
+  isEnpriTrace,
   isEnpriTraceAgent,
   isEnterpriseEdition,
   isMemfit,
@@ -378,8 +379,10 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
         const mode = config.yakitMode || 'classic'
         setSoftMode(mode as SoftMode)
       }
-      const lang = config.softLange || 'zh'
-      i18n.changeLanguage(lang)
+      if (!isEnpriTrace()) {
+        const lang = config.softLange || 'zh'
+        i18n.changeLanguage(lang)
+      }
     } catch (error) {}
   })
 

--- a/app/renderer/src/main/src/i18n/i18n.ts
+++ b/app/renderer/src/main/src/i18n/i18n.ts
@@ -1,37 +1,40 @@
 import i18n from 'i18next'
+import type { Resource, ResourceKey } from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import resourcesToBackend from 'i18next-resources-to-backend'
-import { ALL_I18N_NAMESPACES, type I18nNamespace } from './namespaces'
+import { type I18nNamespace } from './namespaces'
 
 const useI18nInline = process.env.YAKIT_EDITION ? ['yakitEE', 'irifyEE'].includes(process.env.YAKIT_EDITION) : false
 
 if (useI18nInline) {
-  const loadAllZhResources = async () => {
-    const resources: any = { zh: {} }
-    for (const ns of ALL_I18N_NAMESPACES) {
-      // 静态 import，Vite 会将这些 JSON 打包进主 chunk
-      const mod = await import(`../locales/zh/${ns}.json`)
-      resources.zh[ns] = mod.default
-    }
-    return resources
+  // eager glob 在构建期展开为静态 import，中文资源随本模块同步可用（不产运行时懒 chunk）
+  const modules = import.meta.glob('../locales/zh/*.json', { eager: true, import: 'default' })
+
+  const resources: Resource = { zh: {} }
+  for (const [path, mod] of Object.entries(modules)) {
+    const ns = path
+      .split('/')
+      .pop()!
+      .replace(/\.json$/, '')
+    resources.zh[ns] = mod as ResourceKey
   }
 
-  const resources = await loadAllZhResources()
-  await i18n.use(initReactI18next).init({
+  i18n.use(initReactI18next).init({
     resources, // 仅含中文
     lng: 'zh',
     fallbackLng: false,
-    ns: ALL_I18N_NAMESPACES,
+    initAsync: false,
+    ns: Object.keys(resources.zh) as I18nNamespace[],
     defaultNS: '',
     interpolation: { escapeValue: false },
-    react: { useSuspense: false }, // 同步就绪，无需 fallback
+    react: { useSuspense: false }, // 同步就绪，无需 Suspense fallback
   })
 } else {
   i18n
     .use(
       resourcesToBackend((lng: string, ns: string) => {
-        // 动态 import 让 webpack 把每个 (lng, ns) 切成独立 chunk，
-        // 既保留 useI18nNamespaces 的按需懒加载，又让 JSON 经 terser 压缩并随 JS chunk 一起进入 asar。
+        // 动态 import 让 vite 把每个 (lng, ns) 切成独立 chunk，
+        // 既保留 useI18nNamespaces 的按需懒加载，又让 JSON 经压缩随 JS chunk 一起进入 asar。
         return import(`../locales/${lng}/${ns}.json`)
       }),
     )

--- a/app/renderer/src/main/src/i18n/i18n.ts
+++ b/app/renderer/src/main/src/i18n/i18n.ts
@@ -1,47 +1,72 @@
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import resourcesToBackend from 'i18next-resources-to-backend'
-import type { I18nNamespace } from './namespaces'
+import { ALL_I18N_NAMESPACES, type I18nNamespace } from './namespaces'
 
-i18n
-  .use(
-    resourcesToBackend((lng: string, ns: string) => {
-      // 动态 import 让 webpack 把每个 (lng, ns) 切成独立 chunk，
-      // 既保留 useI18nNamespaces 的按需懒加载，又让 JSON 经 terser 压缩并随 JS chunk 一起进入 asar。
-      return import(`../locales/${lng}/${ns}.json`)
-    }),
-  )
-  .use(initReactI18next)
-  .init({
+const useI18nInline = process.env.YAKIT_EDITION ? ['yakitEE', 'irifyEE'].includes(process.env.YAKIT_EDITION) : false
+
+if (useI18nInline) {
+  const loadAllZhResources = async () => {
+    const resources: any = { zh: {} }
+    for (const ns of ALL_I18N_NAMESPACES) {
+      // 静态 import，Vite 会将这些 JSON 打包进主 chunk
+      const mod = await import(`../locales/zh/${ns}.json`)
+      resources.zh[ns] = mod.default
+    }
+    return resources
+  }
+
+  const resources = await loadAllZhResources()
+  await i18n.use(initReactI18next).init({
+    resources, // 仅含中文
     lng: 'zh',
     fallbackLng: false,
-    supportedLngs: ['zh', 'en', 'zh-TW'],
-    ns: [
-      'yakitUi',
-      'yakitRoute',
-      'core',
-      'layout',
-      'customizeMenu',
-      'components',
-      'plugin',
-      'utils',
-      'engineConsole',
-      'yakChat',
-      'home',
-      'history',
-      'webFuzzer',
-      'mitm',
-      'aiAgent',
-      'projectManage',
-      'irifyHome',
-      'apiUtils',
-    ] satisfies I18nNamespace[], // 这几个需要预加载
-    load: 'currentOnly',
+    ns: ALL_I18N_NAMESPACES,
     defaultNS: '',
-    interpolation: {
-      escapeValue: false,
-    },
-    react: { useSuspense: true },
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false }, // 同步就绪，无需 fallback
   })
+} else {
+  i18n
+    .use(
+      resourcesToBackend((lng: string, ns: string) => {
+        // 动态 import 让 webpack 把每个 (lng, ns) 切成独立 chunk，
+        // 既保留 useI18nNamespaces 的按需懒加载，又让 JSON 经 terser 压缩并随 JS chunk 一起进入 asar。
+        return import(`../locales/${lng}/${ns}.json`)
+      }),
+    )
+    .use(initReactI18next)
+    .init({
+      lng: 'zh',
+      fallbackLng: false,
+      supportedLngs: ['zh', 'en', 'zh-TW'],
+      ns: [
+        'yakitUi',
+        'yakitRoute',
+        'core',
+        'layout',
+        'customizeMenu',
+        'components',
+        'plugin',
+        'utils',
+        'engineConsole',
+        'yakChat',
+        'home',
+        'history',
+        'webFuzzer',
+        'mitm',
+        'aiAgent',
+        'projectManage',
+        'irifyHome',
+        'apiUtils',
+      ] satisfies I18nNamespace[], // 这几个需要预加载
+      load: 'currentOnly',
+      defaultNS: '',
+      interpolation: {
+        escapeValue: false,
+      },
+      react: { useSuspense: true },
+    })
+}
 
 export default i18n

--- a/app/renderer/src/main/vite.config.mts
+++ b/app/renderer/src/main/vite.config.mts
@@ -350,5 +350,8 @@ export default defineConfig(({ mode }) => {
     worker: {
       format: 'es',
     },
+    json: {
+      stringify: true,
+    },
   }
 })


### PR DESCRIPTION
## 改动类型

- [x] 新功能（新页面 / 新选项 / 新能力）
- [ ] Bug 修复（有用户可见行为修正）
- [ ] 文档改动
- [ ] 样式 / UI 调整（无逻辑变化）
- [ ] 性能优化
- [ ] 重构（不改变外部行为）
- [ ] 测试改动
- [ ] 构建 / 依赖 / 打包配置
- [ ] CI 流程改动
- [ ] 杂项（脚本 / 工程化 / 版本号）
- [ ] 其他

## 🔗 关联 Issue / PR

None

## 💡 背景与方案

企业版（yakitEE / irifyEE）需要固定中文界面并移除多语言能力。原先所有版本共用 i18next + resourcesToBackend 动态懒加载（zh / en / zh-T 按命名空间懒加载 chunk），且主界面菜单、启动页设置均暴露语言切换入口。

本次按版本拆分 i18n 初始化：

- 企业版：`import.meta.glob('../locales/zh/*.json', { eager: true })` 在构建期将全部中文资源静态内联进入口 chunk，`initAsync: false` 同步完成初始化，不再依赖运行时懒加载 chunk 与顶层 await；
- 其余版本：保持原 resourcesToBackend 按需懒加载不变；
- 企业版界面移除语言切换入口：主界面设置菜单的语言切换子菜单（FuncDomain）、启动页语言下拉与 softLange 配置读写（SoftwareBasics / StartupPage）、UILayout 启动时的 changeLanguage 均按 `isEnpriTrace()` 守卫；
- 两端 vite 配置开启 `json.stringify`，中文 JSON 以压缩形态随 chunk 输出。

## 影响范围

- 企业版（yakitEE / irifyEE）：界面固定简体中文，语言切换入口全部隐藏，不再读写 softLange 配置；首次加载即同步具备全部中文资源（无翻译懒加载）。
- 社区版 / SE / irify / memfit：行为不变（懒加载与语言切换保留）。
- 已验证：两端 type-check 通过；CI 同规则 8 个测试文件 104 用例通过；yakitEE 构建产物确认中文资源以对象字面量内联、页面 chunk 仍懒加载。

## 代码评审结论

**结论：可以合并**（正确 6 项 / 问题 0 项（P0 0 项 / P1 0 项）/ 警告 2 项）

## 合并方式

- [ ] Create a merge commit（保留完整提交历史）
- [x] Squash and merge（压缩为一条提交）
- [ ] Rebase and merge（线性历史）
