### PR TITLE
feat: 对接引擎端结构化事件输出，优化失败提示文案

### DIFF
--- a/.github/workflows/engine-startup-compatibility.yml
+++ b/.github/workflows/engine-startup-compatibility.yml
@@ -10,15 +10,6 @@ on:
       - 'package.json'
       - 'yarn.lock'
       - '.github/workflows/engine-startup-compatibility.yml'
-  push:
-    paths:
-      - 'app/main/**'
-      - 'app/protos/grpc.proto'
-      - 'app/renderer/engine-link-startup/**'
-      - 'scripts/engine-startup/**'
-      - 'package.json'
-      - 'yarn.lock'
-      - '.github/workflows/engine-startup-compatibility.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/engine-startup-compatibility.yml
+++ b/.github/workflows/engine-startup-compatibility.yml
@@ -1,0 +1,151 @@
+name: engine startup compatibility
+
+on:
+  pull_request:
+    paths:
+      - 'app/main/**'
+      - 'app/protos/grpc.proto'
+      - 'app/renderer/engine-link-startup/**'
+      - 'scripts/engine-startup/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/engine-startup-compatibility.yml'
+  push:
+    paths:
+      - 'app/main/**'
+      - 'app/protos/grpc.proto'
+      - 'app/renderer/engine-link-startup/**'
+      - 'scripts/engine-startup/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/engine-startup-compatibility.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  HUSKY: '0'
+  ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+
+jobs:
+  startup:
+    name: startup (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022, ubuntu-24.04, macos-15]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.22.1'
+      - name: Install locked test dependencies without Electron/native build scripts
+        timeout-minutes: 10
+        run: yarn install --frozen-lockfile --ignore-scripts --non-interactive --network-timeout 60000
+      - name: Verify lifecycle, real TCP authentication and owned process cleanup
+        timeout-minutes: 3
+        run: yarn test:engine-startup --reporter=default --reporter=junit --outputFile.junit=engine-startup-junit.xml
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: engine-startup-${{ matrix.os }}-${{ github.run_attempt }}
+          path: engine-startup-junit.xml
+          if-no-files-found: warn
+          retention-days: 14
+
+  recovery-ui:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: app/renderer/engine-link-startup
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.22.1'
+      - name: Install locked Link renderer dependencies
+        timeout-minutes: 10
+        run: yarn install --frozen-lockfile --ignore-scripts --non-interactive --network-timeout 60000
+      - name: Check types
+        run: yarn type-check
+      - name: Check localized recovery messages
+        run: yarn i18n:check
+      - name: Verify recovery buttons and stale asynchronous results
+        timeout-minutes: 3
+        run: yarn test run src/pages/StartupPage --maxWorkers=1 --reporter=default --reporter=junit --outputFile.junit=engine-recovery-junit.xml
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: engine-recovery-ui-${{ github.run_attempt }}
+          path: app/renderer/engine-link-startup/engine-recovery-junit.xml
+          if-no-files-found: warn
+          retention-days: 14
+
+  windows-real-engine:
+    name: Windows real old/new engines
+    runs-on: windows-2022
+    timeout-minutes: 40
+    env:
+      CGO_ENABLED: '1'
+      GOMAXPROCS: '2'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      # Pin both source revisions. Never download an unversioned 'latest' engine.
+      - uses: actions/checkout@v4
+        with:
+          repository: yaklang/yaklang
+          ref: 65467f3cf73d9803b9cee7754008dd317611e3ca
+          path: .engine-source/old
+          persist-credentials: false
+      - uses: actions/checkout@v4
+        with:
+          repository: yaklang/yaklang
+          ref: e873805f11fb0018b8a062db0007c857605c8e42
+          path: .engine-source/new
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.22.1'
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.12'
+          cache: false
+      - name: Install locked client dependencies
+        timeout-minutes: 10
+        run: yarn install --frozen-lockfile --ignore-scripts --non-interactive --network-timeout 60000
+      - name: Build the pre-change engine
+        working-directory: .engine-source/old
+        timeout-minutes: 15
+        run: go build -mod=readonly -p 2 -o "$env:RUNNER_TEMP/yak-old.exe" ./common/yak/cmd/yak.go
+      - name: Build the new engine with the shared dependency cache
+        working-directory: .engine-source/new
+        timeout-minutes: 15
+        run: go build -mod=readonly -p 2 -o "$env:RUNNER_TEMP/yak-new.exe" ./common/yak/cmd/yak.go
+      - name: Verify authenticated startup and port conflict recovery against both binaries
+        timeout-minutes: 5
+        shell: pwsh
+        run: |
+          node scripts/engine-startup/verify-real-engine.cjs "$env:RUNNER_TEMP/yak-old.exe" "$env:RUNNER_TEMP/yak-new.exe" > windows-real-engine.json
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Get-Content windows-real-engine.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: windows-real-engine-${{ github.run_attempt }}
+          path: windows-real-engine.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/engine-startup-compatibility.yml
+++ b/.github/workflows/engine-startup-compatibility.yml
@@ -87,45 +87,37 @@ jobs:
   windows-real-engine:
     name: Windows real old/new engines
     runs-on: windows-2022
-    timeout-minutes: 40
-    env:
-      CGO_ENABLED: '1'
-      GOMAXPROCS: '2'
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      # Pin both source revisions. Never download an unversioned 'latest' engine.
-      - uses: actions/checkout@v4
-        with:
-          repository: yaklang/yaklang
-          ref: 65467f3cf73d9803b9cee7754008dd317611e3ca
-          path: .engine-source/old
-          persist-credentials: false
-      - uses: actions/checkout@v4
-        with:
-          repository: yaklang/yaklang
-          ref: 4f7863298e6cabdeb4ad25e7321743d6a93dd2a3
-          path: .engine-source/new
-          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: '22.22.1'
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.22.12'
-          cache: false
       - name: Install locked client dependencies
         timeout-minutes: 10
         run: yarn install --frozen-lockfile --ignore-scripts --non-interactive --network-timeout 60000
-      - name: Build the pre-change engine
-        working-directory: .engine-source/old
-        timeout-minutes: 15
-        run: go build -mod=readonly -p 2 -o "$env:RUNNER_TEMP/yak-old.exe" ./common/yak/cmd/yak.go
-      - name: Build the new engine with the shared dependency cache
-        working-directory: .engine-source/new
-        timeout-minutes: 15
-        run: go build -mod=readonly -p 2 -o "$env:RUNNER_TEMP/yak-new.exe" ./common/yak/cmd/yak.go
+      - name: Download pinned released engines from CDN and verify SHA-256
+        timeout-minutes: 5
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # Pin published versions AND hashes, including the non-production alpha.
+          # Never compile engines here or follow a moving 'latest' pointer.
+          $engines = @(
+            @{ Version = '1.4.8-beta17'; File = 'yak-old.exe'; SHA256 = '017d3fd2dcde3399f0b26940be94a8d4bb941be2504ccbf36949a67c01eb9d8a' },
+            @{ Version = '1.4.8-alpha0910ipc'; File = 'yak-new.exe'; SHA256 = '351ba169c3ee77b936a619c3f649aa3a4b13d8a692b906176429d527b8ab9a0c' }
+          )
+          foreach ($engine in $engines) {
+            $url = "https://yaklang.oss-accelerate.aliyuncs.com/yak/$($engine.Version)/yak_windows_amd64.exe"
+            $destination = Join-Path $env:RUNNER_TEMP $engine.File
+            curl.exe --fail --location --proto '=https' --proto-redir '=https' --retry 3 --connect-timeout 20 --max-time 120 --output $destination $url
+            if ($LASTEXITCODE -ne 0) { throw "Engine download failed: $($engine.Version)" }
+            $actual = (Get-FileHash -LiteralPath $destination -Algorithm SHA256).Hash
+            if ($actual -ne $engine.SHA256) { throw "Engine SHA-256 mismatch: $($engine.Version)" }
+            Write-Output "Verified $($engine.Version): $actual"
+          }
       - name: Verify authenticated startup and port conflict recovery against both binaries
         timeout-minutes: 5
         shell: pwsh

--- a/.github/workflows/engine-startup-compatibility.yml
+++ b/.github/workflows/engine-startup-compatibility.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: yaklang/yaklang
-          ref: e873805f11fb0018b8a062db0007c857605c8e42
+          ref: 4f7863298e6cabdeb4ad25e7321743d6a93dd2a3
           path: .engine-source/new
           persist-credentials: false
       - uses: actions/setup-node@v4

--- a/app/main/handlers/__test__/newEngineStatus.test.js
+++ b/app/main/handlers/__test__/newEngineStatus.test.js
@@ -1,0 +1,195 @@
+// @vitest-environment node
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+const { EventEmitter } = require('node:events')
+
+function fixture(dispose, options = {}) {
+  const handlers = new Map()
+  const win = new EventEmitter()
+  const lifecycle = new EventEmitter()
+  const startup = { dispose, killOnExit: vi.fn() }
+  const globalYakSetting = { defaultYakGRPCAddr: options.initialAddress || 'old.example:9000' }
+  const callback = options.callback || vi.fn()
+  const getClient = options.getClient || vi.fn()
+  const newClient = options.newClient || vi.fn()
+  const dependencies = {
+    electron: { ipcMain: { handle: (name, handler) => handlers.set(name, handler) } },
+    child_process: {},
+    '../state': { GLOBAL_YAK_SETTING: globalYakSetting },
+    '../filePath': {},
+    '../logFile': {},
+    './utils/engineStartup': options.useRealStartup
+      ? require('../utils/engineStartup')
+      : { createEngineStartup: () => startup },
+  }
+  const module = { exports: {} }
+  vm.runInNewContext(fs.readFileSync(path.join(__dirname, '../newEngineStatus.js'), 'utf8'), {
+    module,
+    Buffer,
+    require: (name) => {
+      if (!(name in dependencies)) throw new Error(`Unexpected dependency: ${name}`)
+      return dependencies[name]
+    },
+    process: lifecycle,
+  })
+  module.exports.registerNewIPC(win, callback, getClient, newClient, 'test-')
+  return {
+    cancel: handlers.get('test-cancel-all-tasks'),
+    connect: handlers.get('test-connect-yaklang-engine'),
+    win,
+    lifecycle,
+    startup,
+    callback,
+    getClient,
+    newClient,
+    globalYakSetting,
+  }
+}
+
+function echoClient(reply) {
+  return {
+    Echo: vi.fn((request, options, callback) => {
+      reply({ request, options, callback })
+      return { cancel: vi.fn() }
+    }),
+    close: vi.fn(),
+  }
+}
+
+describe('startup cleanup IPC', () => {
+  it.each([
+    { ok: true, canceled: 1, status: 'cancelled' },
+    { ok: false, canceled: 0, status: 'process_error', message: 'Engine process did not exit' },
+  ])('preserves the cleanup result: $status', async (result) => {
+    const { cancel } = fixture(vi.fn().mockResolvedValue(result))
+    await expect(cancel()).resolves.toEqual(result)
+  })
+
+  it('does not resolve cancellation before cleanup finishes', async () => {
+    let finish
+    const { cancel } = fixture(vi.fn(() => new Promise((resolve) => (finish = resolve))))
+    const settled = vi.fn()
+    const pending = cancel().then(settled)
+    await Promise.resolve()
+    expect(settled).not.toHaveBeenCalled()
+    const result = { ok: true, canceled: 1, status: 'cancelled' }
+    finish(result)
+    await pending
+    expect(settled).toHaveBeenCalledWith(result)
+  })
+
+  it.each([true, false])('retains the process-exit fallback unless window cleanup succeeds: %s', async (ok) => {
+    const { win, lifecycle, startup } = fixture(vi.fn().mockResolvedValue({ ok }))
+    win.emit('closed')
+    await new Promise(setImmediate)
+    expect(lifecycle.listeners('exit')).toEqual(ok ? [] : [startup.killOnExit])
+  })
+
+  it('retains the process-exit fallback when window cleanup rejects', async () => {
+    const { win, lifecycle, startup } = fixture(vi.fn().mockRejectedValue(new Error('cleanup failed')))
+    win.emit('closed')
+    await new Promise(setImmediate)
+    expect(lifecycle.listeners('exit')).toEqual([startup.killOnExit])
+  })
+})
+
+describe('engine connection IPC', () => {
+  it.each([
+    ['IPv4', { Host: '192.0.2.10', Port: 9011 }, '192.0.2.10:9011'],
+    ['IPv6', { Host: '2001:db8::1', Port: 9012 }, '[2001:db8::1]:9012'],
+    ['Host:Port', { Host: 'engine.example:9013', Port: 1 }, 'engine.example:9013'],
+    ['bracketed IPv6 Host:Port', { Host: '[2001:db8::2]:9014', Port: 1 }, '[2001:db8::2]:9014'],
+  ])('normalizes %s before probing', async (label, params, expectedAddress) => {
+    const client = echoClient(({ request, callback }) => callback(null, { result: request.text }))
+    const callback = vi.fn()
+    const newClient = vi.fn(() => client)
+    const { connect } = fixture(vi.fn(), { useRealStartup: true, callback, newClient })
+
+    await expect(connect(null, { ...params, Mode: 'remote', PemBytes: '', Password: 'secret' })).resolves.toEqual({
+      result: 'Hello Yakit!',
+    })
+
+    expect(newClient).toHaveBeenCalledWith({
+      defaultYakGRPCAddr: expectedAddress,
+      caPem: '',
+      password: 'secret',
+    })
+    expect(callback).toHaveBeenCalledWith(expectedAddress, '', 'secret')
+  })
+
+  it.each([
+    ['zero port', { Host: '127.0.0.1', Port: 0, Mode: 'remote', Password: 'secret' }],
+    ['oversized port', { Host: '127.0.0.1', Port: 65536, Mode: 'remote', Password: 'secret' }],
+    ['non-numeric port', { Host: '127.0.0.1', Port: 'grpc', Mode: 'remote', Password: 'secret' }],
+    ['host containing whitespace', { Host: 'bad host', Port: 9011, Mode: 'remote', Password: 'secret' }],
+    ['host containing a path', { Host: '../engine.sock', Port: 9011, Mode: 'remote', Password: 'secret' }],
+    ['non-loopback local host', { Host: 'localhost', Port: 9011, Mode: 'local', Password: 'secret' }],
+    ['empty local password', { Host: '127.0.0.1', Port: 9011, Mode: 'local', Password: '' }],
+    ['masked local password', { Host: '127.0.0.1', Port: 9011, Mode: 'local', Password: '***' }],
+    ['local password containing a newline', { Host: '127.0.0.1', Port: 9011, Mode: 'local', Password: 'bad\nsecret' }],
+  ])('rejects %s before creating a probe client', async (label, params) => {
+    const newClient = vi.fn()
+    const callback = vi.fn()
+    const { connect } = fixture(vi.fn(), { useRealStartup: true, callback, newClient })
+
+    await expect(connect(null, params)).rejects.toThrow()
+
+    expect(newClient).not.toHaveBeenCalled()
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('preserves existing credentials and client when authentication fails', async () => {
+    const oldClient = { close: vi.fn() }
+    const callback = vi.fn(() => oldClient.close())
+    const probeClient = echoClient(({ callback }) =>
+      callback(Object.assign(new Error('unauthenticated'), { code: 16 })),
+    )
+    const newClient = vi.fn(() => probeClient)
+    const { connect, globalYakSetting } = fixture(vi.fn(), {
+      useRealStartup: true,
+      initialAddress: 'old.example:9000',
+      callback,
+      newClient,
+    })
+
+    await expect(
+      connect(null, { Host: 'new.example', Port: 9011, Mode: 'remote', PemBytes: 'new-ca', Password: 'new-secret' }),
+    ).rejects.toThrow()
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(oldClient.close).not.toHaveBeenCalled()
+    expect(globalYakSetting.defaultYakGRPCAddr).toBe('old.example:9000')
+  })
+
+  it('commits local credentials only after authenticated and anonymous probes complete', async () => {
+    const oldClient = { close: vi.fn() }
+    const callback = vi.fn(() => oldClient.close())
+    let probeCount = 0
+    const newClient = vi.fn((connection) =>
+      echoClient(({ request, callback: finishProbe }) => {
+        probeCount++
+        expect(callback).not.toHaveBeenCalled()
+        expect(oldClient.close).not.toHaveBeenCalled()
+        if (connection.password) finishProbe(null, { result: request.text })
+        else finishProbe(Object.assign(new Error('unauthenticated'), { code: 16 }))
+      }),
+    )
+    const { connect, globalYakSetting } = fixture(vi.fn(), {
+      useRealStartup: true,
+      initialAddress: 'old.example:9000',
+      callback,
+      newClient,
+    })
+
+    await expect(
+      connect(null, { Host: '127.0.0.1', Port: 9011, Mode: 'local', PemBytes: 'local-ca', Password: 'secret' }),
+    ).resolves.toEqual({ result: 'Hello Yakit!' })
+
+    expect(probeCount).toBe(2)
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith('127.0.0.1:9011', 'local-ca', 'secret')
+    expect(oldClient.close).toHaveBeenCalledTimes(1)
+    expect(globalYakSetting.defaultYakGRPCAddr).toBe('127.0.0.1:9011')
+  })
+})

--- a/app/main/handlers/engineStatus.js
+++ b/app/main/handlers/engineStatus.js
@@ -256,7 +256,8 @@ module.exports = (win, callback, getClient, newClient) => {
       hostFormatted = `${hostRaw.substr(0, hostRaw.lastIndexOf(':'))}`
     }
     const addr = `${hostFormatted}:${portFromRaw}`
-    engineLogOutputFileAndUI(win, `原始参数为: ${JSON.stringify(params)}`)
+    const safeConnParams = { Host: params['Host'], Port: params['Port'], IsTLS: params['IsTLS'], Sudo: params['Sudo'] }
+    engineLogOutputFileAndUI(win, `原始参数为: ${JSON.stringify(safeConnParams)}`)
     engineLogOutputFileAndUI(win, `开始连接引擎地址为：${addr} Host: ${hostRaw} Port: ${portFromRaw}`)
     GLOBAL_YAK_SETTING.defaultYakGRPCAddr = addr
 

--- a/app/main/handlers/newEngineStatus.js
+++ b/app/main/handlers/newEngineStatus.js
@@ -9,6 +9,172 @@ const runningTasks = new Map()
 
 const ECHO_TEST_MSG = 'Hello Yakit!'
 
+// #region 引擎 stdout 事件解析
+
+/**
+ * 解析引擎 stdout 单行事件
+ * 事件前缀:
+ *   "yak grpc ready {JSON}"  — 成功,引擎已监听
+ *   "yak grpc failed {JSON}" — 失败,引擎要退出
+ *   "yak grpc ok"            — 旧文本标记,不再据此判定成功
+ * @param {string} line 单行 stdout (已 trim)
+ * @returns {object|null}
+ */
+function parseEngineStdoutLine(line) {
+  if (line.startsWith('yak grpc ready ')) {
+    try {
+      const data = JSON.parse(line.substring('yak grpc ready '.length))
+      return {
+        type: 'ready',
+        schemaVersion: data.schemaVersion,
+        address: data.address,
+        transport: data.transport || 'tcp',
+        instanceId: data.instanceId,
+        engineVersion: data.engineVersion,
+        phaseI18n: data.phaseI18n,
+      }
+    } catch (e) {
+      return null
+    }
+  }
+  if (line.startsWith('yak grpc failed ')) {
+    try {
+      const data = JSON.parse(line.substring('yak grpc failed '.length))
+      return {
+        type: 'failed',
+        schemaVersion: data.schemaVersion,
+        phase: data.phase,
+        reason: data.reason,
+        reasonCode: data.reasonCode || '',
+        elapsedMs: data.elapsedMs,
+        version: data.version,
+        phaseI18n: data.phaseI18n,
+        reasonI18n: data.reasonI18n || null,
+      }
+    } catch (e) {
+      return null
+    }
+  }
+  if (line === 'yak grpc ok') {
+    return { type: 'log_ok' }
+  }
+  return null
+}
+
+/**
+ * 将引擎 failed 事件的 reasonCode + phase 映射到 status 值
+ * @param {string} reasonCode
+ * @param {string} phase
+ * @returns {string}
+ */
+function mapEngineFailedToStatus(reasonCode, phase) {
+  if (reasonCode === 'tcp_bind_in_use') return 'port_occupied'
+  if (reasonCode === 'tcp_bind_denied') return 'port_denied'
+  if (reasonCode === 'tcp_bind_failed') return 'endpoint_unreachable'
+  if (phase === 'database') return 'database_error'
+  if (phase === 'serve') return 'engine_exited'
+  if (phase === 'build_server' || phase === 'cert' || phase === 'init') return 'engine_init_failed'
+  return 'engine_failed'
+}
+
+/**
+ * 从引擎输出中提取 reasonI18n 的中文文案
+ * @param {object} reasonI18n - 引擎输出的 reasonI18n 字段
+ * @returns {string} 中文文案，无值时返回空字符串
+ */
+function pickReasonZh(reasonI18n) {
+  if (!reasonI18n) return ''
+  return reasonI18n.zh || ''
+}
+
+/**
+ * 从引擎输出中提取 phaseI18n 的中文文案
+ * @param {object} phaseI18n - 引擎输出的 phaseI18n 字段
+ * @returns {string} 中文文案，无值时返回空字符串
+ */
+function pickPhaseZh(phaseI18n) {
+  if (!phaseI18n) return ''
+  return phaseI18n.zh || ''
+}
+
+/**
+ * 组装 check 阶段用户可读的 message
+ * 引擎已在每个失败点直接设定 reasonI18n，主进程取来即用，不按 reasonCode 再拼文案。
+ * 当前 dev 引擎的 check-secret JSON 有 phaseI18n 但尚未输出 reasonI18n，
+ * 此时从 info 的 [reasonCode] 前缀 + phase 兜底拼文案。
+ * buildin 旧引擎无 JSON 输出，走 old_version/antivirus_blocked 分支，不会进入此函数。
+ * @param {object} json - check-secret-local-grpc 输出的 JSON
+ * @param {string} reasonCode - 提取出的分类码（仅供日志/诊断）
+ * @param {object} params - 调用参数（含 port）
+ * @returns {string}
+ */
+function buildCheckMessage(json, reasonCode, params) {
+  // 1. 优先用引擎提供的 reasonI18n（核心字段，取来即用）
+  const reasonZh = pickReasonZh(json.reasonI18n)
+  if (reasonZh) return reasonZh
+
+  // 2. 当前 dev 引擎兜底：有 phaseI18n 但缺 reasonI18n，从 info 提取 + phase 拼文案
+  const port = json.port || (params && params.port) || ''
+  const phaseZh = pickPhaseZh(json.phaseI18n)
+  const info = json.info || ''
+  const portLabel = port ? `端口 ${port} ` : ''
+
+  // 旧引擎根据 info 前缀判断具体场景
+  const codeMatch = info.match(/^\[([a-z_]+)\]/)
+  const legacyCode = codeMatch ? codeMatch[1] : ''
+  if (legacyCode === 'tcp_bind_in_use') return `${portLabel}被占用，请结束旧进程或切换端口`
+  if (legacyCode === 'tcp_bind_denied') return `${portLabel}被系统阻止，请以管理员身份运行或检查防火墙`
+  if (legacyCode === 'tcp_bind_failed') return `${portLabel}监听失败，请检查网络配置`
+  if (json.phase === 'database') return `数据库初始化失败，可点击修复进行处理`
+  if (json.phase === 'build_server') return `引擎服务构建失败，请查看日志或联系支持`
+  if (json.phase === 'dial') return `引擎连接失败，请查看日志详细信息`
+  if (json.phase === 'version_rpc') return `引擎认证失败，请查看日志详细信息`
+  if (json.phase === 'wait_connect') return `引擎服务就绪超时，请查看日志或重试`
+
+  // 3. 最终兜底
+  if (info) return info
+  if (phaseZh) return `${phaseZh}失败，请查看日志详细信息`
+  return '引擎环境检查失败，请查看日志详细信息'
+}
+
+/**
+ * 组装 start 阶段用户可读的 message
+ * 引擎已在每个失败点直接设定 reasonI18n，主进程取来即用，不按 reasonCode 再拼文案。
+ * 当前 dev 引擎的 yak grpc failed 事件有 phaseI18n 但可能未输出 reasonI18n，
+ * 此时从 reason 的 [reasonCode] 前缀 + phase 兜底拼文案。
+ * buildin 旧引擎无 failed 事件输出，走轮询 + 进程退出码判定，不会进入此函数。
+ * @param {object} event - 引擎 failed 事件 (parseEngineStdoutLine 输出)
+ * @returns {string}
+ */
+function buildStartMessage(event) {
+  if (!event) return '引擎启动失败，请查看日志详细信息'
+
+  // 1. 优先用引擎提供的 reasonI18n（核心字段，取来即用）
+  const reasonZh = pickReasonZh(event.reasonI18n)
+  if (reasonZh) return reasonZh
+
+  // 2. 当前 dev 引擎兜底：有 phaseI18n 但缺 reasonI18n，从 reason 提取 + phase 拼文案
+  const phaseZh = pickPhaseZh(event.phaseI18n)
+  const reason = event.reason || ''
+
+  // 旧引擎根据 reason 前缀判断具体场景
+  const codeMatch = reason.match(/^\[([a-z_]+)\]/)
+  const legacyCode = codeMatch ? codeMatch[1] : ''
+  if (legacyCode === 'tcp_bind_in_use') return `端口被另一个进程占用，请结束旧进程或切换端口`
+  if (legacyCode === 'tcp_bind_denied') return `端口被系统策略阻止，请以管理员身份运行或检查防火墙`
+  if (legacyCode === 'tcp_bind_failed') return `网络监听失败，请检查网络配置`
+  if (event.phase === 'database') return `数据库初始化失败，可点击修复进行处理`
+  if (event.phase === 'serve') return `引擎服务异常退出，请查看日志或重试`
+  if (event.phase === 'build_server' || event.phase === 'cert') return `引擎服务构建失败，请查看日志或联系支持`
+
+  // 3. 最终兜底
+  if (reason) return reason
+  if (phaseZh) return `${phaseZh}失败，请查看日志详细信息`
+  return '引擎启动失败，请查看日志详细信息'
+}
+
+// #endregion
+
 /** 各版本下的数据库环境变量 */
 const DefaultDBFileEnv = {
   irify: {
@@ -84,7 +250,7 @@ module.exports = {
             if (checkId !== currentCheckId || successDetected || killed) return
             killFun(true)
             engineLogOutputFileAndUI(win, `----- 检查随机密码模式超时 -----`)
-            reject({ status: 'timeout', message: '检查随机密码模式超时' })
+            reject({ status: 'timeout', message: '引擎环境检查超时，请查看日志详细信息' })
           }, timeoutMs)
 
           subprocess.stdout.on('data', (data) => {
@@ -107,7 +273,7 @@ module.exports = {
             clearTimeout(timeoutId)
             engineLogOutputFileAndUI(win, `----- 检查随机密码模式失败 -----`)
             engineLogOutputFileAndUI(win, `process_error: ${error.message}`)
-            reject({ status: 'process_error', message: error.message })
+            reject({ status: 'process_error', message: `引擎进程启动失败：${error.message}` })
           })
 
           subprocess.on('close', (code) => {
@@ -135,57 +301,49 @@ module.exports = {
             }
 
             if (json && json.ok === false) {
-              const reasons = Array.isArray(json.reason)
-                ? json.reason.map((r) => String(r))
-                : [String(json.reason || json.info || combinedOutput || '')]
-              const has = (keyword) => reasons.some((r) => r.includes(keyword))
-
-              if (has('net.Listen(tcp, addr) failed')) {
-                const msg = `端口 ${params.port} 已被占用，请检查是否已有其他 Yakit 实例或进程正在运行，建议用户手动释放或修改端口。`
-                engineLogOutputFileAndUI(win, `----- 检查失败: ${msg} -----`)
-                return reject({ status: 'port_occupied', message: msg, json })
-              } else if (has('build yak grpc server failed')) {
-                const msg = json.info
-                engineLogOutputFileAndUI(win, `----- 检查失败: build yak grpc server failed：${msg} -----`)
-                return reject({
-                  status: 'build_yak_error',
-                  message: msg,
-                  json,
-                })
-              } else if (has('database error')) {
-                const msg = json.info
-                engineLogOutputFileAndUI(win, `----- 检查失败: database error：${msg} -----`)
-                return reject({
-                  status: 'database_error',
-                  message: msg,
-                  json,
-                })
-              } else if (has('dial grpc server failed')) {
-                // 远程，目前没有check处理
-                const msg = json.info
-                engineLogOutputFileAndUI(win, `----- 检查失败: dial grpc server failed：${msg} -----`)
-                return reject({
-                  status: 'dial_error',
-                  message: msg,
-                  json,
-                })
-              } else if (has('call Version RPC failed')) {
-                // 远程，目前没有check处理
-                const msg = json.info
-                engineLogOutputFileAndUI(win, `----- 检查失败: call Version RPC failed：${msg} -----`)
-                return reject({
-                  status: 'call_error',
-                  message: msg,
-                  json,
-                })
-              } else {
-                engineLogOutputFileAndUI(win, `----- 检查失败: unknownReason：${json.info || '未知原因'} -----`)
-                return reject({
-                  status: 'unknownReason',
-                  message: json.info || '未知原因',
-                  json,
-                })
+              // 优先用引擎输出的 reasonCode（新引擎），兜底从 info 正则提取（旧引擎）
+              let reasonCode = json.reasonCode || ''
+              if (!reasonCode) {
+                const infoStr = json.info || ''
+                const codeMatch = infoStr.match(/^\[([a-z_]+)\]/)
+                if (codeMatch) reasonCode = codeMatch[1]
+                // 旧引擎 reason 常量映射
+                if (!reasonCode) {
+                  const reasonStr = Array.isArray(json.reason) ? json.reason[0] : json.reason || ''
+                  if (reasonStr.includes('database')) reasonCode = 'database_error'
+                  else if (reasonStr.includes('build yak grpc')) reasonCode = 'build_server_failed'
+                  else if (reasonStr.includes('dial grpc')) reasonCode = 'dial_failed'
+                  else if (reasonStr.includes('Version RPC')) reasonCode = 'version_rpc_failed'
+                  else if (reasonStr.includes('net.Listen')) reasonCode = 'tcp_bind_failed'
+                  else if (reasonStr.includes('waiting grpc')) reasonCode = 'wait_connect_failed'
+                }
               }
+              // 兼容引擎 phaseI18n 的 Zh/zh 两种字段名
+              const pi = json.phaseI18n || {}
+              const ri = json.reasonI18n || {}
+              const engineEvent = {
+                phase: json.phase || '',
+                reasonCode,
+                reason: json.info || '',
+                phaseI18n: { zh: pi.zh || '', en: pi.en || '' },
+                reasonI18n: ri.zh ? { zh: ri.zh || '', en: ri.en || '' } : null,
+              }
+              // 组装用户可读的 message
+              const message = buildCheckMessage(json, reasonCode, params)
+              // 映射 status
+              let status
+              if (reasonCode === 'tcp_bind_in_use') status = 'port_occupied'
+              else if (reasonCode === 'tcp_bind_denied') status = 'port_denied'
+              else if (reasonCode === 'tcp_bind_failed') status = 'endpoint_unreachable'
+              else if (reasonCode === 'database_error' || json.phase === 'database') status = 'database_error'
+              else if (reasonCode === 'build_server_failed' || json.phase === 'build_server') status = 'build_yak_error'
+              else if (reasonCode === 'dial_failed' || json.phase === 'dial') status = 'dial_error'
+              else if (reasonCode === 'version_rpc_failed' || json.phase === 'version_rpc') status = 'call_error'
+              else if (reasonCode === 'wait_connect_failed' || json.phase === 'wait_connect') status = 'timeout'
+              else status = 'unknownReason'
+
+              engineLogOutputFileAndUI(win, `----- 检查失败: ${message} -----`)
+              return reject({ status, message, json, engineEvent })
             }
 
             if (
@@ -193,30 +351,30 @@ module.exports = {
               /(no such file or directory|The system cannot find the file specified)/i.test(combinedOutput)
             ) {
               engineLogOutputFileAndUI(win, `----- 检查失败：旧版本引擎不支持随机密码模式 -----`)
-              return reject({ status: 'old_version', message: '旧版本引擎不支持随机密码模式' })
+              return reject({ status: 'old_version', message: '引擎版本过低，请更新引擎' })
             }
 
             if (!json && /(flag provided but not defined)/i.test(combinedOutput)) {
               engineLogOutputFileAndUI(win, `----- 检查失败：旧版本无法支持某些参数 -----`)
-              return reject({ status: 'old_version', message: '旧版本无法支持某些参数' })
+              return reject({ status: 'old_version', message: '引擎版本过低，请更新引擎' })
             }
 
             if (!json && !stdout && !stderr) {
               engineLogOutputFileAndUI(win, `----- 检查失败：可能被杀软或防火墙拦截或无法找到引擎 -----`)
               return reject({
                 status: 'antivirus_blocked',
-                message: '可能被杀软或防火墙拦截或无法找到引擎',
+                message: '引擎被杀毒软件拦截，可将应用加入白名单后重启',
               })
             }
 
             engineLogOutputFileAndUI(win, `----- 检查随机密码模式失败 -----`)
-            reject({ status: 'unknown', message: '未知错误，请查看详细日志信息' })
+            reject({ status: 'unknown', message: '引擎环境检查失败，请查看日志详细信息' })
           })
         } catch (e) {
           if (checkId !== currentCheckId) return
           engineLogOutputFileAndUI(win, `----- 执行检查命令时发生异常 -----`)
           engineLogOutputFileAndUI(win, `exception：${e}`)
-          reject({ status: 'exception', message: e.message || String(e) })
+          reject({ status: 'exception', message: `引擎环境检查异常：${e.message || String(e)}` })
         }
       }).catch(async (err) => {
         return Promise.reject({ ok: false, ...err })
@@ -233,6 +391,7 @@ module.exports = {
           status: safeError.status,
           message: safeError.message,
           json: safeError.json || null,
+          engineEvent: safeError.engineEvent || null,
         }
       }
     })
@@ -551,7 +710,13 @@ module.exports = {
         hostFormatted = `${hostRaw.substr(0, hostRaw.lastIndexOf(':'))}`
       }
       const addr = `${hostFormatted}:${portFromRaw}`
-      engineLogOutputFileAndUI(win, `原始参数为: ${JSON.stringify(params)}`)
+      const safeConnParams = {
+        Host: params['Host'],
+        Port: params['Port'],
+        IsTLS: params['IsTLS'],
+        Mode: params['Mode'],
+      }
+      engineLogOutputFileAndUI(win, `原始参数为: ${JSON.stringify(safeConnParams)}`)
       engineLogOutputFileAndUI(win, `开始连接引擎地址为：${addr} Host: ${hostRaw} Port: ${portFromRaw}`)
       GLOBAL_YAK_SETTING.defaultYakGRPCAddr = addr
 
@@ -600,7 +765,8 @@ module.exports = {
           const resultParams = isEnpriTraceAgent ? [...grpcParams, '--disable-output'] : grpcParams
 
           const command = getLocalYaklangEngine()
-          engineLogOutputFileAndUI(win, `启动命令: ${command} ${resultParams.join(' ')}`)
+          const safeResultParams = resultParams.map((p) => (p === password ? '***' : p))
+          engineLogOutputFileAndUI(win, `启动命令: ${command} ${safeResultParams.join(' ')}`)
 
           const defaltEnv = { ...process.env, YAKIT_HOME: getYakitHome() }
           const subprocess = childProcess.spawn(command, resultParams, {
@@ -619,6 +785,10 @@ module.exports = {
           const taskKey = 'start_' + checkId
           let cleaned = false
           let pollIntervalId = null
+          let stdoutLineBuffer = ''
+          let readyEventAddress = null
+          let engineFailedEvent = null
+          let settled = false
           const timeoutMs = 60000 // 增加到 60 秒，配合轮询检测
 
           /** 轮询检测引擎连接状态 */
@@ -634,7 +804,7 @@ module.exports = {
               }
 
               // 尝试连接引擎
-              const addr = `127.0.0.1:${port}`
+              const addr = readyEventAddress || `127.0.0.1:${port}`
               engineLogOutputFileAndUI(win, `轮询尝试连接引擎: ${addr}`)
 
               try {
@@ -698,13 +868,14 @@ module.exports = {
             if (checkId !== currentStartId || successDetected || killed) return
             killFun(true)
             engineLogOutputFileAndUI(win, `----- 启动本地引擎超时 (60s) -----`)
-            reject({ status: 'timeout', message: '启动本地引擎超时' })
+            reject({ status: 'timeout', message: '引擎启动超时，请查看日志或重试' })
           }, timeoutMs)
 
           /** 成功回调，确保只触发一次 */
           const onSuccess = (msg1, msg2) => {
-            if (checkId !== currentStartId || successDetected || killed) return
+            if (checkId !== currentStartId || successDetected || killed || settled) return
             successDetected = true
+            settled = true
             cleanup()
             cleanTask()
             clearTimeout(timeoutId)
@@ -718,6 +889,7 @@ module.exports = {
             stdout += output
             engineLogOutputFileAndUI(win, output)
 
+            // 检测数据库初始化标记（保留原有逻辑）
             const regex = /<json-f97f966eb7f8ba8fdb63e4d29109c058>(.*?)<json-f97f966eb7f8ba8fdb63e4d29109c058>/
 
             const match = output.match(regex)
@@ -729,9 +901,54 @@ module.exports = {
               win.webContents.send('startUp-engine-msg', 'LocalEngine.database_initializing')
             }
 
-            // 保留原有的 yak grpc ok 检测方式
-            if (/yak grpc ok/i.test(output)) {
-              onSuccess('引擎启动成功（通过 yak grpc ok 检测）', `检测到 'yak grpc ok'，引擎启动成功！`)
+            // 按行解析引擎 stdout 事件（yak grpc ready / failed / ok）
+            stdoutLineBuffer += output
+            const lines = stdoutLineBuffer.split('\n')
+            stdoutLineBuffer = lines.pop()
+            for (const line of lines) {
+              const trimmed = line.trim()
+              if (!trimmed) continue
+              const event = parseEngineStdoutLine(trimmed)
+              if (!event) continue
+              if (event.type === 'ready') {
+                if (settled || successDetected || killed) continue
+                if (event.address) readyEventAddress = event.address
+                engineLogOutputFileAndUI(
+                  win,
+                  `----- 收到引擎 ready 事件: address=${event.address} instanceId=${event.instanceId} transport=${event.transport} -----`,
+                )
+                // 立即尝试用 ready 事件提供的地址连接引擎
+                try {
+                  callback(readyEventAddress || `127.0.0.1:${port}`, '', password)
+                  newClient().Echo({ text: ECHO_TEST_MSG }, (err, data) => {
+                    if (settled || successDetected || killed) return
+                    if (err) {
+                      engineLogOutputFileAndUI(win, `ready 事件后首次连接失败，继续轮询等待...`)
+                      return
+                    }
+                    if (data && data['result'] === ECHO_TEST_MSG) {
+                      onSuccess(
+                        `引擎启动成功（ready 事件 + Echo 握手通过，instanceId=${event.instanceId}）`,
+                        `引擎启动成功！(instanceId=${event.instanceId})`,
+                      )
+                    }
+                  })
+                } catch (e) {
+                  engineLogOutputFileAndUI(win, `ready 事件后连接异常: ${e.message || e}`)
+                }
+              } else if (event.type === 'failed') {
+                if (settled || successDetected || killed) continue
+                settled = true
+                engineFailedEvent = event
+                cleanup()
+                cleanTask()
+                clearTimeout(timeoutId)
+                const status = mapEngineFailedToStatus(event.reasonCode, event.phase)
+                const message = buildStartMessage(event)
+                engineLogOutputFileAndUI(win, `----- 引擎启动失败: ${message} -----`)
+                reject({ status, message, engineEvent: event })
+              }
+              // type === 'log_ok': 仅记日志，不再据此判定成功
             }
           })
 
@@ -753,16 +970,20 @@ module.exports = {
             clearTimeout(timeoutId)
             engineLogOutputFileAndUI(win, `启动引擎出错: ${err.message}`)
             win.webContents.send('start-yaklang-engine-error', `本地引擎遭遇错误，错误原因为：${err}`)
-            reject({ status: 'process_error', message: err.message })
+            reject({ status: 'process_error', message: `引擎进程异常：${err.message}` })
           })
 
           subprocess.on('close', (code) => {
-            if (checkId !== currentStartId || killed || successDetected) return
+            if (checkId !== currentStartId || killed || successDetected || settled) return
             cleanup()
             cleanTask()
             clearTimeout(timeoutId)
             engineLogOutputFileAndUI(win, `----- 引擎进程退出，退出码: ${code} -----`)
-            reject({ status: 'exit', message: `引擎进程提前退出 (${code})` })
+            reject({
+              status: 'exit',
+              message: `引擎进程异常退出（退出码 ${code}），请查看日志或重试`,
+              engineEvent: engineFailedEvent,
+            })
           })
         } catch (e) {
           reject({ status: 'exception', message: e.message || String(e) })
@@ -781,6 +1002,7 @@ module.exports = {
           ok: false,
           status: safeError.status,
           message: safeError.message,
+          engineEvent: safeError.engineEvent || null,
         }
       }
     })

--- a/app/main/handlers/newEngineStatus.js
+++ b/app/main/handlers/newEngineStatus.js
@@ -3,177 +3,10 @@ const childProcess = require('child_process')
 const { GLOBAL_YAK_SETTING } = require('../state')
 const { getLocalYaklangEngine, getYakitHome } = require('../filePath')
 const { engineLogOutputFileAndUI, engineLogOutputUI } = require('../logFile')
+const { createEngineStartup, validLocalPassword } = require('./utils/engineStartup')
 
 // 引擎连接过程中涉及到能中断的执行任务
 const runningTasks = new Map()
-
-const ECHO_TEST_MSG = 'Hello Yakit!'
-
-// #region 引擎 stdout 事件解析
-
-/**
- * 解析引擎 stdout 单行事件
- * 事件前缀:
- *   "yak grpc ready {JSON}"  — 成功,引擎已监听
- *   "yak grpc failed {JSON}" — 失败,引擎要退出
- *   "yak grpc ok"            — 旧文本标记,不再据此判定成功
- * @param {string} line 单行 stdout (已 trim)
- * @returns {object|null}
- */
-function parseEngineStdoutLine(line) {
-  if (line.startsWith('yak grpc ready ')) {
-    try {
-      const data = JSON.parse(line.substring('yak grpc ready '.length))
-      return {
-        type: 'ready',
-        schemaVersion: data.schemaVersion,
-        address: data.address,
-        transport: data.transport || 'tcp',
-        instanceId: data.instanceId,
-        engineVersion: data.engineVersion,
-        phaseI18n: data.phaseI18n,
-      }
-    } catch (e) {
-      return null
-    }
-  }
-  if (line.startsWith('yak grpc failed ')) {
-    try {
-      const data = JSON.parse(line.substring('yak grpc failed '.length))
-      return {
-        type: 'failed',
-        schemaVersion: data.schemaVersion,
-        phase: data.phase,
-        reason: data.reason,
-        reasonCode: data.reasonCode || '',
-        elapsedMs: data.elapsedMs,
-        version: data.version,
-        phaseI18n: data.phaseI18n,
-        reasonI18n: data.reasonI18n || null,
-      }
-    } catch (e) {
-      return null
-    }
-  }
-  if (line === 'yak grpc ok') {
-    return { type: 'log_ok' }
-  }
-  return null
-}
-
-/**
- * 将引擎 failed 事件的 reasonCode + phase 映射到 status 值
- * @param {string} reasonCode
- * @param {string} phase
- * @returns {string}
- */
-function mapEngineFailedToStatus(reasonCode, phase) {
-  if (reasonCode === 'tcp_bind_in_use') return 'port_occupied'
-  if (reasonCode === 'tcp_bind_denied') return 'port_denied'
-  if (reasonCode === 'tcp_bind_failed') return 'endpoint_unreachable'
-  if (phase === 'database') return 'database_error'
-  if (phase === 'serve') return 'engine_exited'
-  if (phase === 'build_server' || phase === 'cert' || phase === 'init') return 'engine_init_failed'
-  return 'engine_failed'
-}
-
-/**
- * 从引擎输出中提取 reasonI18n 的中文文案
- * @param {object} reasonI18n - 引擎输出的 reasonI18n 字段
- * @returns {string} 中文文案，无值时返回空字符串
- */
-function pickReasonZh(reasonI18n) {
-  if (!reasonI18n) return ''
-  return reasonI18n.zh || ''
-}
-
-/**
- * 从引擎输出中提取 phaseI18n 的中文文案
- * @param {object} phaseI18n - 引擎输出的 phaseI18n 字段
- * @returns {string} 中文文案，无值时返回空字符串
- */
-function pickPhaseZh(phaseI18n) {
-  if (!phaseI18n) return ''
-  return phaseI18n.zh || ''
-}
-
-/**
- * 组装 check 阶段用户可读的 message
- * 引擎已在每个失败点直接设定 reasonI18n，主进程取来即用，不按 reasonCode 再拼文案。
- * 当前 dev 引擎的 check-secret JSON 有 phaseI18n 但尚未输出 reasonI18n，
- * 此时从 info 的 [reasonCode] 前缀 + phase 兜底拼文案。
- * buildin 旧引擎无 JSON 输出，走 old_version/antivirus_blocked 分支，不会进入此函数。
- * @param {object} json - check-secret-local-grpc 输出的 JSON
- * @param {string} reasonCode - 提取出的分类码（仅供日志/诊断）
- * @param {object} params - 调用参数（含 port）
- * @returns {string}
- */
-function buildCheckMessage(json, reasonCode, params) {
-  // 1. 优先用引擎提供的 reasonI18n（核心字段，取来即用）
-  const reasonZh = pickReasonZh(json.reasonI18n)
-  if (reasonZh) return reasonZh
-
-  // 2. 当前 dev 引擎兜底：有 phaseI18n 但缺 reasonI18n，从 info 提取 + phase 拼文案
-  const port = json.port || (params && params.port) || ''
-  const phaseZh = pickPhaseZh(json.phaseI18n)
-  const info = json.info || ''
-  const portLabel = port ? `端口 ${port} ` : ''
-
-  // 旧引擎根据 info 前缀判断具体场景
-  const codeMatch = info.match(/^\[([a-z_]+)\]/)
-  const legacyCode = codeMatch ? codeMatch[1] : ''
-  if (legacyCode === 'tcp_bind_in_use') return `${portLabel}被占用，请结束旧进程或切换端口`
-  if (legacyCode === 'tcp_bind_denied') return `${portLabel}被系统阻止，请以管理员身份运行或检查防火墙`
-  if (legacyCode === 'tcp_bind_failed') return `${portLabel}监听失败，请检查网络配置`
-  if (json.phase === 'database') return `数据库初始化失败，可点击修复进行处理`
-  if (json.phase === 'build_server') return `引擎服务构建失败，请查看日志或联系支持`
-  if (json.phase === 'dial') return `引擎连接失败，请查看日志详细信息`
-  if (json.phase === 'version_rpc') return `引擎认证失败，请查看日志详细信息`
-  if (json.phase === 'wait_connect') return `引擎服务就绪超时，请查看日志或重试`
-
-  // 3. 最终兜底
-  if (info) return info
-  if (phaseZh) return `${phaseZh}失败，请查看日志详细信息`
-  return '引擎环境检查失败，请查看日志详细信息'
-}
-
-/**
- * 组装 start 阶段用户可读的 message
- * 引擎已在每个失败点直接设定 reasonI18n，主进程取来即用，不按 reasonCode 再拼文案。
- * 当前 dev 引擎的 yak grpc failed 事件有 phaseI18n 但可能未输出 reasonI18n，
- * 此时从 reason 的 [reasonCode] 前缀 + phase 兜底拼文案。
- * buildin 旧引擎无 failed 事件输出，走轮询 + 进程退出码判定，不会进入此函数。
- * @param {object} event - 引擎 failed 事件 (parseEngineStdoutLine 输出)
- * @returns {string}
- */
-function buildStartMessage(event) {
-  if (!event) return '引擎启动失败，请查看日志详细信息'
-
-  // 1. 优先用引擎提供的 reasonI18n（核心字段，取来即用）
-  const reasonZh = pickReasonZh(event.reasonI18n)
-  if (reasonZh) return reasonZh
-
-  // 2. 当前 dev 引擎兜底：有 phaseI18n 但缺 reasonI18n，从 reason 提取 + phase 拼文案
-  const phaseZh = pickPhaseZh(event.phaseI18n)
-  const reason = event.reason || ''
-
-  // 旧引擎根据 reason 前缀判断具体场景
-  const codeMatch = reason.match(/^\[([a-z_]+)\]/)
-  const legacyCode = codeMatch ? codeMatch[1] : ''
-  if (legacyCode === 'tcp_bind_in_use') return `端口被另一个进程占用，请结束旧进程或切换端口`
-  if (legacyCode === 'tcp_bind_denied') return `端口被系统策略阻止，请以管理员身份运行或检查防火墙`
-  if (legacyCode === 'tcp_bind_failed') return `网络监听失败，请检查网络配置`
-  if (event.phase === 'database') return `数据库初始化失败，可点击修复进行处理`
-  if (event.phase === 'serve') return `引擎服务异常退出，请查看日志或重试`
-  if (event.phase === 'build_server' || event.phase === 'cert') return `引擎服务构建失败，请查看日志或联系支持`
-
-  // 3. 最终兜底
-  if (reason) return reason
-  if (phaseZh) return `${phaseZh}失败，请查看日志详细信息`
-  return '引擎启动失败，请查看日志详细信息'
-}
-
-// #endregion
 
 /** 各版本下的数据库环境变量 */
 const DefaultDBFileEnv = {
@@ -194,207 +27,28 @@ module.exports = {
       engineLogOutputUI(win, `${msg}`, true)
     })
 
-    let currentCheckId = 0 // 全局任务标识
-    /** check校验 */
-    const asyncAllowSecretLocal = async (win, params) => {
-      const checkId = ++currentCheckId // 本次任务唯一 ID
-
-      return new Promise((resolve, reject) => {
-        try {
-          const { port, softwareVersion } = params
-          const command = getLocalYaklangEngine()
-          const args = ['check-secret-local-grpc', '--port', String(port)]
-
-          engineLogOutputFileAndUI(win, `----- 检查本地随机密码模式支持 -----`)
-          engineLogOutputFileAndUI(win, `执行命令: ${command} ${args.join(' ')}`)
-
-          const defaltEnv = { ...process.env, YAKIT_HOME: getYakitHome() }
-          const subprocess = childProcess.spawn(command, args, {
-            stdio: ['ignore', 'pipe', 'pipe'],
-            env: { ...defaltEnv, ...(DefaultDBFileEnv[softwareVersion] || {}) },
-          })
-
-          let stdout = ''
-          let stderr = ''
-          const timeoutMs = 11000
-          let killed = false
-          let successDetected = false
-          const taskKey = 'check_' + checkId
-          let cleaned = false
-
-          const killFun = (timeOut = false) => {
-            if (killed) return
-            killed = true
-            cleanTask()
-            clearTimeout(timeoutId)
-            !timeOut && engineLogOutputFileAndUI(win, `----- 执行中止 check -----`)
-            try {
-              subprocess.kill()
-              if (process.platform === 'win32') {
-                childProcess.exec(`taskkill /PID ${subprocess.pid} /T /F`)
-              } else {
-                process.kill(subprocess.pid, 'SIGKILL')
-              }
-            } catch {}
-          }
-
-          runningTasks.set(taskKey, killFun)
-
-          const cleanTask = () => {
-            if (cleaned) return
-            cleaned = true
-            runningTasks.delete(taskKey)
-          }
-
-          const timeoutId = setTimeout(() => {
-            if (checkId !== currentCheckId || successDetected || killed) return
-            killFun(true)
-            engineLogOutputFileAndUI(win, `----- 检查随机密码模式超时 -----`)
-            reject({ status: 'timeout', message: '引擎环境检查超时，请查看日志详细信息' })
-          }, timeoutMs)
-
-          subprocess.stdout.on('data', (data) => {
-            if (checkId !== currentCheckId) return // 已过期任务不打印
-            const output = data.toString('utf-8')
-            stdout += output
-            engineLogOutputFileAndUI(win, output)
-          })
-
-          subprocess.stderr.on('data', (data) => {
-            if (checkId !== currentCheckId) return
-            const output = data.toString('utf-8')
-            stderr += output
-            engineLogOutputFileAndUI(win, output)
-          })
-
-          subprocess.on('error', (error) => {
-            if (checkId !== currentCheckId) return
-            cleanTask()
-            clearTimeout(timeoutId)
-            engineLogOutputFileAndUI(win, `----- 检查随机密码模式失败 -----`)
-            engineLogOutputFileAndUI(win, `process_error: ${error.message}`)
-            reject({ status: 'process_error', message: `引擎进程启动失败：${error.message}` })
-          })
-
-          subprocess.on('close', (code) => {
-            if (checkId !== currentCheckId || killed) return
-            cleanTask()
-            clearTimeout(timeoutId)
-            const combinedOutput = (stdout + stderr).trim()
-            engineLogOutputFileAndUI(win, `----- 检查随机密码模式结束，退出码: ${code} -----`)
-
-            // 提取 JSON
-            const match = combinedOutput.match(/<json-[\w-]+>([\s\S]*?)<\/json-[\w-]+>/)
-            let json = null
-            if (match) {
-              try {
-                json = JSON.parse(match[1].trim())
-              } catch (e) {
-                engineLogOutputFileAndUI(win, `JSON 解析失败: ${e.message}`)
-              }
-            }
-
-            if (json && json.ok === true) {
-              successDetected = true
-              engineLogOutputFileAndUI(win, `----- 随机密码模式检查通过 -----`)
-              return resolve({ status: 'success', json })
-            }
-
-            if (json && json.ok === false) {
-              // 优先用引擎输出的 reasonCode（新引擎），兜底从 info 正则提取（旧引擎）
-              let reasonCode = json.reasonCode || ''
-              if (!reasonCode) {
-                const infoStr = json.info || ''
-                const codeMatch = infoStr.match(/^\[([a-z_]+)\]/)
-                if (codeMatch) reasonCode = codeMatch[1]
-                // 旧引擎 reason 常量映射
-                if (!reasonCode) {
-                  const reasonStr = Array.isArray(json.reason) ? json.reason[0] : json.reason || ''
-                  if (reasonStr.includes('database')) reasonCode = 'database_error'
-                  else if (reasonStr.includes('build yak grpc')) reasonCode = 'build_server_failed'
-                  else if (reasonStr.includes('dial grpc')) reasonCode = 'dial_failed'
-                  else if (reasonStr.includes('Version RPC')) reasonCode = 'version_rpc_failed'
-                  else if (reasonStr.includes('net.Listen')) reasonCode = 'tcp_bind_failed'
-                  else if (reasonStr.includes('waiting grpc')) reasonCode = 'wait_connect_failed'
-                }
-              }
-              // 兼容引擎 phaseI18n 的 Zh/zh 两种字段名
-              const pi = json.phaseI18n || {}
-              const ri = json.reasonI18n || {}
-              const engineEvent = {
-                phase: json.phase || '',
-                reasonCode,
-                reason: json.info || '',
-                phaseI18n: { zh: pi.zh || '', en: pi.en || '' },
-                reasonI18n: ri.zh ? { zh: ri.zh || '', en: ri.en || '' } : null,
-              }
-              // 组装用户可读的 message
-              const message = buildCheckMessage(json, reasonCode, params)
-              // 映射 status
-              let status
-              if (reasonCode === 'tcp_bind_in_use') status = 'port_occupied'
-              else if (reasonCode === 'tcp_bind_denied') status = 'port_denied'
-              else if (reasonCode === 'tcp_bind_failed') status = 'endpoint_unreachable'
-              else if (reasonCode === 'database_error' || json.phase === 'database') status = 'database_error'
-              else if (reasonCode === 'build_server_failed' || json.phase === 'build_server') status = 'build_yak_error'
-              else if (reasonCode === 'dial_failed' || json.phase === 'dial') status = 'dial_error'
-              else if (reasonCode === 'version_rpc_failed' || json.phase === 'version_rpc') status = 'call_error'
-              else if (reasonCode === 'wait_connect_failed' || json.phase === 'wait_connect') status = 'timeout'
-              else status = 'unknownReason'
-
-              engineLogOutputFileAndUI(win, `----- 检查失败: ${message} -----`)
-              return reject({ status, message, json, engineEvent })
-            }
-
-            if (
-              !json &&
-              /(no such file or directory|The system cannot find the file specified)/i.test(combinedOutput)
-            ) {
-              engineLogOutputFileAndUI(win, `----- 检查失败：旧版本引擎不支持随机密码模式 -----`)
-              return reject({ status: 'old_version', message: '引擎版本过低，请更新引擎' })
-            }
-
-            if (!json && /(flag provided but not defined)/i.test(combinedOutput)) {
-              engineLogOutputFileAndUI(win, `----- 检查失败：旧版本无法支持某些参数 -----`)
-              return reject({ status: 'old_version', message: '引擎版本过低，请更新引擎' })
-            }
-
-            if (!json && !stdout && !stderr) {
-              engineLogOutputFileAndUI(win, `----- 检查失败：可能被杀软或防火墙拦截或无法找到引擎 -----`)
-              return reject({
-                status: 'antivirus_blocked',
-                message: '引擎被杀毒软件拦截，可将应用加入白名单后重启',
-              })
-            }
-
-            engineLogOutputFileAndUI(win, `----- 检查随机密码模式失败 -----`)
-            reject({ status: 'unknown', message: '引擎环境检查失败，请查看日志详细信息' })
-          })
-        } catch (e) {
-          if (checkId !== currentCheckId) return
-          engineLogOutputFileAndUI(win, `----- 执行检查命令时发生异常 -----`)
-          engineLogOutputFileAndUI(win, `exception：${e}`)
-          reject({ status: 'exception', message: `引擎环境检查异常：${e.message || String(e)}` })
-        }
-      }).catch(async (err) => {
-        return Promise.reject({ ok: false, ...err })
-      })
-    }
-    ipcMain.handle(ipcEventPre + 'check-allow-secret-local-yaklang-engine', async (e, params) => {
-      try {
-        const result = await asyncAllowSecretLocal(win, params)
-        return { ok: true, ...result }
-      } catch (err) {
-        const safeError = typeof err === 'object' && err !== null ? err : { message: String(err) }
-        return {
-          ok: false,
-          status: safeError.status,
-          message: safeError.message,
-          json: safeError.json || null,
-          engineEvent: safeError.engineEvent || null,
-        }
-      }
+    const startup = createEngineStartup({
+      getCommand: getLocalYaklangEngine,
+      getEnv: (softwareVersion) => ({
+        ...process.env,
+        YAKIT_HOME: getYakitHome(),
+        ...(DefaultDBFileEnv[softwareVersion] || {}),
+      }),
+      createClient: (connection) => newClient(connection),
+      commitConnection: ({ defaultYakGRPCAddr, caPem, password }) => {
+        callback(defaultYakGRPCAddr, caPem, password)
+        GLOBAL_YAK_SETTING.defaultYakGRPCAddr = defaultYakGRPCAddr
+      },
+      log: (message) => engineLogOutputFileAndUI(win, message),
+      notify: (message) => {
+        if (!win.isDestroyed()) win.webContents.send('startUp-engine-msg', message)
+      },
     })
+    process.once('exit', startup.killOnExit)
+    win.once('closed', () => {
+      void startup.dispose().finally(() => process.removeListener('exit', startup.killOnExit))
+    })
+    ipcMain.handle(ipcEventPre + 'check-allow-secret-local-yaklang-engine', (e, params) => startup.check(params))
 
     let currentFixId = 0 // 全局任务标识
     /** 修复数据库 */
@@ -690,330 +344,38 @@ module.exports = {
       }
     })
 
-    /** 连接引擎 */
+    /** Probe with an isolated client; commit global credentials only after authentication. */
     ipcMain.handle(ipcEventPre + 'connect-yaklang-engine', async (e, params) => {
-      /**
-       * connect yaklang engine 实际上是为了设置参数，实际上他是不知道远程还是本地
-       * params 中的参数应该有如下：
-       *  @Host: 主机名，可能携带端口
-       *  @Port: 端口
-       *  @Sudo: 是否是管理员权限
-       *  @IsTLS?: 是否是 TLS 加密的
-       *  @PemBytes?: Uint8Array 是 CaPem
-       *  @Password?: 登陆密码
-       */
-      const hostRaw = `${params['Host'] || '127.0.0.1'}`
-      let portFromRaw = `${params['Port']}`
-      let hostFormatted = hostRaw
-      if (hostRaw.lastIndexOf(':') >= 0) {
-        portFromRaw = `${parseInt(hostRaw.substr(hostRaw.lastIndexOf(':') + 1))}`
-        hostFormatted = `${hostRaw.substr(0, hostRaw.lastIndexOf(':'))}`
+      const hostRaw = String(params.Host || '127.0.0.1')
+      let host = hostRaw
+      let port = params.Port
+      const hostWithPort = /^(\[[^\]]+\]|[^:]+):(\d+)$/.exec(hostRaw)
+      if (hostWithPort) [, host, port] = hostWithPort
+      if (!/^\d+$/.test(String(port)) || Number(port) < 1 || Number(port) > 65535 || /[\s/\\]/.test(host)) {
+        throw new Error('引擎连接地址无效')
       }
-      const addr = `${hostFormatted}:${portFromRaw}`
-      const safeConnParams = {
-        Host: params['Host'],
-        Port: params['Port'],
-        IsTLS: params['IsTLS'],
-        Mode: params['Mode'],
+      if (params.Mode === 'local' && (host !== '127.0.0.1' || !validLocalPassword(params.Password))) {
+        throw new Error('本地引擎连接参数无效，请重新检查引擎')
       }
-      engineLogOutputFileAndUI(win, `原始参数为: ${JSON.stringify(safeConnParams)}`)
-      engineLogOutputFileAndUI(win, `开始连接引擎地址为：${addr} Host: ${hostRaw} Port: ${portFromRaw}`)
-      GLOBAL_YAK_SETTING.defaultYakGRPCAddr = addr
-
-      callback(
-        GLOBAL_YAK_SETTING.defaultYakGRPCAddr,
-        Buffer.from(params['PemBytes'] === undefined ? '' : params['PemBytes']).toString('utf-8'),
-        params['Password'] || '',
-      )
-      return await new Promise((resolve, reject) => {
-        const deadline = new Date()
-        // 设置超时时间为60秒
-        deadline.setSeconds(deadline.getSeconds() + 60)
-        newClient().Echo({ text: ECHO_TEST_MSG }, { deadline }, (err, data) => {
-          if (err) {
-            reject(err + '')
-            return
-          }
-          if (data['result'] === ECHO_TEST_MSG) {
-            resolve(data)
-          } else {
-            reject(`ECHO ${ECHO_TEST_MSG} ERROR`)
-          }
-        })
+      const address = `${host.includes(':') && !host.startsWith('[') ? `[${host}]` : host}:${port}`
+      const result = await startup.connect({
+        defaultYakGRPCAddr: address,
+        caPem: Buffer.from(params.PemBytes || '').toString('utf8'),
+        password: params.Password || '',
       })
+      if (!result.ok) throw new Error(result.message)
+      return result.data
     })
-
-    let currentStartId = 0 // 全局启动任务标识
-    /** 启动引擎 */
-    const asyncStartSecretLocalYakEngineServer = async (win, params) => {
-      const checkId = ++currentStartId
-      const { version, port, password, isEnpriTraceAgent, softwareVersion } = params
-
-      return new Promise((resolve, reject) => {
-        engineLogOutputFileAndUI(win, `----- 启动本地引擎进程 (Random Local Password, Port: ${port})  -----`)
-
-        try {
-          const grpcParams = [
-            'grpc',
-            '--local-password',
-            password,
-            '--frontend',
-            `${version || 'yakit'}`,
-            '--port',
-            port,
-          ]
-          const resultParams = isEnpriTraceAgent ? [...grpcParams, '--disable-output'] : grpcParams
-
-          const command = getLocalYaklangEngine()
-          const safeResultParams = resultParams.map((p) => (p === password ? '***' : p))
-          engineLogOutputFileAndUI(win, `启动命令: ${command} ${safeResultParams.join(' ')}`)
-
-          const defaltEnv = { ...process.env, YAKIT_HOME: getYakitHome() }
-          const subprocess = childProcess.spawn(command, resultParams, {
-            detached: false,
-            windowsHide: true,
-            stdio: ['ignore', 'pipe', 'pipe'],
-            env: { ...defaltEnv, ...(DefaultDBFileEnv[softwareVersion] || {}) },
-          })
-
-          subprocess.unref()
-
-          let stdout = ''
-          let stderr = ''
-          let successDetected = false
-          let killed = false
-          const taskKey = 'start_' + checkId
-          let cleaned = false
-          let pollIntervalId = null
-          let stdoutLineBuffer = ''
-          let readyEventAddress = null
-          let engineFailedEvent = null
-          let settled = false
-          const timeoutMs = 60000 // 增加到 60 秒，配合轮询检测
-
-          /** 轮询检测引擎连接状态 */
-          const startConnectionPolling = () => {
-            engineLogOutputFileAndUI(win, `开始轮询检测引擎连接状态 (每 2 秒一次)...`)
-            // 传 i18n key，由渲染端 LocalEngine 翻译后展示
-            win.webContents.send('startUp-engine-msg', 'LocalEngine.waiting_engine_fully_started')
-
-            pollIntervalId = setInterval(() => {
-              if (successDetected || killed || checkId !== currentStartId) {
-                cleanup()
-                return
-              }
-
-              // 尝试连接引擎
-              const addr = readyEventAddress || `127.0.0.1:${port}`
-              engineLogOutputFileAndUI(win, `轮询尝试连接引擎: ${addr}`)
-
-              try {
-                callback(addr, '', password)
-                newClient().Echo({ text: ECHO_TEST_MSG }, (err, data) => {
-                  if (successDetected || killed) return
-
-                  if (err) {
-                    engineLogOutputFileAndUI(win, `轮询连接失败，继续等待...`)
-                    return
-                  }
-
-                  if (data && data['result'] === ECHO_TEST_MSG) {
-                    onSuccess('引擎启动成功（通过连接检测）', `轮询检测到引擎连接成功 (Echo 测试通过)！`)
-                  }
-                })
-              } catch (e) {
-                engineLogOutputFileAndUI(win, `轮询连接异常: ${e.message || e}`)
-              }
-            }, 2000) // 每 2 秒检测一次
-          }
-          // 延迟 2 秒开始轮询，给引擎一点启动时间
-          setTimeout(() => {
-            if (!successDetected && !killed && checkId === currentStartId) {
-              startConnectionPolling()
-            }
-          }, 2000)
-          /** 清理轮询 */
-          const cleanup = () => {
-            if (pollIntervalId) {
-              clearInterval(pollIntervalId)
-              pollIntervalId = null
-            }
-          }
-
-          const killFun = (timeOut = false) => {
-            if (killed) return
-            killed = true
-            cleanup()
-            cleanTask()
-            clearTimeout(timeoutId)
-            !timeOut && engineLogOutputFileAndUI(win, `----- 执行中止 启动本地引擎  -----`)
-            try {
-              subprocess.kill()
-              if (process.platform === 'win32') {
-                childProcess.exec(`taskkill /PID ${subprocess.pid} /T /F`)
-              } else {
-                process.kill(subprocess.pid, 'SIGKILL')
-              }
-            } catch {}
-          }
-
-          runningTasks.set(taskKey, killFun)
-          const cleanTask = () => {
-            if (cleaned) return
-            cleaned = true
-            runningTasks.delete(taskKey)
-          }
-
-          const timeoutId = setTimeout(() => {
-            if (checkId !== currentStartId || successDetected || killed) return
-            killFun(true)
-            engineLogOutputFileAndUI(win, `----- 启动本地引擎超时 (60s) -----`)
-            reject({ status: 'timeout', message: '引擎启动超时，请查看日志或重试' })
-          }, timeoutMs)
-
-          /** 成功回调，确保只触发一次 */
-          const onSuccess = (msg1, msg2) => {
-            if (checkId !== currentStartId || successDetected || killed || settled) return
-            successDetected = true
-            settled = true
-            cleanup()
-            cleanTask()
-            clearTimeout(timeoutId)
-            engineLogOutputFileAndUI(win, msg2)
-            resolve({ status: 'success', msg1 })
-          }
-
-          subprocess.stdout.on('data', (data) => {
-            if (checkId !== currentStartId) return
-            const output = data.toString('utf-8')
-            stdout += output
-            engineLogOutputFileAndUI(win, output)
-
-            // 检测数据库初始化标记（保留原有逻辑）
-            const regex = /<json-f97f966eb7f8ba8fdb63e4d29109c058>(.*?)<json-f97f966eb7f8ba8fdb63e4d29109c058>/
-
-            const match = output.match(regex)
-
-            if (match) {
-              // 数据库正在初始化中...
-              engineLogOutputFileAndUI(win, `----- 数据库正在初始化中... -----`)
-              // 传 i18n key，由渲染端 LocalEngine 翻译后展示
-              win.webContents.send('startUp-engine-msg', 'LocalEngine.database_initializing')
-            }
-
-            // 按行解析引擎 stdout 事件（yak grpc ready / failed / ok）
-            stdoutLineBuffer += output
-            const lines = stdoutLineBuffer.split('\n')
-            stdoutLineBuffer = lines.pop()
-            for (const line of lines) {
-              const trimmed = line.trim()
-              if (!trimmed) continue
-              const event = parseEngineStdoutLine(trimmed)
-              if (!event) continue
-              if (event.type === 'ready') {
-                if (settled || successDetected || killed) continue
-                if (event.address) readyEventAddress = event.address
-                engineLogOutputFileAndUI(
-                  win,
-                  `----- 收到引擎 ready 事件: address=${event.address} instanceId=${event.instanceId} transport=${event.transport} -----`,
-                )
-                // 立即尝试用 ready 事件提供的地址连接引擎
-                try {
-                  callback(readyEventAddress || `127.0.0.1:${port}`, '', password)
-                  newClient().Echo({ text: ECHO_TEST_MSG }, (err, data) => {
-                    if (settled || successDetected || killed) return
-                    if (err) {
-                      engineLogOutputFileAndUI(win, `ready 事件后首次连接失败，继续轮询等待...`)
-                      return
-                    }
-                    if (data && data['result'] === ECHO_TEST_MSG) {
-                      onSuccess(
-                        `引擎启动成功（ready 事件 + Echo 握手通过，instanceId=${event.instanceId}）`,
-                        `引擎启动成功！(instanceId=${event.instanceId})`,
-                      )
-                    }
-                  })
-                } catch (e) {
-                  engineLogOutputFileAndUI(win, `ready 事件后连接异常: ${e.message || e}`)
-                }
-              } else if (event.type === 'failed') {
-                if (settled || successDetected || killed) continue
-                settled = true
-                engineFailedEvent = event
-                cleanup()
-                cleanTask()
-                clearTimeout(timeoutId)
-                const status = mapEngineFailedToStatus(event.reasonCode, event.phase)
-                const message = buildStartMessage(event)
-                engineLogOutputFileAndUI(win, `----- 引擎启动失败: ${message} -----`)
-                reject({ status, message, engineEvent: event })
-              }
-              // type === 'log_ok': 仅记日志，不再据此判定成功
-            }
-          })
-
-          subprocess.stderr.on('data', (data) => {
-            if (checkId !== currentStartId) return
-            const output = data.toString('utf-8')
-            stderr += output
-            engineLogOutputFileAndUI(win, output)
-          })
-
-          process.on('exit', () => {
-            killFun()
-          })
-
-          subprocess.on('error', (err) => {
-            if (checkId !== currentStartId) return
-            cleanup()
-            cleanTask()
-            clearTimeout(timeoutId)
-            engineLogOutputFileAndUI(win, `启动引擎出错: ${err.message}`)
-            win.webContents.send('start-yaklang-engine-error', `本地引擎遭遇错误，错误原因为：${err}`)
-            reject({ status: 'process_error', message: `引擎进程异常：${err.message}` })
-          })
-
-          subprocess.on('close', (code) => {
-            if (checkId !== currentStartId || killed || successDetected || settled) return
-            cleanup()
-            cleanTask()
-            clearTimeout(timeoutId)
-            engineLogOutputFileAndUI(win, `----- 引擎进程退出，退出码: ${code} -----`)
-            reject({
-              status: 'exit',
-              message: `引擎进程异常退出（退出码 ${code}），请查看日志或重试`,
-              engineEvent: engineFailedEvent,
-            })
-          })
-        } catch (e) {
-          reject({ status: 'exception', message: e.message || String(e) })
-        }
-      }).catch(async (err) => {
-        return Promise.reject({ ok: false, ...err })
-      })
-    }
-    ipcMain.handle(ipcEventPre + 'start-secret-local-yaklang-engine', async (e, params) => {
-      try {
-        const result = await asyncStartSecretLocalYakEngineServer(win, params)
-        return { ok: true, ...result }
-      } catch (err) {
-        const safeError = typeof err === 'object' && err !== null ? err : { message: String(err) }
-        return {
-          ok: false,
-          status: safeError.status,
-          message: safeError.message,
-          engineEvent: safeError.engineEvent || null,
-        }
-      }
-    })
+    ipcMain.handle(ipcEventPre + 'start-secret-local-yaklang-engine', (e, params) => startup.start(params))
 
     // 中断连接 取消所有正在执行的任务
-    ipcMain.handle(ipcEventPre + 'cancel-all-tasks', () => {
+    ipcMain.handle(ipcEventPre + 'cancel-all-tasks', async () => {
+      const engineCanceled = await startup.dispose()
       if (runningTasks.size === 0) {
-        return { ok: true, canceled: 0 }
+        return { ok: true, canceled: engineCanceled }
       }
 
-      let count = 0
+      let count = engineCanceled
 
       for (const [, cancel] of runningTasks) {
         try {

--- a/app/main/handlers/newEngineStatus.js
+++ b/app/main/handlers/newEngineStatus.js
@@ -5,9 +5,6 @@ const { getLocalYaklangEngine, getYakitHome } = require('../filePath')
 const { engineLogOutputFileAndUI, engineLogOutputUI } = require('../logFile')
 const { createEngineStartup, validLocalPassword } = require('./utils/engineStartup')
 
-// 引擎连接过程中涉及到能中断的执行任务
-const runningTasks = new Map()
-
 /** 各版本下的数据库环境变量 */
 const DefaultDBFileEnv = {
   irify: {
@@ -48,7 +45,14 @@ module.exports = {
     })
     process.once('exit', startup.killOnExit)
     win.once('closed', () => {
-      void startup.dispose().finally(() => process.removeListener('exit', startup.killOnExit))
+      void startup.dispose().then(
+        (result) => {
+          if (result.ok) process.removeListener('exit', startup.killOnExit)
+        },
+        () => {
+          // Keep the synchronous exit fallback if asynchronous cleanup failed.
+        },
+      )
     })
     ipcMain.handle(ipcEventPre + 'check-allow-secret-local-yaklang-engine', (e, params) => startup.check(params))
 
@@ -374,27 +378,6 @@ module.exports = {
     ipcMain.handle(ipcEventPre + 'start-secret-local-yaklang-engine', (e, params) => startup.start(params))
 
     // 中断连接 取消所有正在执行的任务
-    ipcMain.handle(ipcEventPre + 'cancel-all-tasks', async () => {
-      const engineCanceled = await startup.dispose()
-      if (runningTasks.size === 0) {
-        return { ok: true, canceled: engineCanceled }
-      }
-
-      let count = engineCanceled
-
-      for (const [, cancel] of runningTasks) {
-        try {
-          cancel()
-          count++
-        } catch {}
-      }
-
-      runningTasks.clear()
-
-      return {
-        ok: true,
-        canceled: count,
-      }
-    })
+    ipcMain.handle(ipcEventPre + 'cancel-all-tasks', () => startup.dispose())
   },
 }

--- a/app/main/handlers/newEngineStatus.js
+++ b/app/main/handlers/newEngineStatus.js
@@ -358,11 +358,14 @@ module.exports = {
         throw new Error('本地引擎连接参数无效，请重新检查引擎')
       }
       const address = `${host.includes(':') && !host.startsWith('[') ? `[${host}]` : host}:${port}`
-      const result = await startup.connect({
-        defaultYakGRPCAddr: address,
-        caPem: Buffer.from(params.PemBytes || '').toString('utf8'),
-        password: params.Password || '',
-      })
+      const result = await startup.connect(
+        {
+          defaultYakGRPCAddr: address,
+          caPem: Buffer.from(params.PemBytes || '').toString('utf8'),
+          password: params.Password || '',
+        },
+        params.Mode === 'local',
+      )
       if (!result.ok) throw new Error(result.message)
       return result.data
     })

--- a/app/main/handlers/newEngineStatus.js
+++ b/app/main/handlers/newEngineStatus.js
@@ -314,8 +314,11 @@ module.exports = {
                   else if (reasonStr.includes('build yak grpc')) reasonCode = 'build_server_failed'
                   else if (reasonStr.includes('dial grpc')) reasonCode = 'dial_failed'
                   else if (reasonStr.includes('Version RPC')) reasonCode = 'version_rpc_failed'
-                  else if (reasonStr.includes('net.Listen')) reasonCode = 'tcp_bind_failed'
-                  else if (reasonStr.includes('waiting grpc')) reasonCode = 'wait_connect_failed'
+                  else if (reasonStr.includes('net.Listen')) {
+                    if (reasonStr.includes('is occupied') || reasonStr.includes('address already in use'))
+                      reasonCode = 'tcp_bind_in_use'
+                    else reasonCode = 'tcp_bind_failed'
+                  } else if (reasonStr.includes('waiting grpc')) reasonCode = 'wait_connect_failed'
                 }
               }
               // 兼容引擎 phaseI18n 的 Zh/zh 两种字段名

--- a/app/main/handlers/newEngineStatus.js
+++ b/app/main/handlers/newEngineStatus.js
@@ -41,7 +41,9 @@ module.exports = {
       },
       log: (message) => engineLogOutputFileAndUI(win, message),
       notify: (message) => {
-        if (!win.isDestroyed()) win.webContents.send('startUp-engine-msg', message)
+        try {
+          if (!win.isDestroyed() && !win.webContents.isDestroyed()) win.webContents.send('startUp-engine-msg', message)
+        } catch {}
       },
     })
     process.once('exit', startup.killOnExit)

--- a/app/main/handlers/utils/__test__/engineStartup.integration.test.js
+++ b/app/main/handlers/utils/__test__/engineStartup.integration.test.js
@@ -7,6 +7,54 @@ const { createEngineStartup } = require('../engineStartup')
 const { createEngineGrpcClient } = require('../engineGrpcClient')
 const { grpc, Yak } = require('../../../../../scripts/engine-startup/grpc.cjs')
 
+// Self-signed credentials used only by the loopback integration test.
+const TLS_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDNWLiKxGTU4JCx
+G098i8B/fefyOxuEqSqEfntvOHCNV2oMe+voJWFW0Dy5tCjas47pFvSqmAxCEmhp
+1mH18Uw9toE7X2P8tbbu6v+PN6OvsPXolRQy4IRBgmFAmKZIbfzhJN1qOpYvbANR
+DP5VrICb3izTu3AbMAHk1pborcrQPEwcl7gImi2pP+MZEVU5XyLhAz5wkSZEw0wb
+PN0djSISh3QALmbEX55KveoUyzBcvZYO5RFA392ltOPJaYUkPRz4q9Ve+nTx6b43
+KX0AFhySzBC3wQLz1f1tjwrQMLuqI8K6SX5wSoheokZDhWdFxdXP07fdOcwTqo/x
+n6ZzUZL/AgMBAAECggEAMA1a4d4jWk1Sjp89cn+hhDQKWvzJ67lKYcbXS6eBbxHN
+ly5IfgKBTLdd/nbSOJtcDd95UZJTDAMSu/GW6t6UYLyccTBZTYGYVUBYnUL/4tUe
+Nlbsaxtu14WTDHKsNrbGPklKJtme22oDPKw1uAat8cuD4egyy6noR4yPs9M3apLF
+sJKzGdAhUGJyxw9xpXEVcDQCd4Xc2bnshqKi2E2oste1BJ1xxigRVRQc5qAZ/ERI
+WWS9aTa6eaXiOstyhzsIfPVZNhcJX0aLWQ+AAc7f92v1QTcuPiFChF+OG72EXLCu
+LoLQ1sHhRkiFVk93JtK08mTVFXjJswQ9QCjgIRgzQQKBgQD/NBbKpAohCZTC2Wh1
+n2pzlEeZz2Lxf4kcatbgM5TXJ4XsPDq71yoZEKl1ShX8NdVpZ+LcJU4nyXaLUZuN
+ZbRQjM0L85to+RuejHPlU4vA4cKoUmP36zcQMCALp9Ev7UZw2RFV9IJkk0VjhRKZ
+CmW+CZCa+5tQEr7/L73Q1OIXpQKBgQDN/MumRe15/GrW6K/OSvymMojaQSiGPObA
+cHIdlSmNjA0Ea+gTkDusAG6yk3iy8acP+sm9OJy7mKpQ+nKJQqXqVb0H/kNpnO3/
+FtSwn99lEWN4d9oMJZuTzmzzwGrC/L85lq+wZyvC+UV0l1/AX0RjAcrM2ei/YPil
+6sb82Ove0wKBgQCJwWRMHiAZlUJnq1NnqpWbrf64V+ng0icA3+r9OtqtCPiRfDF4
+E7z1qrjORx929Ngt/ZXHn5uAfo8uxO5idPPQRzCnsufA0jbGbqpgr6hQhYy9rzun
+J6ChbFjf8cZJSJstbv6cl0+LWrOp9LsFQUeKPT+BaS99GaFfvjWH9GHWwQKBgQCA
+/EFRtwwDjOoh9MbRuOcH8zD66j5EALLF4iOzHopMllw4XpGOXozfIc4viGTWOLfS
+K8pT8LVES06rMoiyJsfaOyIJdVAlPB1T1KoOh63NjdvpvbMOVCZdoa9b2yt/OeFM
+YG1XWuNuTcUOQxO0VHNwQ9kH+ZPi8wgAbUl5XyQj/QKBgCx9lGcpC+/dVHgLb/V6
++DCjswqvFAcjh4jD/cusx3L9JyfLSdQDkDmmCvY5wfmhvshDy9X+VIOVu8W4kL2I
+6dsowgBbotmDf5W/hYRqeESCwQUX1ucxdI7iEbf/YNoqMsFW7u0so4c20N2P0Xf0
+ZaoxdgiavpPWtOG++cMDeCBm
+-----END PRIVATE KEY-----`
+const TLS_CERT = `-----BEGIN CERTIFICATE-----
+MIIC6jCCAdKgAwIBAgIJAIQQe8RFAyPxMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV
+BAMMCWxvY2FsaG9zdDAeFw0yNjA5MTEwNDE4NTJaFw0zNjA5MDgwNDE4NTJaMBQx
+EjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAM1YuIrEZNTgkLEbT3yLwH995/I7G4SpKoR+e284cI1Xagx76+glYVbQPLm0
+KNqzjukW9KqYDEISaGnWYfXxTD22gTtfY/y1tu7q/483o6+w9eiVFDLghEGCYUCY
+pkht/OEk3Wo6li9sA1EM/lWsgJveLNO7cBswAeTWluitytA8TByXuAiaLak/4xkR
+VTlfIuEDPnCRJkTDTBs83R2NIhKHdAAuZsRfnkq96hTLMFy9lg7lEUDf3aW048lp
+hSQ9HPir1V76dPHpvjcpfQAWHJLMELfBAvPV/W2PCtAwu6ojwrpJfnBKiF6iRkOF
+Z0XF1c/Tt905zBOqj/GfpnNRkv8CAwEAAaM/MD0wGgYDVR0RBBMwEYIJbG9jYWxo
+b3N0hwR/AAABMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgKkMA0GCSqG
+SIb3DQEBCwUAA4IBAQCZSOMRodKmFvFgvlYswO3UJ/JHl4AKo81i4gFgL9VQRX0P
+ggiThzt0CH07KAHyWgYXzlvxvARtZDhFEodw9P2i+N88WKNjjzwQJYXnLd+gbMU7
+0pqza6aMcthtW6fr/538BXBcFQcBGZEy0/aV7f+WJIwc8sIhdw9P5of6kimzNg00
+P/4wDSVcL+kGI6JXchxNG+eUrWkE4p05iFy1HQsUDHe+xHeNveIwx8lSvDffQAoV
+2cFm522BPkMrctBk8ovOpm7qoKZ4OStxE1XDGs7xavSB5zMswKIAsU5LcP7BgW/X
+d6R3Nz1x7W5f+JHhLWp23B9oSl+/gey9H5EE6wDc
+-----END CERTIFICATE-----`
+
 const scripts = path.resolve(__dirname, '../../../../../scripts/engine-startup')
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 const alive = (child) => child.exitCode === null && child.signalCode === null
@@ -104,7 +152,7 @@ describe('real child processes and authenticated TCP', () => {
       expect((await echo({ ...connection, password })).error.code).toBe(grpc.status.UNAUTHENTICATED)
     }
     expect(logs.join('\n')).not.toContain(checked.json.secret)
-    await manager.dispose()
+    expect(await manager.dispose()).toEqual({ ok: true, canceled: 1, status: 'cancelled' })
     const replacement = net.createServer()
     await new Promise((resolve, reject) => {
       replacement.once('error', reject)
@@ -136,7 +184,7 @@ describe('real child processes and authenticated TCP', () => {
     const port = await freePort()
     const first = manager.start({ port, password: 'first-password' })
     await vi.waitFor(() => expect(children).toHaveLength(1))
-    await manager.cancel()
+    expect(await manager.cancel()).toEqual({ ok: true, canceled: 1, status: 'cancelled' })
     expect((await first).status).toBe('cancelled')
     expect((await manager.start({ port, password: 'second-password' })).ok).toBe(true)
     expect(logs.join('\n')).not.toContain('second-password')
@@ -176,6 +224,61 @@ describe('real child processes and authenticated TCP', () => {
       expect(result.result).toBe('snapshot')
     } finally {
       client.close()
+    }
+  })
+
+  it('allows a remote Echo response after the short startup probe window', async () => {
+    const port = await freePort()
+    const server = new grpc.Server()
+    server.addService(Yak.service, {
+      Echo(call, done) {
+        setTimeout(() => done(null, { result: call.request.text }), 750)
+      },
+    })
+    await new Promise((resolve, reject) => {
+      server.bindAsync(`127.0.0.1:${port}`, grpc.ServerCredentials.createInsecure(), (error) =>
+        error ? reject(error) : resolve(),
+      )
+    })
+    server.start()
+
+    const { manager, commitConnection } = setup('v2', 'success', { connect: 2000, probe: 100 })
+    try {
+      const result = await manager.connect({ defaultYakGRPCAddr: `127.0.0.1:${port}`, password: '', caPem: '' })
+      expect(result).toMatchObject({ ok: true, status: 'success' })
+      expect(commitConnection).toHaveBeenCalledOnce()
+    } finally {
+      server.forceShutdown()
+    }
+  })
+
+  it('allows a delayed TLS Echo within the shared connect budget', async () => {
+    const port = await freePort()
+    const server = new grpc.Server()
+    server.addService(Yak.service, {
+      Echo(call, done) {
+        setTimeout(() => done(null, { result: call.request.text }), 750)
+      },
+    })
+    await new Promise((resolve, reject) => {
+      const credentials = grpc.ServerCredentials.createSsl(null, [
+        { private_key: Buffer.from(TLS_KEY), cert_chain: Buffer.from(TLS_CERT) },
+      ])
+      server.bindAsync(`127.0.0.1:${port}`, credentials, (error) => (error ? reject(error) : resolve()))
+    })
+    server.start()
+
+    const { manager, commitConnection } = setup('v2', 'success', { connect: 2000, probe: 100 })
+    try {
+      const result = await manager.connect({
+        defaultYakGRPCAddr: `localhost:${port}`,
+        password: '',
+        caPem: TLS_CERT,
+      })
+      expect(result).toMatchObject({ ok: true, status: 'success' })
+      expect(commitConnection).toHaveBeenCalledOnce()
+    } finally {
+      server.forceShutdown()
     }
   })
 

--- a/app/main/handlers/utils/__test__/engineStartup.integration.test.js
+++ b/app/main/handlers/utils/__test__/engineStartup.integration.test.js
@@ -1,0 +1,191 @@
+const fs = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+const net = require('node:net')
+const childProcess = require('node:child_process')
+const { createEngineStartup } = require('../engineStartup')
+const { createEngineGrpcClient } = require('../engineGrpcClient')
+const { grpc, Yak } = require('../../../../../scripts/engine-startup/grpc.cjs')
+
+const scripts = path.resolve(__dirname, '../../../../../scripts/engine-startup')
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+const alive = (child) => child.exitCode === null && child.signalCode === null
+const pidAlive = (pid) => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+const listen = () =>
+  new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolve(server))
+  })
+const close = (server) => new Promise((resolve) => server.close(resolve))
+
+describe('real child processes and authenticated TCP', () => {
+  let dir, fixturePath, managers, children, servers, descendants
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'Yakit startup 空格 '))
+    fixturePath = path.join(dir, 'engine fixture.cjs')
+    await fs.copyFile(path.join(scripts, 'fixtures/engine.cjs'), fixturePath)
+    managers = []
+    children = []
+    servers = []
+    descendants = []
+  })
+  afterEach(async () => {
+    await Promise.all(managers.map((manager) => manager.dispose()))
+    for (const pid of descendants) {
+      if (pidAlive(pid)) process.kill(pid, 'SIGKILL')
+    }
+    await Promise.all(servers.map(close))
+    await fs.rm(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 })
+    expect(children.filter(alive)).toHaveLength(0)
+  })
+
+  async function freePort() {
+    const server = await listen()
+    const port = server.address().port
+    await close(server)
+    return port
+  }
+  function setup(contract = 'v2', scenario = 'success', timeouts = {}) {
+    const commitConnection = vi.fn()
+    const logs = []
+    const manager = createEngineStartup({
+      getCommand: () => process.execPath,
+      getEnv: () => ({
+        ...process.env,
+        YAKIT_HOME: dir,
+        YAKIT_TEST_GRPC_HELPER: path.join(scripts, 'grpc.cjs'),
+        YAKIT_TEST_CONTRACT: contract,
+        YAKIT_TEST_SCENARIO: scenario,
+        YAKIT_TEST_DESCENDANT: path.join(dir, 'descendant'),
+      }),
+      spawn: (command, args, options) => {
+        const child = childProcess.spawn(command, [fixturePath, ...args], options)
+        children.push(child)
+        return child
+      },
+      createClient: (connection) => createEngineGrpcClient(Yak, connection),
+      commitConnection,
+      log: (line) => logs.push(line),
+      timeouts: { check: 8000, start: 8000, probe: 500, retry: 200, ...timeouts },
+    })
+    managers.push(manager)
+    return { manager, commitConnection, logs }
+  }
+  function echo(connection) {
+    const client = createEngineGrpcClient(Yak, connection)
+    return new Promise((resolve) => {
+      client.Echo({ text: 'auth test' }, { deadline: new Date(Date.now() + 2000) }, (error, data) => {
+        client.close()
+        resolve({ error, data })
+      })
+    })
+  }
+
+  it.each(['legacy', 'v1', 'v2'])('%s: checks, starts, authenticates and releases the port', async (contract) => {
+    const { manager, commitConnection, logs } = setup(contract)
+    const port = await freePort()
+    const checked = await manager.check({ port })
+    expect(checked.ok).toBe(true)
+    expect(checked.json.secret).toMatch(/^[0-9a-f]{64}$/)
+    const result = await manager.start({ port, password: checked.json.secret })
+    expect(result).toMatchObject({ ok: true, status: 'success' })
+    expect(commitConnection).toHaveBeenCalledOnce()
+    const connection = commitConnection.mock.calls[0][0]
+    expect((await echo(connection)).data).toEqual({ result: 'auth test' })
+    for (const password of ['', '***', 'incorrect']) {
+      expect((await echo({ ...connection, password })).error.code).toBe(grpc.status.UNAUTHENTICATED)
+    }
+    expect(logs.join('\n')).not.toContain(checked.json.secret)
+    await manager.dispose()
+    const replacement = net.createServer()
+    await new Promise((resolve, reject) => {
+      replacement.once('error', reject)
+      replacement.listen(port, '127.0.0.1', resolve)
+    })
+    servers.push(replacement)
+  })
+
+  it.each(['legacy', 'v2'])('%s: preserves an unrelated process occupying the port', async (contract) => {
+    const occupied = await listen()
+    servers.push(occupied)
+    const { manager, commitConnection } = setup(contract)
+    const result = await manager.check({ port: occupied.address().port })
+    expect(result.status).toBe('port_occupied')
+    expect(occupied.listening).toBe(true)
+    expect(commitConnection).not.toHaveBeenCalled()
+  })
+
+  it.each(['hang', 'slow-rpc', 'wrong-auth'])('%s: reaches a deadline and cleans up', async (scenario) => {
+    const { manager, commitConnection } = setup('v2', scenario, { start: 2000 })
+    const result = await manager.start({ port: await freePort(), password: 'real-test-password' })
+    expect(result.status).toBe('timeout')
+    expect(commitConnection).not.toHaveBeenCalled()
+    expect(children.every((child) => !alive(child))).toBe(true)
+  })
+
+  it('cancels a live process and can start again immediately', async () => {
+    const { manager, logs } = setup()
+    const port = await freePort()
+    const first = manager.start({ port, password: 'first-password' })
+    await vi.waitFor(() => expect(children).toHaveLength(1))
+    await manager.cancel()
+    expect((await first).status).toBe('cancelled')
+    expect((await manager.start({ port, password: 'second-password' })).ok).toBe(true)
+    expect(logs.join('\n')).not.toContain('second-password')
+  })
+
+  it('reports an exited executable instead of hanging', async () => {
+    const { manager } = setup('v2', 'crash')
+    expect((await manager.start({ port: await freePort(), password: 'password' })).status).toBe('engine_exited')
+  })
+
+  it('does not commit a connection advertising an unexpected transport', async () => {
+    const { manager, commitConnection } = setup('v2', 'wrong-transport', { retry: 3000 })
+    expect((await manager.start({ port: await freePort(), password: 'password' })).status).toBe('protocol_error')
+    expect(commitConnection).not.toHaveBeenCalled()
+  })
+
+  it('keeps client credentials immutable across other connection attempts', async () => {
+    const { manager, commitConnection } = setup()
+    const port = await freePort()
+    await manager.start({ port, password: 'snapshot-secret' })
+    const settings = { ...commitConnection.mock.calls[0][0] }
+    const client = createEngineGrpcClient(Yak, settings)
+    settings.password = 'changed-global-value'
+    try {
+      const result = await new Promise((resolve, reject) =>
+        client.Echo({ text: 'snapshot' }, { deadline: new Date(Date.now() + 2000) }, (error, data) =>
+          error ? reject(error) : resolve(data),
+        ),
+      )
+      expect(result.result).toBe('snapshot')
+    } finally {
+      client.close()
+    }
+  })
+
+  it.skipIf(process.platform !== 'win32')('Windows: cancels the owned process tree with taskkill', async () => {
+    const { manager } = setup('v2', 'tree')
+    const pending = manager.start({ port: await freePort(), password: 'password' })
+    let pid
+    await vi.waitFor(
+      async () => {
+        pid = Number(await fs.readFile(path.join(dir, 'descendant'), 'utf8'))
+        expect(pidAlive(pid)).toBe(true)
+      },
+      { timeout: 5000 },
+    )
+    descendants.push(pid)
+    await manager.cancel()
+    expect((await pending).status).toBe('cancelled')
+    await vi.waitFor(() => expect(pidAlive(pid)).toBe(false), { timeout: 2000 })
+  })
+})

--- a/app/main/handlers/utils/__test__/engineStartup.integration.test.js
+++ b/app/main/handlers/utils/__test__/engineStartup.integration.test.js
@@ -147,6 +147,13 @@ describe('real child processes and authenticated TCP', () => {
     expect((await manager.start({ port: await freePort(), password: 'password' })).status).toBe('engine_exited')
   })
 
+  it('rejects an Echo server that accepts anonymous requests', async () => {
+    const { manager, commitConnection } = setup('v2', 'unauthenticated')
+    const result = await manager.start({ port: await freePort(), password: 'password' })
+    expect(result.status).toBe('protocol_error')
+    expect(commitConnection).not.toHaveBeenCalled()
+  })
+
   it('does not commit a connection advertising an unexpected transport', async () => {
     const { manager, commitConnection } = setup('v2', 'wrong-transport', { retry: 3000 })
     expect((await manager.start({ port: await freePort(), password: 'password' })).status).toBe('protocol_error')

--- a/app/main/handlers/utils/__test__/engineStartup.integration.test.js
+++ b/app/main/handlers/utils/__test__/engineStartup.integration.test.js
@@ -66,6 +66,14 @@ const pidAlive = (pid) => {
     return false
   }
 }
+const processGroupAlive = (pid) => {
+  try {
+    process.kill(-pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
 const listen = () =>
   new Promise((resolve, reject) => {
     const server = net.createServer()
@@ -75,7 +83,7 @@ const listen = () =>
 const close = (server) => new Promise((resolve) => server.close(resolve))
 
 describe('real child processes and authenticated TCP', () => {
-  let dir, fixturePath, managers, children, servers, descendants
+  let dir, fixturePath, managers, children, servers, descendants, externalChildren
   beforeEach(async () => {
     dir = await fs.mkdtemp(path.join(os.tmpdir(), 'Yakit startup 空格 '))
     fixturePath = path.join(dir, 'engine fixture.cjs')
@@ -84,12 +92,27 @@ describe('real child processes and authenticated TCP', () => {
     children = []
     servers = []
     descendants = []
+    externalChildren = []
   })
   afterEach(async () => {
     await Promise.all(managers.map((manager) => manager.dispose()))
     for (const pid of descendants) {
-      if (pidAlive(pid)) process.kill(pid, 'SIGKILL')
+      try {
+        if (pidAlive(pid)) process.kill(pid, 'SIGKILL')
+      } catch {}
     }
+    for (const child of externalChildren) {
+      try {
+        if (pidAlive(child.pid)) process.kill(-child.pid, 'SIGKILL')
+      } catch {}
+    }
+    await vi.waitFor(
+      () => {
+        expect(descendants.filter(pidAlive)).toHaveLength(0)
+        expect(externalChildren.filter((child) => pidAlive(child.pid))).toHaveLength(0)
+      },
+      { timeout: 5000 },
+    )
     await Promise.all(servers.map(close))
     await fs.rm(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 })
     expect(children.filter(alive)).toHaveLength(0)
@@ -100,6 +123,18 @@ describe('real child processes and authenticated TCP', () => {
     const port = server.address().port
     await close(server)
     return port
+  }
+  async function readDescendantPid() {
+    let pid
+    await vi.waitFor(
+      async () => {
+        pid = Number(await fs.readFile(path.join(dir, 'descendant'), 'utf8'))
+        expect(pidAlive(pid)).toBe(true)
+      },
+      { timeout: 5000 },
+    )
+    descendants.push(pid)
+    return pid
   }
   function setup(contract = 'v2', scenario = 'success', timeouts = {}) {
     const commitConnection = vi.fn()
@@ -116,6 +151,7 @@ describe('real child processes and authenticated TCP', () => {
       }),
       spawn: (command, args, options) => {
         const child = childProcess.spawn(command, [fixturePath, ...args], options)
+        child.spawnOptions = options
         children.push(child)
         return child
       },
@@ -282,18 +318,83 @@ describe('real child processes and authenticated TCP', () => {
     }
   })
 
-  it.skipIf(process.platform !== 'win32')('Windows: cancels the owned process tree with taskkill', async () => {
-    const { manager } = setup('v2', 'tree')
+  it.skipIf(process.platform === 'win32').each([
+    ['normal helper', 'tree'],
+    ['SIGTERM-ignoring helper', 'tree-ignore-term'],
+  ])('POSIX: cancel removes the entire owned process group with a %s', async (_label, scenario) => {
+    const { manager } = setup('v2', scenario)
     const pending = manager.start({ port: await freePort(), password: 'password' })
-    let pid
+    await vi.waitFor(() => expect(children).toHaveLength(1))
+    const parent = children[0]
+    const helperPid = await readDescendantPid()
+
+    expect(parent.spawnOptions.detached).toBe(true)
+    expect(await manager.cancel()).toEqual({ ok: true, canceled: 1, status: 'cancelled' })
+    expect((await pending).status).toBe('cancelled')
     await vi.waitFor(
-      async () => {
-        pid = Number(await fs.readFile(path.join(dir, 'descendant'), 'utf8'))
-        expect(pidAlive(pid)).toBe(true)
+      () => {
+        expect(pidAlive(parent.pid)).toBe(false)
+        expect(pidAlive(helperPid)).toBe(false)
+        expect(processGroupAlive(parent.pid)).toBe(false)
       },
       { timeout: 5000 },
     )
-    descendants.push(pid)
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'POSIX: dispose removes a retained group after its parent exits naturally',
+    async () => {
+      const { manager } = setup('v2', 'success-parent-exit-tree')
+      const port = await freePort()
+      expect((await manager.start({ port, password: 'password' })).ok).toBe(true)
+      const parent = children[0]
+      const helperPid = await readDescendantPid()
+      await vi.waitFor(() => expect(parent.exitCode).toBe(0), { timeout: 5000 })
+      expect(pidAlive(helperPid)).toBe(true)
+      expect(processGroupAlive(parent.pid)).toBe(true)
+
+      expect(await manager.dispose()).toEqual({ ok: true, canceled: 1, status: 'cancelled' })
+      await vi.waitFor(
+        () => {
+          expect(pidAlive(helperPid)).toBe(false)
+          expect(processGroupAlive(parent.pid)).toBe(false)
+        },
+        { timeout: 5000 },
+      )
+    },
+  )
+
+  it.skipIf(process.platform === 'win32')('POSIX: killOnExit kills only the owned process group', async () => {
+    const external = childProcess.spawn(process.execPath, ['-e', 'setTimeout(() => process.exit(92), 15000)'], {
+      detached: true,
+      stdio: 'ignore',
+    })
+    externalChildren.push(external)
+    await vi.waitFor(() => expect(pidAlive(external.pid)).toBe(true))
+
+    const { manager } = setup('v2', 'tree')
+    const pending = manager.start({ port: await freePort(), password: 'password' })
+    await vi.waitFor(() => expect(children).toHaveLength(1))
+    const parent = children[0]
+    const helperPid = await readDescendantPid()
+
+    manager.killOnExit()
+    await vi.waitFor(
+      () => {
+        expect(pidAlive(parent.pid)).toBe(false)
+        expect(pidAlive(helperPid)).toBe(false)
+        expect(processGroupAlive(parent.pid)).toBe(false)
+      },
+      { timeout: 5000 },
+    )
+    expect(pidAlive(external.pid)).toBe(true)
+    expect((await pending).status).toBe('engine_exited')
+  })
+
+  it.skipIf(process.platform !== 'win32')('Windows: cancels the owned process tree with taskkill', async () => {
+    const { manager } = setup('v2', 'tree')
+    const pending = manager.start({ port: await freePort(), password: 'password' })
+    const pid = await readDescendantPid()
     await manager.cancel()
     expect((await pending).status).toBe('cancelled')
     await vi.waitFor(() => expect(pidAlive(pid)).toBe(false), { timeout: 2000 })

--- a/app/main/handlers/utils/__test__/engineStartup.test.js
+++ b/app/main/handlers/utils/__test__/engineStartup.test.js
@@ -1,0 +1,318 @@
+// @vitest-environment node
+const { EventEmitter } = require('events')
+const { createEngineStartup, stopEngineChild } = require('../engineStartup')
+const {
+  createEngineLineReader,
+  classifyEngineFailure,
+  parseEngineEvent,
+  parseCheckResult,
+  redactEngineLog,
+} = require('../engineDiagnostics')
+
+const MARKER = '50551aa97b5aa5ae8a3c3243ac60a8a7'
+const params = { port: 9011, password: 'a'.repeat(64), softwareVersion: 'yakit' }
+const wrap = (json) => `<json-${MARKER}>\n${JSON.stringify(json)}\n</json-${MARKER}>\n`
+
+function fixture(options = {}) {
+  const children = []
+  const clients = []
+  const log = vi.fn()
+  const commitConnection = vi.fn()
+  const spawn = vi.fn((command, args, settings) => {
+    const child = new EventEmitter()
+    Object.assign(child, {
+      pid: 10000 + children.length,
+      exitCode: null,
+      signalCode: null,
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      args,
+      settings,
+    })
+    child.exit = (code = 0, signal = null) => {
+      child.exitCode = code
+      child.signalCode = signal
+      child.emit('exit', code, signal)
+      child.emit('close', code, signal)
+    }
+    child.kill = vi.fn((signal) => {
+      queueMicrotask(() => child.exit(null, signal))
+      return true
+    })
+    child.output = (text, stream = 'stdout') => child[stream].emit('data', Buffer.from(text))
+    children.push(child)
+    return child
+  })
+  const createClient = vi.fn((connection) => {
+    const client = { connection, close: vi.fn(), call: { cancel: vi.fn() } }
+    client.Echo = vi.fn((request, callOptions, done) => {
+      client.done = done
+      client.deadline = callOptions.deadline
+      return client.call
+    })
+    clients.push(client)
+    return client
+  })
+  const manager = createEngineStartup({
+    getCommand: () => '/fake/yak',
+    getEnv: () => ({ YAKIT_HOME: '/fake/home' }),
+    createClient,
+    commitConnection,
+    spawn,
+    log,
+    timeouts: { check: 1000, start: 1000, probe: 100, retry: 50 },
+    ...options,
+  })
+  return { manager, children, clients, log, spawn, commitConnection }
+}
+
+describe('engine startup lifecycle', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it.each(['***', 'legacy-secret', ''])(
+    'creates a fresh production password regardless of check secret %s',
+    async (secret) => {
+      const f = fixture()
+      const run = async () => {
+        const pending = f.manager.check(params)
+        f.children.at(-1).output(wrap({ ok: true, port: 9011, secret, version: 'dev' }))
+        f.children.at(-1).exit()
+        return pending
+      }
+      const first = await run()
+      const second = await run()
+      expect(first.ok).toBe(true)
+      expect(first.json.secret).toMatch(/^[a-f0-9]{64}$/)
+      expect(second.json.secret).not.toBe(first.json.secret)
+      expect(first.json.secret).not.toBe(secret)
+      expect(f.log.mock.calls.flat().join('')).not.toContain('legacy-secret')
+    },
+  )
+
+  it.each([1, 2])('authenticates ready v%s before committing global state', async (schemaVersion) => {
+    const f = fixture()
+    const pending = f.manager.start(params)
+    f.children[0].output('yak grpc rea')
+    f.children[0].output(`dy ${JSON.stringify({ schemaVersion, address: '127.0.0.1:9011', transport: 'tcp' })}\r\n`)
+    expect(f.commitConnection).not.toHaveBeenCalled()
+    expect(f.clients[0].connection.password).toBe(params.password)
+    expect(f.clients[0].deadline).toBeInstanceOf(Date)
+    f.clients[0].done(null, { result: 'Hello Yakit!' })
+    expect((await pending).ok).toBe(true)
+    expect(f.clients[0].close).toHaveBeenCalledOnce()
+    expect(f.commitConnection).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+    await f.manager.dispose()
+  })
+
+  it('supports a legacy engine without a structured ready event', async () => {
+    const f = fixture()
+    const pending = f.manager.start(params)
+    await vi.advanceTimersByTimeAsync(50)
+    f.clients[0].done(null, { result: 'Hello Yakit!' })
+    expect((await pending).ok).toBe(true)
+    expect(f.children[0].args).not.toContain('--transport')
+    expect(f.children[0].args).toContain('--local-password')
+    await f.manager.dispose()
+  })
+
+  it('rejects failed, exits its child and never restarts polling afterwards', async () => {
+    const f = fixture()
+    const pending = f.manager.start(params)
+    f.children[0].output('yak grpc failed {"phase":"listen","reasonCode":"tcp_bind_in_use"}\n')
+    expect((await pending).status).toBe('port_occupied')
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(f.clients).toHaveLength(0)
+    expect(f.commitConnection).not.toHaveBeenCalled()
+    expect(f.children[0].kill).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('cancels a pending Echo, closes its client and ignores late success', async () => {
+    const f = fixture()
+    const pending = f.manager.start(params)
+    await vi.advanceTimersByTimeAsync(50)
+    await f.manager.cancel()
+    f.clients[0].done(null, { result: 'Hello Yakit!' })
+    expect((await pending).status).toBe('cancelled')
+    expect(f.clients[0].call.cancel).toHaveBeenCalledOnce()
+    expect(f.clients[0].close).toHaveBeenCalledOnce()
+    expect(f.commitConnection).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('waits for the superseded child to exit before spawning the next check', async () => {
+    const f = fixture()
+    const first = f.manager.check(params)
+    const child = f.children[0]
+    child.kill.mockImplementation(() => true)
+    const second = f.manager.check(params)
+    expect(f.spawn).toHaveBeenCalledTimes(1)
+    child.exit(null, 'SIGTERM')
+    expect((await first).status).toBe('cancelled')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(f.spawn).toHaveBeenCalledTimes(2)
+    f.children[1].output(wrap({ ok: true, port: 9011 }))
+    f.children[1].exit()
+    expect((await second).ok).toBe(true)
+  })
+
+  it('does not start another process if cleanup cannot confirm exit', async () => {
+    const f = fixture()
+    const first = f.manager.start(params)
+    f.children[0].kill.mockImplementation(() => false)
+    const second = f.manager.start(params)
+    await vi.advanceTimersByTimeAsync(4000)
+    expect((await first).status).toBe('process_error')
+    expect((await second).status).toBe('port_occupied')
+    expect(f.spawn).toHaveBeenCalledOnce()
+    f.children[0].exit()
+  })
+
+  it('settles both timeout and early exit without leaked timers', async () => {
+    const f = fixture()
+    const pending = f.manager.check(params)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect((await pending).status).toBe('timeout')
+    expect(vi.getTimerCount()).toBe(0)
+    const again = f.manager.start(params)
+    f.children.at(-1).exit(1)
+    expect((await again).status).toBe('engine_exited')
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('keeps only one bounded RPC in flight when the engine never responds', async () => {
+    const f = fixture()
+    const pending = f.manager.start(params)
+    await vi.advanceTimersByTimeAsync(999)
+    expect(f.clients.length).toBeLessThan(8)
+    expect(f.clients.slice(0, -1).every((client) => client.close.mock.calls.length === 1)).toBe(true)
+    await vi.advanceTimersByTimeAsync(1)
+    expect((await pending).status).toBe('timeout')
+    expect(f.clients.every((client) => client.close.mock.calls.length === 1)).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it.each([
+    { schemaVersion: 2, transport: 'unix', address: '/tmp/engine.sock' },
+    { schemaVersion: 2, transport: 'npipe', address: '\\\\.\\pipe\\engine' },
+    { schemaVersion: 2, transport: 'tcp', address: '192.0.2.1:9011' },
+    { schemaVersion: 99, address: '127.0.0.1:9011' },
+    null,
+  ])('rejects unexpected ready data without sending credentials: %j', async (event) => {
+    const f = fixture()
+    const pending = f.manager.start(params)
+    f.children[0].output(`yak grpc ready ${JSON.stringify(event)}\n`)
+    expect((await pending).status).toBe('protocol_error')
+    expect(f.clients).toHaveLength(0)
+  })
+
+  it.each(['', '***', '\nunsafe'])('refuses invalid production passwords before spawn: %j', async (password) => {
+    const f = fixture()
+    expect((await f.manager.start({ ...params, password })).status).toBe('protocol_error')
+    expect(f.spawn).not.toHaveBeenCalled()
+  })
+
+  it('does not trust an ok result when the child exits unsuccessfully', async () => {
+    const f = fixture()
+    const pending = f.manager.check(params)
+    f.children[0].output(wrap({ ok: true, port: 9011 }))
+    f.children[0].exit(1)
+    expect((await pending).ok).toBe(false)
+  })
+
+  it('flushes an unterminated failed line on child close', async () => {
+    const f = fixture()
+    const pending = f.manager.start(params)
+    f.children[0].output('yak grpc failed {"phase":"database"}')
+    f.children[0].exit(1)
+    expect((await pending).status).toBe('database_error')
+  })
+
+  it('bounds diagnostic output and still kills the child', async () => {
+    const f = fixture()
+    const pending = f.manager.check(params)
+    f.children[0].output('x'.repeat(65537))
+    expect((await pending).status).toBe('protocol_error')
+    expect(f.children[0].kill).toHaveBeenCalledOnce()
+  })
+
+  it('does not let a cancelled connection overwrite a newer remote connection', async () => {
+    const f = fixture()
+    const first = f.manager.connect({ defaultYakGRPCAddr: '127.0.0.1:9011', password: 'old', caPem: '' })
+    const second = f.manager.connect({ defaultYakGRPCAddr: 'remote.example:9011', password: 'new', caPem: 'cert' })
+    expect((await first).status).toBe('cancelled')
+    await vi.advanceTimersByTimeAsync(0)
+    f.clients[0].done(null, { result: 'Hello Yakit!' })
+    f.clients[1].done(null, { result: 'Hello Yakit!' })
+    expect((await second).ok).toBe(true)
+    expect(f.commitConnection).toHaveBeenCalledOnce()
+    expect(f.commitConnection.mock.calls[0][0].password).toBe('new')
+  })
+
+  it('uses argument-safe Windows process-tree termination and skips exited children', async () => {
+    const f = fixture()
+    const running = f.manager.start(params)
+    const child = f.children[0]
+    const execFile = vi.fn((file, args, options, done) => {
+      child.exit(1)
+      done(null)
+    })
+    expect(await stopEngineChild(child, execFile, 'win32')).toBe(true)
+    expect(execFile).toHaveBeenCalledWith(
+      'taskkill.exe',
+      ['/PID', '10000', '/T', '/F'],
+      expect.objectContaining({ windowsHide: true, timeout: 3000 }),
+      expect.any(Function),
+    )
+    expect(await stopEngineChild(child, execFile, 'win32')).toBe(true)
+    expect(execFile).toHaveBeenCalledOnce()
+    await running
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+describe('engine diagnostic compatibility', () => {
+  it.each([
+    ['net.Listen(tcp, addr) failed', 'port_occupied'],
+    ['database error', 'database_error'],
+    ['build yak grpc server failed', 'build_yak_error'],
+    ['dial grpc server failed', 'dial_error'],
+    ['call Version RPC failed', 'call_error'],
+    ['waiting grpc listener failed', 'timeout'],
+  ])('preserves the legacy recovery route for %s in any reason array position', (reason, status) => {
+    expect(classifyEngineFailure({ reason: ['unrelated', reason] }).status).toBe(status)
+  })
+  it('uses precise Windows denial diagnostics without losing legacy fallback', () => {
+    expect(
+      classifyEngineFailure({ reason: ['net.Listen(tcp, addr) failed'], info: 'bind: WSAEACCES 10013' }).status,
+    ).toBe('port_denied')
+    expect(
+      classifyEngineFailure({ reason: ['net.Listen(tcp, addr) failed'], reasonCode: 'tcp_bind_failed' }).status,
+    ).toBe('endpoint_unreachable')
+  })
+  it('decodes UTF-8 split across chunks and flushes a final line', () => {
+    const lines = []
+    const reader = createEngineLineReader(
+      (line) => lines.push(line),
+      () => {
+        throw Error('overflow')
+      },
+    )
+    const bytes = Buffer.from('数据库异常\r\nlast')
+    for (const byte of bytes) reader.write(Buffer.from([byte]))
+    reader.end()
+    reader.end()
+    expect(lines).toEqual(['数据库异常', 'last'])
+  })
+  it('redacts old engine secret logs and JSON without changing protocol parsing', () => {
+    const json = { ok: true, port: 9011, secret: 'legacy-secret' }
+    expect(redactEngineLog(wrap(json))).not.toContain('legacy-secret')
+    expect(redactEngineLog('generated random secret for testing: legacy-secret')).not.toContain('legacy-secret')
+    expect(parseCheckResult(wrap(json)).secret).toBe('legacy-secret')
+    expect(parseCheckResult(wrap(json) + wrap(json))).toBeNull()
+    expect(parseCheckResult('<json-unrelated>{"ok":true}</json-unrelated>')).toBeNull()
+    expect(parseEngineEvent('yak grpc ready null').type).toBe('invalid')
+  })
+})

--- a/app/main/handlers/utils/__test__/engineStartup.test.js
+++ b/app/main/handlers/utils/__test__/engineStartup.test.js
@@ -281,9 +281,49 @@ describe('engine startup lifecycle', () => {
     const second = f.manager.start(params)
     await vi.advanceTimersByTimeAsync(4000)
     expect((await first).status).toBe('process_error')
-    expect((await second).status).toBe('port_occupied')
+    expect((await second).status).toBe('process_error')
     expect(f.spawn).toHaveBeenCalledOnce()
     f.children[0].exit()
+  })
+
+  it('does not connect when superseding an active child whose exit cannot be confirmed', async () => {
+    const f = fixture()
+    const first = f.manager.start(params)
+    f.children[0].kill.mockImplementation(() => false)
+    const second = f.manager.connect({
+      defaultYakGRPCAddr: 'remote.example:9011',
+      password: 'remote',
+      caPem: 'cert',
+    })
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(await first).toMatchObject({ ok: false, status: 'process_error' })
+    expect(await second).toMatchObject({ ok: false, stage: 'connect', status: 'process_error' })
+    expect(f.clients).toHaveLength(0)
+    expect(f.commitConnection).not.toHaveBeenCalled()
+    f.children[0].exit(null, 'SIGKILL')
+  })
+
+  it('blocks independent connections after a settled startup fails to clean up', async () => {
+    const f = fixture()
+    const pending = f.manager.start(params)
+    f.children[0].kill.mockImplementation(() => false)
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(await pending).toMatchObject({ ok: false, status: 'process_error' })
+
+    const connection = { defaultYakGRPCAddr: 'remote.example:9011', password: 'remote', caPem: '' }
+    const clientCount = f.clients.length
+    const blockedConnection = f.manager.connect(connection)
+    expect(f.clients).toHaveLength(clientCount)
+    expect(await blockedConnection).toMatchObject({ ok: false, status: 'process_error' })
+    expect(f.commitConnection).not.toHaveBeenCalled()
+
+    f.children[0].exit(null, 'SIGKILL')
+    expect((await f.manager.dispose()).ok).toBe(true)
+    const reconnect = f.manager.connect(connection)
+    expect(f.clients).toHaveLength(clientCount + 1)
+    f.clients.at(-1).done(null, { result: 'Hello Yakit!' })
+    expect((await reconnect).ok).toBe(true)
+    expect(f.commitConnection).toHaveBeenCalledOnce()
   })
 
   it('settles both timeout and early exit without leaked timers', async () => {
@@ -365,6 +405,219 @@ describe('engine startup lifecycle', () => {
     expect((await second).ok).toBe(true)
     expect(f.commitConnection).toHaveBeenCalledOnce()
     expect(f.commitConnection.mock.calls[0][0].password).toBe('new')
+  })
+
+  it('uses the full connect budget instead of the short startup probe deadline', async () => {
+    const f = fixture()
+    const startedAt = Date.now()
+    const pending = f.manager.connect({ defaultYakGRPCAddr: 'remote.example:9011', password: 'remote', caPem: 'cert' })
+    expect(f.clients[0].deadline.getTime()).toBe(startedAt + 10000)
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(f.commitConnection).not.toHaveBeenCalled()
+    f.clients[0].done(null, { result: 'Hello Yakit!' })
+    expect((await pending).ok).toBe(true)
+  })
+
+  it('times out an unresponsive explicit connection at 10 seconds and closes its RPC resources', async () => {
+    const f = fixture()
+    const pending = f.manager.connect({ defaultYakGRPCAddr: 'remote.example:9011', password: 'remote', caPem: 'cert' })
+    await vi.advanceTimersByTimeAsync(9999)
+    expect(f.clients[0].close).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(await pending).toMatchObject({ ok: false, status: 'timeout' })
+    expect(f.clients[0].call.cancel).toHaveBeenCalledOnce()
+    expect(f.clients[0].close).toHaveBeenCalledOnce()
+    expect(f.commitConnection).not.toHaveBeenCalled()
+  })
+
+  it('fails an explicit local connection immediately on authentication rejection', async () => {
+    const f = fixture()
+    const pending = f.manager.connect(
+      { defaultYakGRPCAddr: '127.0.0.1:9011', password: 'wrong-password', caPem: '' },
+      true,
+    )
+    f.clients[0].done({ code: 16 })
+    expect(await pending).toMatchObject({ ok: false, status: 'dial_error' })
+    expect(f.clients).toHaveLength(1)
+    expect(f.commitConnection).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('shares one absolute connect deadline across both local authentication probes', async () => {
+    const f = fixture({ timeouts: { check: 1000, start: 1000, connect: 1000, probe: 100, retry: 50 } })
+    const pending = f.manager.connect(
+      { defaultYakGRPCAddr: '127.0.0.1:9011', password: 'local-password', caPem: '' },
+      true,
+    )
+    const deadline = f.clients[0].deadline.getTime()
+    await vi.advanceTimersByTimeAsync(300)
+    f.clients[0].done(null, { result: 'Hello Yakit!' })
+    expect(f.clients[1].deadline.getTime()).toBe(deadline)
+    f.clients[1].done({ code: 16 })
+    expect((await pending).ok).toBe(true)
+  })
+
+  it('does not extend the connect budget when the anonymous authentication probe starts late', async () => {
+    const f = fixture({ timeouts: { check: 1000, start: 1000, connect: 1000, probe: 100, retry: 50 } })
+    const pending = f.manager.connect(
+      { defaultYakGRPCAddr: '127.0.0.1:9011', password: 'local-password', caPem: '' },
+      true,
+    )
+    const deadline = f.clients[0].deadline.getTime()
+    await vi.advanceTimersByTimeAsync(900)
+    f.clients[0].done(null, { result: 'Hello Yakit!' })
+    expect(f.clients[1].deadline.getTime()).toBe(deadline)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(await pending).toMatchObject({ ok: false, status: 'timeout' })
+    expect(f.clients[1].close).toHaveBeenCalledOnce()
+    expect(f.commitConnection).not.toHaveBeenCalled()
+  })
+
+  it('reports retained child cleanup failure and blocks later operations until cleanup succeeds', async () => {
+    const f = fixture()
+    const started = f.manager.start(params)
+    await vi.advanceTimersByTimeAsync(50)
+    f.clients[0].done(null, { result: 'Hello Yakit!' })
+    f.clients[1].done({ code: 16 })
+    expect((await started).ok).toBe(true)
+    f.children[0].kill.mockImplementation(() => false)
+
+    const disposing = f.manager.dispose()
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(await disposing).toMatchObject({ ok: false, canceled: 0, status: 'process_error' })
+    expect(
+      await f.manager.connect({ defaultYakGRPCAddr: 'remote.example:9011', password: 'remote', caPem: 'cert' }),
+    ).toMatchObject({
+      ok: false,
+      status: 'process_error',
+    })
+    expect(f.clients).toHaveLength(2)
+
+    f.children[0].exit(null, 'SIGKILL')
+    expect(await f.manager.dispose()).toEqual({ ok: true, canceled: 0, status: 'cancelled' })
+  })
+
+  it('propagates active cleanup failure without double-counting its child', async () => {
+    const f = fixture()
+    const pending = f.manager.start(params)
+    f.children[0].kill.mockImplementation(() => false)
+    const cancelling = f.manager.cancel()
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(await pending).toMatchObject({ ok: false, status: 'process_error' })
+    expect(await cancelling).toMatchObject({ ok: false, canceled: 0, status: 'process_error' })
+    f.children[0].exit(null, 'SIGKILL')
+  })
+
+  it('accepts cleanup when an already-finishing timed out operation confirms child exit', async () => {
+    const f = fixture()
+    const pending = f.manager.start(params)
+    f.children[0].kill.mockImplementation(() => true)
+    await vi.advanceTimersByTimeAsync(1000)
+
+    const cancelling = f.manager.cancel()
+    f.children[0].exit(null, 'SIGTERM')
+    expect((await pending).status).toBe('timeout')
+    expect(await cancelling).toEqual({ ok: true, canceled: 0, status: 'cancelled' })
+  })
+
+  it('does not begin a new operation until retained child cleanup has settled', async () => {
+    const f = fixture()
+    const started = f.manager.start(params)
+    await vi.advanceTimersByTimeAsync(50)
+    f.clients[0].done(null, { result: 'Hello Yakit!' })
+    f.clients[1].done({ code: 16 })
+    await started
+    f.children[0].kill.mockImplementation(() => true)
+
+    const disposing = f.manager.dispose()
+    const connecting = f.manager.connect({
+      defaultYakGRPCAddr: 'remote.example:9011',
+      password: 'remote',
+      caPem: 'cert',
+    })
+    expect(f.clients).toHaveLength(2)
+    f.children[0].exit(null, 'SIGTERM')
+    expect(await disposing).toEqual({ ok: true, canceled: 1, status: 'cancelled' })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(f.clients).toHaveLength(3)
+    f.clients[2].done(null, { result: 'Hello Yakit!' })
+    expect((await connecting).ok).toBe(true)
+  })
+
+  it('lets a repeated dispose invalidate an operation queued behind cleanup', async () => {
+    const f = fixture()
+    const started = f.manager.start(params)
+    await vi.advanceTimersByTimeAsync(50)
+    f.clients[0].done(null, { result: 'Hello Yakit!' })
+    f.clients[1].done({ code: 16 })
+    await started
+    f.children[0].kill.mockImplementation(() => true)
+
+    const firstDispose = f.manager.dispose()
+    const connecting = f.manager.connect({
+      defaultYakGRPCAddr: 'remote.example:9011',
+      password: 'remote',
+      caPem: 'cert',
+    })
+    const secondDispose = f.manager.dispose()
+    f.children[0].exit(null, 'SIGTERM')
+
+    expect(await firstDispose).toEqual({ ok: true, canceled: 1, status: 'cancelled' })
+    expect(await secondDispose).toEqual({ ok: true, canceled: 1, status: 'cancelled' })
+    expect(await connecting).toMatchObject({ ok: false, stage: 'connect', status: 'cancelled' })
+    expect(f.clients).toHaveLength(2)
+    expect(f.commitConnection).toHaveBeenCalledOnce()
+  })
+
+  it('logs bounded cleanup evidence and ignores logging failures', async () => {
+    const f = fixture({
+      log: () => {
+        throw new Error('log unavailable')
+      },
+    })
+    const pending = f.manager.start(params)
+    const cancelling = f.manager.cancel()
+    await vi.advanceTimersByTimeAsync(0)
+    expect((await pending).status).toBe('cancelled')
+    expect(await cancelling).toEqual({ ok: true, canceled: 1, status: 'cancelled' })
+
+    const withLog = fixture()
+    const run = withLog.manager.start(params)
+    const cancel = withLog.manager.cancel()
+    await vi.advanceTimersByTimeAsync(0)
+    await run
+    await cancel
+    const cleanupLogs = withLog.log.mock.calls
+      .flat()
+      .filter((line) => String(line).includes('cleanup_'))
+      .join('\n')
+    expect(cleanupLogs).toContain('cleanup_start')
+    expect(cleanupLogs).toContain('cleanup_result')
+    expect(cleanupLogs).toContain('operationId')
+    expect(cleanupLogs).toContain('ownedChildPid')
+    expect(cleanupLogs).toContain('confirmedExit')
+    expect(cleanupLogs).not.toContain(params.password)
+  })
+
+  it('logs cleanup action boundaries even when there is no owned child', async () => {
+    const f = fixture()
+    expect(await f.manager.dispose()).toEqual({ ok: true, canceled: 0, status: 'cancelled' })
+    const events = f.log.mock.calls.flat().map((line) => JSON.parse(line))
+    expect(events).toEqual([
+      expect.objectContaining({
+        event: 'cleanup_start',
+        stage: 'dispose',
+        ownedChildPid: null,
+        confirmedExit: null,
+      }),
+      expect.objectContaining({
+        event: 'cleanup_result',
+        stage: 'dispose',
+        ownedChildPid: null,
+        confirmedExit: true,
+      }),
+    ])
+    expect(events[0].operationId).toBe(events[1].operationId)
   })
 
   it('uses argument-safe Windows process-tree termination and skips exited children', async () => {

--- a/app/main/handlers/utils/__test__/engineStartup.test.js
+++ b/app/main/handlers/utils/__test__/engineStartup.test.js
@@ -60,6 +60,9 @@ function fixture(options = {}) {
     commitConnection,
     spawn,
     log,
+    // These children have synthetic PIDs. Never invoke the host's taskkill from a unit test.
+    // Windows process-tree behavior is exercised separately with owned real processes.
+    platform: 'linux',
     timeouts: { check: 1000, start: 1000, probe: 100, retry: 50 },
     ...options,
   })
@@ -99,6 +102,9 @@ describe('engine startup lifecycle', () => {
     expect(f.clients[0].connection.password).toBe(params.password)
     expect(f.clients[0].deadline).toBeInstanceOf(Date)
     f.clients[0].done(null, { result: 'Hello Yakit!' })
+    expect(f.commitConnection).not.toHaveBeenCalled()
+    expect(f.clients[1].connection.password).toBe('')
+    f.clients[1].done({ code: 16 })
     expect((await pending).ok).toBe(true)
     expect(f.clients[0].close).toHaveBeenCalledOnce()
     expect(f.commitConnection).toHaveBeenCalledOnce()
@@ -111,6 +117,7 @@ describe('engine startup lifecycle', () => {
     const pending = f.manager.start(params)
     await vi.advanceTimersByTimeAsync(50)
     f.clients[0].done(null, { result: 'Hello Yakit!' })
+    f.clients[1].done({ code: 16 })
     expect((await pending).ok).toBe(true)
     expect(f.children[0].args).not.toContain('--transport')
     expect(f.children[0].args).toContain('--local-password')
@@ -138,6 +145,20 @@ describe('engine startup lifecycle', () => {
     expect((await pending).status).toBe('cancelled')
     expect(f.clients[0].call.cancel).toHaveBeenCalledOnce()
     expect(f.clients[0].close).toHaveBeenCalledOnce()
+    expect(f.commitConnection).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('ignores a late anonymous-auth rejection after cancellation', async () => {
+    const f = fixture()
+    const pending = f.manager.start(params)
+    await vi.advanceTimersByTimeAsync(50)
+    f.clients[0].done(null, { result: 'Hello Yakit!' })
+    expect(f.clients).toHaveLength(2)
+    await f.manager.cancel()
+    f.clients[1].done({ code: 16 })
+    expect((await pending).status).toBe('cancelled')
+    expect(f.clients[1].close).toHaveBeenCalledOnce()
     expect(f.commitConnection).not.toHaveBeenCalled()
     expect(vi.getTimerCount()).toBe(0)
   })

--- a/app/main/handlers/utils/__test__/engineStartup.test.js
+++ b/app/main/handlers/utils/__test__/engineStartup.test.js
@@ -15,6 +15,7 @@ const wrap = (json) => `<json-${MARKER}>\n${JSON.stringify(json)}\n</json-${MARK
 
 function fixture(options = {}) {
   const children = []
+  const processGroups = new Map()
   const clients = []
   const log = vi.fn()
   const notify = vi.fn()
@@ -31,6 +32,7 @@ function fixture(options = {}) {
       settings,
     })
     child.exit = (code = 0, signal = null) => {
+      processGroups.set(child.pid, false)
       child.exitCode = code
       child.signalCode = signal
       child.emit('exit', code, signal)
@@ -41,8 +43,25 @@ function fixture(options = {}) {
       return true
     })
     child.output = (text, stream = 'stdout') => child[stream].emit('data', Buffer.from(text))
+    child.exitParent = (code = 0, signal = null) => {
+      child.exitCode = code
+      child.signalCode = signal
+      child.emit('exit', code, signal)
+      child.emit('close', code, signal)
+    }
     children.push(child)
+    processGroups.set(child.pid, true)
     return child
+  })
+  const killProcess = vi.fn((pid, signal) => {
+    const groupId = Math.abs(pid)
+    if (!processGroups.get(groupId)) {
+      const error = new Error('process group not found')
+      error.code = 'ESRCH'
+      throw error
+    }
+    if (signal !== 0) children.find((child) => child.pid === groupId)?.kill(signal)
+    return true
   })
   const createClient = vi.fn((connection) => {
     const client = { connection, close: vi.fn(), call: { cancel: vi.fn() } }
@@ -62,13 +81,14 @@ function fixture(options = {}) {
     spawn,
     log,
     notify,
+    killProcess,
     // These children have synthetic PIDs. Never invoke the host's taskkill from a unit test.
     // Windows process-tree behavior is exercised separately with owned real processes.
     platform: 'linux',
     timeouts: { check: 1000, start: 1000, probe: 100, retry: 50 },
     ...options,
   })
-  return { manager, children, clients, log, notify, spawn, commitConnection }
+  return { manager, children, clients, processGroups, killProcess, log, notify, spawn, commitConnection }
 }
 
 describe('engine startup lifecycle', () => {
@@ -639,6 +659,61 @@ describe('engine startup lifecycle', () => {
     expect(execFile).toHaveBeenCalledOnce()
     await running
     expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('spawns an owned POSIX process group and waits for the whole group to exit', async () => {
+    const f = fixture()
+    const running = f.manager.start(params)
+    const child = f.children[0]
+    expect(child.settings.detached).toBe(true)
+    child.kill.mockImplementation(() => true)
+
+    const cancelling = f.manager.cancel()
+    child.exitParent(null, 'SIGTERM')
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(f.killProcess).toHaveBeenCalledWith(-child.pid, 'SIGTERM')
+    expect(f.killProcess).toHaveBeenCalledWith(-child.pid, 'SIGKILL')
+    expect(await Promise.race([cancelling.then(() => 'settled'), Promise.resolve('pending')])).toBe('pending')
+
+    f.processGroups.set(child.pid, false)
+    await vi.advanceTimersByTimeAsync(50)
+    expect((await running).status).toBe('cancelled')
+    expect(await cancelling).toEqual({ ok: true, canceled: 1, status: 'cancelled' })
+
+    const callsAfterExit = f.killProcess.mock.calls.length
+    f.processGroups.set(child.pid, true)
+    f.manager.killOnExit()
+    expect(f.killProcess).toHaveBeenCalledTimes(callsAfterExit)
+  })
+
+  it('reports cleanup failure when the POSIX group survives the four second deadline', async () => {
+    const f = fixture()
+    const running = f.manager.start(params)
+    const child = f.children[0]
+    child.kill.mockImplementation(() => true)
+
+    const cancelling = f.manager.cancel()
+    child.exitParent(null, 'SIGTERM')
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(await running).toMatchObject({ ok: false, status: 'process_error' })
+    expect(await cancelling).toMatchObject({ ok: false, status: 'process_error' })
+
+    f.processGroups.set(child.pid, false)
+    expect((await f.manager.dispose()).ok).toBe(true)
+  })
+
+  it('uses only the owned POSIX group for the synchronous exit fallback', () => {
+    const f = fixture()
+    f.manager.start(params)
+    const child = f.children[0]
+    const externalGroupId = 99999
+    f.processGroups.set(externalGroupId, true)
+
+    f.manager.killOnExit()
+
+    expect(f.killProcess).toHaveBeenCalledWith(-child.pid, 'SIGKILL')
+    expect(f.killProcess.mock.calls.some(([pid]) => pid > 0)).toBe(false)
+    expect(f.killProcess.mock.calls.some(([pid]) => pid === -externalGroupId)).toBe(false)
   })
 })
 

--- a/app/main/handlers/utils/__test__/engineStartup.test.js
+++ b/app/main/handlers/utils/__test__/engineStartup.test.js
@@ -17,6 +17,7 @@ function fixture(options = {}) {
   const children = []
   const clients = []
   const log = vi.fn()
+  const notify = vi.fn()
   const commitConnection = vi.fn()
   const spawn = vi.fn((command, args, settings) => {
     const child = new EventEmitter()
@@ -60,18 +61,112 @@ function fixture(options = {}) {
     commitConnection,
     spawn,
     log,
+    notify,
     // These children have synthetic PIDs. Never invoke the host's taskkill from a unit test.
     // Windows process-tree behavior is exercised separately with owned real processes.
     platform: 'linux',
     timeouts: { check: 1000, start: 1000, probe: 100, retry: 50 },
     ...options,
   })
-  return { manager, children, clients, log, spawn, commitConnection }
+  return { manager, children, clients, log, notify, spawn, commitConnection }
 }
 
 describe('engine startup lifecycle', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
+
+  it.each(['stdout', 'stderr'])('accepts the authoritative check result on %s', async (stream) => {
+    const f = fixture()
+    const pending = f.manager.check(params)
+    f.children[0].output(wrap({ ok: true, port: 9011, secret: 'legacy-secret' }), stream)
+    f.children[0].exit()
+    expect((await pending).ok).toBe(true)
+    expect(f.log.mock.calls.flat().join('')).not.toContain('legacy-secret')
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('preserves structured failures on stderr and rejects contradictory results', async () => {
+    const f = fixture()
+    const failed = f.manager.check(params)
+    f.children[0].output(wrap({ ok: false, reason: ['database error'] }), 'stderr')
+    f.children[0].exit(1)
+    expect((await failed).status).toBe('database_error')
+    const ambiguous = f.manager.check(params)
+    f.children[1].output(wrap({ ok: true, port: 9011 }))
+    f.children[1].output(wrap({ ok: false, reason: ['database error'] }), 'stderr')
+    f.children[1].exit()
+    expect((await ambiguous).ok).toBe(false)
+    expect(f.commitConnection).not.toHaveBeenCalled()
+  })
+
+  it.each([0, 1, 3221225477])('keeps actionable advice and exit code %s for silent check exits', async (code) => {
+    const f = fixture()
+    const pending = f.manager.check(params)
+    f.children[0].exit(code)
+    expect(await pending).toMatchObject({ ok: false, status: 'antivirus_blocked', exitCode: code })
+    expect(f.log).toHaveBeenCalledWith(`Engine check exited: code=${code}, signal=none`)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('does not label a diagnostic process crash as antivirus blocking', async () => {
+    const f = fixture()
+    const pending = f.manager.check(params)
+    f.children[0].output('runtime panic: failed to initialize\n', 'stderr')
+    f.children[0].exit(2)
+    expect(await pending).toMatchObject({ status: 'process_error', exitCode: 2 })
+  })
+
+  it.each(['check', 'start'])('allows %s to wait 180 seconds with a single hint after 20 seconds', async (stage) => {
+    const f = fixture({ timeouts: {} })
+    const pending = f.manager[stage](params)
+    await vi.advanceTimersByTimeAsync(19999)
+    expect(f.notify).not.toHaveBeenCalledWith('LocalEngine.migration_wait_hint')
+    await vi.advanceTimersByTimeAsync(1)
+    expect(f.notify.mock.calls.filter(([key]) => key === 'LocalEngine.migration_wait_hint')).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(159999)
+    expect(f.children[0].kill).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect((await pending).status).toBe('timeout')
+    expect(f.children[0].kill).toHaveBeenCalledOnce()
+    expect(f.notify.mock.calls.filter(([key]) => key === 'LocalEngine.migration_wait_hint')).toHaveLength(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it.each(['check', 'start'])('clears the delayed hint when %s is cancelled or superseded', async (stage) => {
+    const f = fixture({ timeouts: {} })
+    const first = f.manager[stage](params)
+    await vi.advanceTimersByTimeAsync(19000)
+    await f.manager.cancel()
+    expect((await first).status).toBe('cancelled')
+    const second = f.manager.check(params)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(f.notify).not.toHaveBeenCalledWith('LocalEngine.migration_wait_hint')
+    f.children[1].output(wrap({ ok: true, port: 9011 }))
+    f.children[1].exit()
+    expect((await second).ok).toBe(true)
+    await vi.advanceTimersByTimeAsync(20000)
+    expect(f.notify).not.toHaveBeenCalledWith('LocalEngine.migration_wait_hint')
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('treats initial, database and delayed progress as best-effort when the window closes', async () => {
+    const f = fixture({
+      timeouts: {},
+      notify: () => {
+        throw new Error('Object has been destroyed')
+      },
+    })
+    const pending = f.manager.start(params)
+    expect(() => f.children[0].output('<json-f97f966eb7f8ba8fdb63e4d29109c058>\n')).not.toThrow()
+    await vi.advanceTimersByTimeAsync(20000)
+    expect(f.children[0].kill).not.toHaveBeenCalled()
+    f.children[0].output('yak grpc ok\n')
+    f.clients.at(-1).done(null, { result: 'Hello Yakit!' })
+    f.clients.at(-1).done({ code: 16 })
+    expect((await pending).ok).toBe(true)
+    await f.manager.dispose()
+    expect(vi.getTimerCount()).toBe(0)
+  })
 
   it.each(['***', 'legacy-secret', ''])(
     'creates a fresh production password regardless of check secret %s',

--- a/app/main/handlers/utils/engineDiagnostics.js
+++ b/app/main/handlers/utils/engineDiagnostics.js
@@ -1,0 +1,175 @@
+const { StringDecoder } = require('string_decoder')
+
+const CHECK_MARKER = '50551aa97b5aa5ae8a3c3243ac60a8a7'
+const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value)
+const stringValue = (value) => (typeof value === 'string' ? value : '')
+
+function redactEngineLog(value, secrets = []) {
+  let text = String(value)
+  for (const secret of secrets) {
+    if (secret) text = text.split(secret).join('***')
+  }
+  return text
+    .replace(/("(?:secret|password)"\s*:\s*)"(?:\\.|[^"\\])*"/gi, '$1"***"')
+    .replace(/((?:generated random secret for testing|secret|password)\s*[:=]\s*)\S+/gi, '$1***')
+    .replace(/(bearer\s+)\S+/gi, '$1***')
+}
+
+function redactEngineData(value, secrets = []) {
+  if (typeof value === 'string') return redactEngineLog(value, secrets)
+  if (Array.isArray(value)) return value.map((item) => redactEngineData(item, secrets))
+  if (isObject(value))
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        /^(secret|password)$/i.test(key) ? '***' : redactEngineData(item, secrets),
+      ]),
+    )
+  return value
+}
+
+// Decode bytes before splitting lines: both JSON and UTF-8 characters can span chunks.
+function createEngineLineReader(onLine, onOverflow, maxLength = 64 * 1024) {
+  const decoder = new StringDecoder('utf8')
+  let pending = ''
+  let ended = false
+  function consume(text) {
+    pending += text
+    let index
+    while ((index = pending.indexOf('\n')) !== -1) {
+      if (index > maxLength) return overflow()
+      const line = pending.slice(0, index).replace(/\r$/, '')
+      pending = pending.slice(index + 1)
+      onLine(line)
+    }
+    if (pending.length > maxLength) overflow()
+  }
+  function overflow() {
+    ended = true
+    pending = ''
+    onOverflow()
+  }
+  return {
+    write(data) {
+      if (!ended) consume(decoder.write(Buffer.isBuffer(data) ? data : Buffer.from(data)))
+    },
+    end() {
+      if (ended) return
+      consume(decoder.end())
+      if (ended) return
+      ended = true
+      if (pending) onLine(pending.replace(/\r$/, ''))
+      pending = ''
+    },
+  }
+}
+
+function parseEngineEvent(line) {
+  const text = line.trim()
+  if (text === 'yak grpc ok') return { type: 'log_ok' }
+  const match = /^(yak grpc (ready|failed)) (.*)$/.exec(text)
+  if (!match) return null
+  try {
+    const data = JSON.parse(match[3])
+    if (!isObject(data)) return { type: 'invalid' }
+    if (match[2] === 'ready') {
+      if (![1, 2].includes(data.schemaVersion) || typeof data.address !== 'string') return { type: 'invalid' }
+      if (data.transport !== undefined && typeof data.transport !== 'string') return { type: 'invalid' }
+    }
+    return { ...data, type: match[2], transport: data.transport || 'tcp' }
+  } catch {
+    return { type: 'invalid' }
+  }
+}
+
+function parseCheckResult(stdout) {
+  // Only the check-secret result is authoritative; unrelated JSON log markers are ignored.
+  const pattern = new RegExp(`<json-${CHECK_MARKER}>([\\s\\S]*?)<\\/json-${CHECK_MARKER}>`, 'g')
+  const matches = [...stdout.matchAll(pattern)]
+  if (matches.length !== 1) return null
+  try {
+    const result = JSON.parse(matches[0][1])
+    return isObject(result) && typeof result.ok === 'boolean' ? result : null
+  } catch {
+    return null
+  }
+}
+
+function classifyEngineFailure(data = {}, stage = 'check') {
+  const phase = stringValue(data.phase)
+  const reasons = (Array.isArray(data.reason) ? data.reason : [data.reason]).map(stringValue)
+  const detail = stringValue(data.info) || (typeof data.reason === 'string' ? data.reason : '')
+  let reasonCode = stringValue(data.reasonCode)
+  if (!reasonCode) reasonCode = /^\[([a-z_]+)\]/.exec(detail)?.[1] || ''
+  if (!reasonCode) {
+    const legacy = reasons.join('\n')
+    if (/net\.Listen/.test(legacy)) {
+      reasonCode = /EACCES|WSAEACCES|10013|permission denied|forbidden by its access permissions/i.test(detail)
+        ? 'tcp_bind_denied'
+        : 'tcp_bind_in_use' // Preserve the legacy recovery path when errno is unavailable.
+    } else if (/database[ _]error/.test(legacy)) reasonCode = 'database_error'
+    else if (/build yak grpc|build_server_failed/.test(legacy)) reasonCode = 'build_server_failed'
+    else if (/dial grpc|dial_failed/.test(legacy)) reasonCode = 'dial_failed'
+    else if (/Version RPC|version_rpc_failed/.test(legacy)) reasonCode = 'version_rpc_failed'
+    else if (/waiting grpc|wait_connect_failed/.test(legacy)) reasonCode = 'wait_connect_failed'
+  }
+  const statusByCode = {
+    tcp_bind_in_use: 'port_occupied',
+    tcp_bind_denied: 'port_denied',
+    tcp_bind_failed: 'endpoint_unreachable',
+    database_error: 'database_error',
+    database_failed: 'database_error',
+    build_server_failed: stage === 'check' ? 'build_yak_error' : 'engine_init_failed',
+    dial_failed: 'dial_error',
+    version_rpc_failed: 'call_error',
+    wait_connect_failed: 'timeout',
+  }
+  const statusByPhase = {
+    database: 'database_error',
+    build_server: stage === 'check' ? 'build_yak_error' : 'engine_init_failed',
+    dial: 'dial_error',
+    version_rpc: 'call_error',
+    wait_connect: 'timeout',
+    serve: 'engine_exited',
+    init: 'engine_init_failed',
+    cert: 'engine_init_failed',
+  }
+  const status =
+    (Object.hasOwn(statusByCode, reasonCode) && statusByCode[reasonCode]) ||
+    (Object.hasOwn(statusByPhase, phase) && statusByPhase[phase]) ||
+    (stage === 'check' ? 'unknownReason' : 'engine_failed')
+  const messages = {
+    port_occupied: '端口被占用，请切换端口或检查占用进程',
+    port_denied: '系统拒绝使用该端口，请切换端口或检查系统策略',
+    endpoint_unreachable: '引擎监听失败，请检查端口配置后重试',
+    database_error: '数据库初始化失败，可点击修复进行处理',
+    build_yak_error: '引擎服务构建失败，请查看日志或重新安装引擎',
+    dial_error: '引擎连接失败，请查看日志或重试',
+    call_error: '引擎认证失败，请重新检查连接',
+    timeout: '等待引擎就绪超时，请重试',
+  }
+  const message = stringValue(data.reasonI18n?.zh) || messages[status] || detail || '引擎启动失败，请查看日志或重试'
+  return {
+    ok: false,
+    stage,
+    status,
+    message,
+    engineEvent: {
+      type: 'failed',
+      phase,
+      reasonCode,
+      reason: detail,
+      reasonI18n: isObject(data.reasonI18n) ? data.reasonI18n : null,
+      phaseI18n: isObject(data.phaseI18n) ? data.phaseI18n : null,
+    },
+  }
+}
+
+module.exports = {
+  createEngineLineReader,
+  parseEngineEvent,
+  parseCheckResult,
+  classifyEngineFailure,
+  redactEngineLog,
+  redactEngineData,
+}

--- a/app/main/handlers/utils/engineGrpcClient.js
+++ b/app/main/handlers/utils/engineGrpcClient.js
@@ -1,0 +1,37 @@
+const grpc = require('@grpc/grpc-js')
+
+function createEngineGrpcClient(Yak, connection, options = {}) {
+  // Each client owns its credentials. An unrelated connection attempt cannot change
+  // the metadata of RPCs already in flight on this client.
+  const { defaultYakGRPCAddr, caPem = '', password = '' } = connection
+  if (caPem) {
+    const metadata = new grpc.Metadata()
+    metadata.set('authorization', `bearer ${password}`)
+    const auth = grpc.credentials.createFromMetadataGenerator((params, callback) => callback(null, metadata))
+    return new Yak(
+      defaultYakGRPCAddr,
+      grpc.credentials.combineChannelCredentials(
+        grpc.credentials.createSsl(Buffer.from(caPem, 'latin1'), null, null, {
+          checkServerIdentity: () => undefined,
+        }),
+        auth,
+      ),
+      options,
+    )
+  }
+  const interceptors = [...(options.interceptors || [])]
+  if (password) {
+    interceptors.unshift(
+      (callOptions, nextCall) =>
+        new grpc.InterceptingCall(nextCall(callOptions), {
+          start(metadata, listener, next) {
+            metadata.set('authorization', `bearer ${password}`)
+            next(metadata, listener)
+          },
+        }),
+    )
+  }
+  return new Yak(defaultYakGRPCAddr, grpc.credentials.createInsecure(), { ...options, interceptors })
+}
+
+module.exports = { createEngineGrpcClient }

--- a/app/main/handlers/utils/engineStartup.js
+++ b/app/main/handlers/utils/engineStartup.js
@@ -83,6 +83,8 @@ function createEngineStartup({
   const limits = { check: 180000, start: 180000, connect: 10000, probe: 2000, retry: 500, ...timeouts }
   let generation = 0
   let active = null
+  let cleanupPromise = null
+  let cleanupFailure = null
   const children = new Set()
 
   // Progress is best-effort: a closing renderer must not interrupt engine cleanup.
@@ -92,9 +94,56 @@ function createEngineStartup({
     } catch {}
   }
 
+  function logCleanup(event, { operationId, stage, child, confirmedExit, elapsedMs = 0 }) {
+    try {
+      log(
+        redactEngineLog(
+          JSON.stringify({
+            event,
+            operationId,
+            stage,
+            ownedChildPid: child?.pid ?? null,
+            exitCode: child?.exitCode ?? null,
+            signal: child?.signalCode ?? null,
+            confirmedExit,
+            elapsedMs,
+          }),
+        ),
+      )
+    } catch {}
+  }
+
+  async function stopOwnedChild(child, operationId, stage) {
+    const startedAt = Date.now()
+    logCleanup('cleanup_start', { operationId, stage, child, confirmedExit: !isAlive(child) })
+    const confirmedExit = await stopEngineChild(child, execFile, platform)
+    logCleanup('cleanup_result', {
+      operationId,
+      stage,
+      child,
+      confirmedExit,
+      elapsedMs: Date.now() - startedAt,
+    })
+    return confirmedExit
+  }
+
   async function operation(stage, work) {
     const id = ++generation
-    if (active) await active.cancel()
+    if (cleanupPromise) await cleanupPromise
+    if (id !== generation) return cancelled(stage)
+    if (cleanupFailure) return { stage, ...cleanupFailure }
+    if (active) {
+      const previous = active
+      await previous.cancel()
+      if (previous.cleanupFailed || isAlive(previous.child)) {
+        cleanupFailure = {
+          ok: false,
+          status: 'process_error',
+          message: '引擎进程尚未退出，请稍后重试或查看日志',
+        }
+        return { stage, ...cleanupFailure }
+      }
+    }
     if (id !== generation) return cancelled(stage)
     let resolve
     const promise = new Promise((done) => {
@@ -103,6 +152,7 @@ function createEngineStartup({
     const resources = new Set()
     const op = {
       child: null,
+      cleanupFailed: false,
       finished: false,
       promise,
       current: () => !op.finished && id === generation,
@@ -128,8 +178,10 @@ function createEngineStartup({
           } catch {}
         }
         resources.clear()
-        if (!keepChild && op.child && !(await stopEngineChild(op.child, execFile, platform))) {
-          result = { ok: false, stage, status: 'process_error', message: '引擎进程尚未退出，请稍后重试或查看日志' }
+        if (!keepChild && op.child && !(await stopOwnedChild(op.child, id, stage))) {
+          op.cleanupFailed = true
+          cleanupFailure = { ok: false, status: 'process_error', message: '引擎进程尚未退出，请稍后重试或查看日志' }
+          result = cleanupFailure
         }
         if (active === op) active = null
         resolve({ stage, ...result })
@@ -192,7 +244,7 @@ function createEngineStartup({
     return child
   }
 
-  function probe(op, connection, done) {
+  function probe(op, connection, done, deadlineAt = Date.now() + limits.probe) {
     let client
     let call
     let finished = false
@@ -216,10 +268,11 @@ function createEngineStartup({
       if (op.current()) done(error, data)
     }
     remove = op.add(dispose)
-    clearTimer = op.timer(() => finish(new Error('Echo timed out')), limits.probe)
+    const remaining = Math.max(0, deadlineAt - Date.now())
+    clearTimer = op.timer(() => finish(new Error('Echo timed out')), remaining)
     try {
       client = createClient(connection)
-      call = client.Echo({ text: ECHO_TEXT }, { deadline: new Date(Date.now() + limits.probe) }, (error, data) => {
+      call = client.Echo({ text: ECHO_TEXT }, { deadline: new Date(deadlineAt) }, (error, data) => {
         finish(error || (data?.result !== ECHO_TEXT ? new Error('Unexpected Echo response') : null), data)
       })
     } catch (error) {
@@ -227,17 +280,27 @@ function createEngineStartup({
     }
   }
 
-  function authenticatedProbe(op, connection, done) {
-    probe(op, connection, (error, data) => {
-      if (error) return done(error)
-      // A different, unauthenticated Echo server can occupy the port between
-      // check and start. A successful Echo alone does not establish auth enforcement.
-      probe(op, { ...connection, password: '' }, (anonymousError) => {
-        if (anonymousError?.code === 16) return done(null, data) // UNAUTHENTICATED, including legacy engines.
-        if (anonymousError) return done(anonymousError)
-        done(Object.assign(new Error('Local endpoint accepts unauthenticated RPCs'), { unsafeEndpoint: true }))
-      })
-    })
+  function authenticatedProbe(op, connection, done, deadlineAt) {
+    probe(
+      op,
+      connection,
+      (error, data) => {
+        if (error) return done(error)
+        // A different, unauthenticated Echo server can occupy the port between
+        // check and start. A successful Echo alone does not establish auth enforcement.
+        probe(
+          op,
+          { ...connection, password: '' },
+          (anonymousError) => {
+            if (anonymousError?.code === 16) return done(null, data) // UNAUTHENTICATED, including legacy engines.
+            if (anonymousError) return done(anonymousError)
+            done(Object.assign(new Error('Local endpoint accepts unauthenticated RPCs'), { unsafeEndpoint: true }))
+          },
+          deadlineAt,
+        )
+      },
+      deadlineAt,
+    )
   }
 
   function check(params) {
@@ -422,30 +485,88 @@ function createEngineStartup({
   function connect(connection, requireLocalAuth = false) {
     return operation('connect', (op) => {
       const connectProbe = requireLocalAuth ? authenticatedProbe : probe
-      connectProbe(op, connection, (error, data) => {
-        if (error) return op.finish({ ok: false, status: 'dial_error', message: '引擎连接失败，请检查地址和认证信息' })
-        try {
-          commitConnection(connection)
-          op.finish({ ok: true, status: 'success', data })
-        } catch (error) {
-          op.finish({ ok: false, status: 'exception', message: '引擎连接失败，请重试' })
-        }
-      })
+      const deadlineAt = Date.now() + limits.connect
+      connectProbe(
+        op,
+        connection,
+        (error, data) => {
+          if (error)
+            return op.finish({ ok: false, status: 'dial_error', message: '引擎连接失败，请检查地址和认证信息' })
+          try {
+            commitConnection(connection)
+            op.finish({ ok: true, status: 'success', data })
+          } catch {
+            op.finish({ ok: false, status: 'exception', message: '引擎连接失败，请重试' })
+          }
+        },
+        deadlineAt,
+      )
     })
   }
 
-  async function cancel() {
-    generation++
+  function cleanupAll() {
+    const operationId = ++generation
+    if (cleanupPromise) return cleanupPromise
     const pending = active
-    if (pending) await pending.cancel()
-    return pending ? 1 : 0
-  }
+    const pendingChild = pending?.child || null
+    const cleanupStartedAt = Date.now()
+    const task = (async () => {
+      let canceled = 0
+      let failed = false
+      logCleanup('cleanup_start', {
+        operationId,
+        stage: 'dispose',
+        child: null,
+        confirmedExit: null,
+      })
 
-  async function dispose() {
-    const count = children.size || (active ? 1 : 0)
-    await cancel()
-    await Promise.all([...children].map((child) => stopEngineChild(child, execFile, platform)))
-    return count
+      if (pending) {
+        const result = await pending.cancel()
+        if (result.status === 'cancelled') canceled++
+        if (pending.cleanupFailed || isAlive(pendingChild)) failed = true
+      }
+
+      const retained = [...children].filter((child) => child !== pendingChild && isAlive(child))
+      const retainedResults = await Promise.all(retained.map((child) => stopOwnedChild(child, operationId, 'dispose')))
+      for (const confirmedExit of retainedResults) {
+        if (confirmedExit) canceled++
+        else failed = true
+      }
+
+      if (failed) {
+        cleanupFailure = {
+          ok: false,
+          status: 'process_error',
+          message: '引擎进程尚未退出，请稍后重试或查看日志',
+        }
+        return { ...cleanupFailure, canceled }
+      }
+      cleanupFailure = null
+      return { ok: true, canceled, status: 'cancelled' }
+    })()
+      .catch(() => {
+        cleanupFailure = {
+          ok: false,
+          status: 'process_error',
+          message: '引擎进程清理失败，请稍后重试或查看日志',
+        }
+        return { ...cleanupFailure, canceled: 0 }
+      })
+      .then((result) => {
+        logCleanup('cleanup_result', {
+          operationId,
+          stage: 'dispose',
+          child: null,
+          confirmedExit: result.ok,
+          elapsedMs: Date.now() - cleanupStartedAt,
+        })
+        return result
+      })
+    cleanupPromise = task
+    task.finally(() => {
+      if (cleanupPromise === task) cleanupPromise = null
+    })
+    return task
   }
 
   function killOnExit() {
@@ -467,7 +588,7 @@ function createEngineStartup({
     }
   }
 
-  return { check, start, connect, cancel, dispose, killOnExit }
+  return { check, start, connect, cancel: cleanupAll, dispose: cleanupAll, killOnExit }
 }
 
 module.exports = { createEngineStartup, stopEngineChild, validLocalPassword }

--- a/app/main/handlers/utils/engineStartup.js
+++ b/app/main/handlers/utils/engineStartup.js
@@ -1,0 +1,432 @@
+const childProcess = require('child_process')
+const { randomBytes } = require('crypto')
+const {
+  createEngineLineReader,
+  parseEngineEvent,
+  parseCheckResult,
+  classifyEngineFailure,
+  redactEngineLog,
+  redactEngineData,
+} = require('./engineDiagnostics')
+
+const ECHO_TEXT = 'Hello Yakit!'
+const MAX_CHECK_OUTPUT = 512 * 1024
+const cancelled = (stage) => ({ ok: false, stage, status: 'cancelled', message: '引擎连接已取消' })
+const isAlive = (child) => child?.pid && child.exitCode === null && child.signalCode === null
+
+// Only terminate a child we spawned. Never search for engines or kill a process by port/name.
+function stopEngineChild(child, execFile = childProcess.execFile, platform = process.platform) {
+  if (!isAlive(child)) return Promise.resolve(true)
+  return new Promise((resolve) => {
+    let finished = false
+    const finish = () => {
+      if (finished) return
+      finished = true
+      clearTimeout(forceTimer)
+      clearTimeout(deadline)
+      child.removeListener('close', finish)
+      resolve(!isAlive(child))
+    }
+    const forceTimer = setTimeout(() => {
+      if (isAlive(child)) {
+        try {
+          child.kill('SIGKILL')
+        } catch {}
+      }
+    }, 2000)
+    const deadline = setTimeout(finish, 4000)
+    child.once('close', finish)
+    try {
+      if (platform === 'win32') {
+        execFile(
+          'taskkill.exe',
+          ['/PID', String(child.pid), '/T', '/F'],
+          { windowsHide: true, timeout: 3000 },
+          () => {},
+        )
+      } else {
+        child.kill('SIGTERM')
+      }
+    } catch {
+      try {
+        child.kill('SIGKILL')
+      } catch {}
+    }
+  })
+}
+
+function validPort(port) {
+  return /^(?:[1-9]\d*)$/.test(String(port)) && Number(port) <= 65535
+}
+
+function validLocalPassword(password) {
+  return (
+    typeof password === 'string' &&
+    password.trim().length > 0 &&
+    !/^\*+$/.test(password.trim()) &&
+    !/[\r\n\0]/.test(password)
+  )
+}
+
+function createEngineStartup({
+  getCommand,
+  getEnv,
+  createClient,
+  commitConnection,
+  log = () => {},
+  notify = () => {},
+  spawn = childProcess.spawn,
+  execFile = childProcess.execFile,
+  platform = process.platform,
+  timeouts = {},
+}) {
+  const limits = { check: 60000, start: 60000, connect: 10000, probe: 2000, retry: 500, ...timeouts }
+  let generation = 0
+  let active = null
+  const children = new Set()
+
+  async function operation(stage, work) {
+    const id = ++generation
+    if (active) await active.cancel()
+    if (id !== generation) return cancelled(stage)
+    let resolve
+    const promise = new Promise((done) => {
+      resolve = done
+    })
+    const resources = new Set()
+    const op = {
+      child: null,
+      finished: false,
+      promise,
+      current: () => !op.finished && id === generation,
+      add: (dispose) => {
+        resources.add(dispose)
+        return () => resources.delete(dispose)
+      },
+      timer(fn, delay) {
+        const timer = setTimeout(() => {
+          resources.delete(clear)
+          if (op.current()) fn()
+        }, delay)
+        const clear = () => clearTimeout(timer)
+        resources.add(clear)
+        return clear
+      },
+      async finish(result, keepChild = false) {
+        if (op.finished) return promise
+        op.finished = true
+        for (const dispose of resources) {
+          try {
+            dispose()
+          } catch {}
+        }
+        resources.clear()
+        if (!keepChild && op.child && !(await stopEngineChild(op.child, execFile, platform))) {
+          result = { ok: false, stage, status: 'process_error', message: '引擎进程尚未退出，请稍后重试或查看日志' }
+        }
+        if (active === op) active = null
+        resolve({ stage, ...result })
+        return promise
+      },
+      cancel: () => op.finish(cancelled(stage)),
+    }
+    active = op
+    op.timer(
+      () => op.finish({ ok: false, status: 'timeout', message: '等待引擎超时，请重试或查看日志' }),
+      limits[stage],
+    )
+    try {
+      await work(op)
+    } catch (error) {
+      op.finish({ ok: false, status: 'exception', message: `引擎启动异常：${redactEngineLog(error.message || error)}` })
+    }
+    return promise
+  }
+
+  function attachProcess(op, args, params, onLine, onClose) {
+    const password = params.password || ''
+    const child = spawn(getCommand(), args, {
+      detached: false,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: getEnv(params.softwareVersion),
+    })
+    op.child = child
+    children.add(child)
+    const overflow = () =>
+      op.finish({ ok: false, status: 'protocol_error', message: '引擎启动输出过大，请查看日志或重新安装引擎' })
+    const readers = ['stdout', 'stderr'].map((stream) => {
+      const reader = createEngineLineReader((line) => {
+        // A closed window or failed log write must not strand an engine operation.
+        try {
+          log(redactEngineLog(line, [password]))
+        } catch {}
+        if (op.current()) onLine(line, stream)
+      }, overflow)
+      child[stream].on('data', reader.write)
+      child[stream].once('end', reader.end)
+      return reader
+    })
+    child.once('error', (error) =>
+      op.finish({
+        ok: false,
+        status: 'process_error',
+        message: `引擎进程启动失败：${redactEngineLog(error.message, [password])}`,
+      }),
+    )
+    child.once('close', (code, signal) => {
+      for (const reader of readers) reader.end()
+      children.delete(child)
+      if (op.current()) onClose(code, signal)
+    })
+    return child
+  }
+
+  function probe(op, connection, done) {
+    let client
+    let call
+    let finished = false
+    let remove = () => {}
+    let clearTimer = () => {}
+    const dispose = () => {
+      if (finished) return
+      finished = true
+      clearTimer()
+      remove()
+      try {
+        call?.cancel()
+      } catch {}
+      try {
+        client?.close()
+      } catch {}
+    }
+    const finish = (error, data) => {
+      if (finished) return
+      dispose()
+      if (op.current()) done(error, data)
+    }
+    remove = op.add(dispose)
+    clearTimer = op.timer(() => finish(new Error('Echo timed out')), limits.probe)
+    try {
+      client = createClient(connection)
+      call = client.Echo({ text: ECHO_TEXT }, { deadline: new Date(Date.now() + limits.probe) }, (error, data) => {
+        finish(error || (data?.result !== ECHO_TEXT ? new Error('Unexpected Echo response') : null), data)
+      })
+    } catch (error) {
+      finish(error)
+    }
+  }
+
+  function check(params) {
+    return operation('check', async (op) => {
+      if (!validPort(params.port) || (params.transport && params.transport !== 'tcp')) {
+        return op.finish({ ok: false, status: 'protocol_error', message: '本地引擎端口或连接方式无效，请重新配置' })
+      }
+      // A cancelled process must have exited before another check touches the same databases.
+      for (const child of children) {
+        if (isAlive(child))
+          return op.finish({
+            ok: false,
+            status: 'port_occupied',
+            message: '已有本地引擎进程正在运行，请先断开或切换端口',
+          })
+      }
+      const args = ['check-secret-local-grpc', '--port', String(params.port)]
+      let stdout = ''
+      let stderr = ''
+      attachProcess(
+        op,
+        args,
+        params,
+        (line, stream) => {
+          if (stream === 'stdout') stdout += line + '\n'
+          else stderr += line + '\n'
+          if (stdout.length + stderr.length > MAX_CHECK_OUTPUT) {
+            op.finish({ ok: false, status: 'protocol_error', message: '引擎检查输出过大，请查看日志' })
+          }
+        },
+        (code, signal) => {
+          const json = parseCheckResult(stdout)
+          if (json?.ok === true && code === 0 && !signal) {
+            if ((json.transport && json.transport !== 'tcp') || Number(json.port) !== Number(params.port)) {
+              return op.finish({
+                ok: false,
+                status: 'protocol_error',
+                message: '引擎检查返回的地址与请求不一致，请重试或更新引擎',
+              })
+            }
+            // The check's secret is diagnostic data in newer engines (sometimes "***").
+            // Generate a fresh production credential here for both old and new engines.
+            return op.finish({
+              ok: true,
+              status: 'success',
+              json: { ...json, secret: randomBytes(32).toString('hex') },
+            })
+          }
+          if (json?.ok === false) {
+            const failure = classifyEngineFailure(json, 'check')
+            const safe = redactEngineData({ ...failure, json })
+            return op.finish(safe)
+          }
+          const output = stdout + stderr
+          if (
+            /flag provided but not defined|unknown command.*check-secret-local-grpc|No help topic for.*check-secret-local-grpc/i.test(
+              output,
+            ) ||
+            (/check-secret-local-grpc/.test(output) &&
+              /no such file or directory|cannot find the file specified/i.test(output))
+          ) {
+            return op.finish({
+              ok: false,
+              status: 'old_version',
+              message: '当前引擎不支持安全本地启动，请选择其他引擎版本或更新引擎',
+            })
+          }
+          op.finish({
+            ok: false,
+            status: 'process_error',
+            message: `引擎检查未正常完成（退出码 ${code ?? signal ?? '未知'}），请重试或查看日志`,
+          })
+        },
+      )
+    })
+  }
+
+  function start(params) {
+    return operation('start', async (op) => {
+      if (
+        !validPort(params.port) ||
+        !validLocalPassword(params.password) ||
+        (params.transport && params.transport !== 'tcp')
+      ) {
+        return op.finish({ ok: false, status: 'protocol_error', message: '本地引擎连接参数无效，请重新检查引擎' })
+      }
+      for (const child of children) {
+        if (isAlive(child))
+          return op.finish({
+            ok: false,
+            status: 'port_occupied',
+            message: '已有本地引擎进程正在运行，请先断开或切换端口',
+          })
+      }
+      const connection = { defaultYakGRPCAddr: `127.0.0.1:${params.port}`, caPem: '', password: params.password }
+      const args = [
+        'grpc',
+        '--local-password',
+        params.password,
+        '--frontend',
+        String(params.version || 'yakit'),
+        '--port',
+        String(params.port),
+      ]
+      if (params.isEnpriTraceAgent) args.push('--disable-output')
+      let inFlight = false
+      let clearRetry = () => {}
+      const tryConnect = () => {
+        if (!op.current() || inFlight || !isAlive(op.child)) return
+        clearRetry()
+        inFlight = true
+        probe(op, connection, (error) => {
+          inFlight = false
+          if (!isAlive(op.child)) return
+          if (error) {
+            clearRetry = op.timer(tryConnect, limits.retry)
+            return
+          }
+          try {
+            commitConnection(connection)
+            op.finish({ ok: true, status: 'success', message: '引擎认证连接成功' }, true)
+          } catch (error) {
+            op.finish({
+              ok: false,
+              status: 'exception',
+              message: `引擎连接失败：${redactEngineLog(error.message, [params.password])}`,
+            })
+          }
+        })
+      }
+      attachProcess(
+        op,
+        args,
+        params,
+        (line, stream) => {
+          if (stream !== 'stdout') return
+          const event = parseEngineEvent(line)
+          if (
+            event?.type === 'invalid' ||
+            (event?.type === 'ready' && (event.transport !== 'tcp' || event.address !== connection.defaultYakGRPCAddr))
+          ) {
+            return op.finish({
+              ok: false,
+              status: 'protocol_error',
+              message: '引擎返回了不兼容的连接信息，请重新检查或更新引擎',
+            })
+          }
+          if (event?.type === 'failed')
+            return op.finish(redactEngineData(classifyEngineFailure(event, 'start'), [params.password]))
+          if (event?.type === 'ready' || event?.type === 'log_ok') tryConnect()
+          if (line.includes('<json-f97f966eb7f8ba8fdb63e4d29109c058>')) notify('LocalEngine.database_initializing')
+        },
+        (code, signal) =>
+          op.finish({
+            ok: false,
+            status: 'engine_exited',
+            message: `引擎进程已退出（${code ?? signal ?? '未知'}），请重试或查看日志`,
+          }),
+      )
+      notify('LocalEngine.waiting_engine_fully_started')
+      clearRetry = op.timer(tryConnect, limits.retry)
+    })
+  }
+
+  function connect(connection) {
+    return operation('connect', (op) => {
+      probe(op, connection, (error, data) => {
+        if (error) return op.finish({ ok: false, status: 'dial_error', message: '引擎连接失败，请检查地址和认证信息' })
+        try {
+          commitConnection(connection)
+          op.finish({ ok: true, status: 'success', data })
+        } catch (error) {
+          op.finish({ ok: false, status: 'exception', message: '引擎连接失败，请重试' })
+        }
+      })
+    })
+  }
+
+  async function cancel() {
+    generation++
+    const pending = active
+    if (pending) await pending.cancel()
+    return pending ? 1 : 0
+  }
+
+  async function dispose() {
+    const count = children.size || (active ? 1 : 0)
+    await cancel()
+    await Promise.all([...children].map((child) => stopEngineChild(child, execFile, platform)))
+    return count
+  }
+
+  function killOnExit() {
+    for (const child of children) {
+      if (isAlive(child)) {
+        try {
+          if (platform === 'win32') {
+            childProcess.execFileSync('taskkill.exe', ['/PID', String(child.pid), '/T', '/F'], {
+              windowsHide: true,
+              timeout: 3000,
+              stdio: 'ignore',
+            })
+          }
+        } catch {}
+        try {
+          child.kill('SIGKILL')
+        } catch {}
+      }
+    }
+  }
+
+  return { check, start, connect, cancel, dispose, killOnExit }
+}
+
+module.exports = { createEngineStartup, stopEngineChild, validLocalPassword }

--- a/app/main/handlers/utils/engineStartup.js
+++ b/app/main/handlers/utils/engineStartup.js
@@ -80,10 +80,17 @@ function createEngineStartup({
   platform = process.platform,
   timeouts = {},
 }) {
-  const limits = { check: 60000, start: 60000, connect: 10000, probe: 2000, retry: 500, ...timeouts }
+  const limits = { check: 180000, start: 180000, connect: 10000, probe: 2000, retry: 500, ...timeouts }
   let generation = 0
   let active = null
   const children = new Set()
+
+  // Progress is best-effort: a closing renderer must not interrupt engine cleanup.
+  function notifyProgress(message) {
+    try {
+      notify(message)
+    } catch {}
+  }
 
   async function operation(stage, work) {
     const id = ++generation
@@ -135,6 +142,9 @@ function createEngineStartup({
       () => op.finish({ ok: false, status: 'timeout', message: '等待引擎超时，请重试或查看日志' }),
       limits[stage],
     )
+    if (stage === 'check' || stage === 'start') {
+      op.timer(() => notifyProgress('LocalEngine.migration_wait_hint'), 20000)
+    }
     try {
       await work(op)
     } catch (error) {
@@ -259,7 +269,13 @@ function createEngineStartup({
           }
         },
         (code, signal) => {
-          const json = parseCheckResult(stdout)
+          try {
+            log(`Engine check exited: code=${code ?? 'unknown'}, signal=${signal ?? 'none'}`)
+          } catch {}
+          // Some legacy engines write the marked result to stderr. Multiple
+          // results across either stream remain ambiguous and are rejected.
+          const output = stdout + '\n' + stderr
+          const json = parseCheckResult(output)
           if (json?.ok === true && code === 0 && !signal) {
             if ((json.transport && json.transport !== 'tcp') || Number(json.port) !== Number(params.port)) {
               return op.finish({
@@ -281,7 +297,6 @@ function createEngineStartup({
             const safe = redactEngineData({ ...failure, json })
             return op.finish(safe)
           }
-          const output = stdout + stderr
           if (
             /flag provided but not defined|unknown command.*check-secret-local-grpc|No help topic for.*check-secret-local-grpc/i.test(
               output,
@@ -297,8 +312,12 @@ function createEngineStartup({
           }
           op.finish({
             ok: false,
-            status: 'process_error',
-            message: `引擎检查未正常完成（退出码 ${code ?? signal ?? '未知'}），请重试或查看日志`,
+            status: output.trim() ? 'process_error' : 'antivirus_blocked',
+            exitCode: code,
+            signal,
+            message: output.trim()
+              ? `引擎检查未正常完成（退出码 ${code ?? signal ?? '未知'}），请重试或查看日志`
+              : `引擎未输出诊断信息便退出（退出码 ${code ?? signal ?? '未知'}）。可能被安全软件拦截，也可能是进程异常；请检查拦截记录和引擎日志，确认文件可信后重试`,
           })
         },
       )
@@ -385,7 +404,8 @@ function createEngineStartup({
           if (event?.type === 'failed')
             return op.finish(redactEngineData(classifyEngineFailure(event, 'start'), [params.password]))
           if (event?.type === 'ready' || event?.type === 'log_ok') tryConnect()
-          if (line.includes('<json-f97f966eb7f8ba8fdb63e4d29109c058>')) notify('LocalEngine.database_initializing')
+          if (line.includes('<json-f97f966eb7f8ba8fdb63e4d29109c058>'))
+            notifyProgress('LocalEngine.database_initializing')
         },
         (code, signal) =>
           op.finish({
@@ -394,7 +414,7 @@ function createEngineStartup({
             message: `引擎进程已退出（${code ?? signal ?? '未知'}），请重试或查看日志`,
           }),
       )
-      notify('LocalEngine.waiting_engine_fully_started')
+      notifyProgress('LocalEngine.waiting_engine_fully_started')
       clearRetry = op.timer(tryConnect, limits.retry)
     })
   }

--- a/app/main/handlers/utils/engineStartup.js
+++ b/app/main/handlers/utils/engineStartup.js
@@ -14,28 +14,73 @@ const MAX_CHECK_OUTPUT = 512 * 1024
 const cancelled = (stage) => ({ ok: false, stage, status: 'cancelled', message: '引擎连接已取消' })
 const isAlive = (child) => child?.pid && child.exitCode === null && child.signalCode === null
 
+function isProcessGroupAlive(groupId, killProcess) {
+  if (!groupId) return false
+  try {
+    killProcess(-groupId, 0)
+    return true
+  } catch (error) {
+    return error?.code !== 'ESRCH'
+  }
+}
+
+function isOwnedProcessAlive(child, platform, killProcess) {
+  if (platform !== 'win32' && child?.ownedProcessGroupExited) return false
+  if (platform !== 'win32' && child?.ownedProcessGroup) {
+    const alive = isProcessGroupAlive(child.ownedProcessGroup, killProcess)
+    if (!alive) {
+      child.ownedProcessGroup = null
+      child.ownedProcessGroupExited = true
+    }
+    return alive
+  }
+  return Boolean(isAlive(child))
+}
+
 // Only terminate a child we spawned. Never search for engines or kill a process by port/name.
-function stopEngineChild(child, execFile = childProcess.execFile, platform = process.platform) {
-  if (!isAlive(child)) return Promise.resolve(true)
+function stopEngineChild(
+  child,
+  execFile = childProcess.execFile,
+  platform = process.platform,
+  killProcess = process.kill,
+) {
+  if (!isOwnedProcessAlive(child, platform, killProcess)) return Promise.resolve(true)
   return new Promise((resolve) => {
     let finished = false
-    const finish = () => {
+    let forceTimer
+    let deadline
+    let pollTimer
+    const finish = (confirmedExit = !isOwnedProcessAlive(child, platform, killProcess)) => {
       if (finished) return
       finished = true
       clearTimeout(forceTimer)
       clearTimeout(deadline)
-      child.removeListener('close', finish)
-      resolve(!isAlive(child))
+      clearTimeout(pollTimer)
+      child.removeListener('close', checkExit)
+      resolve(confirmedExit)
     }
-    const forceTimer = setTimeout(() => {
-      if (isAlive(child)) {
-        try {
-          child.kill('SIGKILL')
-        } catch {}
-      }
-    }, 2000)
-    const deadline = setTimeout(finish, 4000)
-    child.once('close', finish)
+
+    const checkExit = () => {
+      if (!isOwnedProcessAlive(child, platform, killProcess)) return finish(true)
+      clearTimeout(pollTimer)
+      pollTimer = setTimeout(checkExit, 50)
+    }
+
+    const signalOwnedProcess = (signal) => {
+      if (!isOwnedProcessAlive(child, platform, killProcess)) return checkExit()
+      try {
+        if (platform !== 'win32' && child.ownedProcessGroup) {
+          killProcess(-child.ownedProcessGroup, signal)
+        } else {
+          child.kill(signal)
+        }
+      } catch {}
+      checkExit()
+    }
+
+    forceTimer = setTimeout(() => signalOwnedProcess('SIGKILL'), 2000)
+    deadline = setTimeout(() => finish(), 4000)
+    child.on('close', checkExit)
     try {
       if (platform === 'win32') {
         execFile(
@@ -45,12 +90,10 @@ function stopEngineChild(child, execFile = childProcess.execFile, platform = pro
           () => {},
         )
       } else {
-        child.kill('SIGTERM')
+        signalOwnedProcess('SIGTERM')
       }
     } catch {
-      try {
-        child.kill('SIGKILL')
-      } catch {}
+      signalOwnedProcess('SIGKILL')
     }
   })
 }
@@ -78,6 +121,7 @@ function createEngineStartup({
   spawn = childProcess.spawn,
   execFile = childProcess.execFile,
   platform = process.platform,
+  killProcess = process.kill,
   timeouts = {},
 }) {
   const limits = { check: 180000, start: 180000, connect: 10000, probe: 2000, retry: 500, ...timeouts }
@@ -86,6 +130,28 @@ function createEngineStartup({
   let cleanupPromise = null
   let cleanupFailure = null
   const children = new Set()
+
+  function ownedChildAlive(child) {
+    const alive = isOwnedProcessAlive(child, platform, killProcess)
+    if (!alive) {
+      clearTimeout(child?.ownedProcessGroupWatcher)
+      if (child) child.ownedProcessGroupWatcher = null
+      children.delete(child)
+    }
+    return alive
+  }
+
+  function watchOwnedChild(child) {
+    if (!child?.ownedProcessGroup || child.ownedProcessGroupWatcher) return
+    const check = () => {
+      child.ownedProcessGroupWatcher = null
+      if (!ownedChildAlive(child)) return
+      child.ownedProcessGroupWatcher = setTimeout(check, 250)
+      child.ownedProcessGroupWatcher.unref?.()
+    }
+    child.ownedProcessGroupWatcher = setTimeout(check, 250)
+    child.ownedProcessGroupWatcher.unref?.()
+  }
 
   // Progress is best-effort: a closing renderer must not interrupt engine cleanup.
   function notifyProgress(message) {
@@ -115,8 +181,14 @@ function createEngineStartup({
 
   async function stopOwnedChild(child, operationId, stage) {
     const startedAt = Date.now()
-    logCleanup('cleanup_start', { operationId, stage, child, confirmedExit: !isAlive(child) })
-    const confirmedExit = await stopEngineChild(child, execFile, platform)
+    logCleanup('cleanup_start', {
+      operationId,
+      stage,
+      child,
+      confirmedExit: !ownedChildAlive(child),
+    })
+    const confirmedExit = await stopEngineChild(child, execFile, platform, killProcess)
+    if (confirmedExit) children.delete(child)
     logCleanup('cleanup_result', {
       operationId,
       stage,
@@ -135,7 +207,7 @@ function createEngineStartup({
     if (active) {
       const previous = active
       await previous.cancel()
-      if (previous.cleanupFailed || isAlive(previous.child)) {
+      if (previous.cleanupFailed || ownedChildAlive(previous.child)) {
         cleanupFailure = {
           ok: false,
           status: 'process_error',
@@ -208,11 +280,15 @@ function createEngineStartup({
   function attachProcess(op, args, params, onLine, onClose) {
     const password = params.password || ''
     const child = spawn(getCommand(), args, {
-      detached: false,
+      detached: platform !== 'win32',
       windowsHide: true,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: getEnv(params.softwareVersion),
     })
+    if (platform !== 'win32' && child.pid) {
+      child.ownedProcessGroup = child.pid
+      child.ownedProcessGroupExited = false
+    }
     op.child = child
     children.add(child)
     const overflow = () =>
@@ -238,7 +314,7 @@ function createEngineStartup({
     )
     child.once('close', (code, signal) => {
       for (const reader of readers) reader.end()
-      children.delete(child)
+      if (ownedChildAlive(child)) watchOwnedChild(child)
       if (op.current()) onClose(code, signal)
     })
     return child
@@ -310,7 +386,7 @@ function createEngineStartup({
       }
       // A cancelled process must have exited before another check touches the same databases.
       for (const child of children) {
-        if (isAlive(child))
+        if (ownedChildAlive(child))
           return op.finish({
             ok: false,
             status: 'port_occupied',
@@ -397,7 +473,7 @@ function createEngineStartup({
         return op.finish({ ok: false, status: 'protocol_error', message: '本地引擎连接参数无效，请重新检查引擎' })
       }
       for (const child of children) {
-        if (isAlive(child))
+        if (ownedChildAlive(child))
           return op.finish({
             ok: false,
             status: 'port_occupied',
@@ -523,10 +599,10 @@ function createEngineStartup({
       if (pending) {
         const result = await pending.cancel()
         if (result.status === 'cancelled') canceled++
-        if (pending.cleanupFailed || isAlive(pendingChild)) failed = true
+        if (pending.cleanupFailed || ownedChildAlive(pendingChild)) failed = true
       }
 
-      const retained = [...children].filter((child) => child !== pendingChild && isAlive(child))
+      const retained = [...children].filter((child) => child !== pendingChild && ownedChildAlive(child))
       const retainedResults = await Promise.all(retained.map((child) => stopOwnedChild(child, operationId, 'dispose')))
       for (const confirmedExit of retainedResults) {
         if (confirmedExit) canceled++
@@ -571,7 +647,7 @@ function createEngineStartup({
 
   function killOnExit() {
     for (const child of children) {
-      if (isAlive(child)) {
+      if (ownedChildAlive(child)) {
         try {
           if (platform === 'win32') {
             childProcess.execFileSync('taskkill.exe', ['/PID', String(child.pid), '/T', '/F'], {
@@ -579,11 +655,15 @@ function createEngineStartup({
               timeout: 3000,
               stdio: 'ignore',
             })
+          } else if (child.ownedProcessGroup) {
+            killProcess(-child.ownedProcessGroup, 'SIGKILL')
           }
         } catch {}
-        try {
-          child.kill('SIGKILL')
-        } catch {}
+        if (platform === 'win32') {
+          try {
+            child.kill('SIGKILL')
+          } catch {}
+        }
       }
     }
   }

--- a/app/main/handlers/utils/engineStartup.js
+++ b/app/main/handlers/utils/engineStartup.js
@@ -217,6 +217,19 @@ function createEngineStartup({
     }
   }
 
+  function authenticatedProbe(op, connection, done) {
+    probe(op, connection, (error, data) => {
+      if (error) return done(error)
+      // A different, unauthenticated Echo server can occupy the port between
+      // check and start. A successful Echo alone does not establish auth enforcement.
+      probe(op, { ...connection, password: '' }, (anonymousError) => {
+        if (anonymousError?.code === 16) return done(null, data) // UNAUTHENTICATED, including legacy engines.
+        if (anonymousError) return done(anonymousError)
+        done(Object.assign(new Error('Local endpoint accepts unauthenticated RPCs'), { unsafeEndpoint: true }))
+      })
+    })
+  }
+
   function check(params) {
     return operation('check', async (op) => {
       if (!validPort(params.port) || (params.transport && params.transport !== 'tcp')) {
@@ -326,10 +339,17 @@ function createEngineStartup({
         if (!op.current() || inFlight || !isAlive(op.child)) return
         clearRetry()
         inFlight = true
-        probe(op, connection, (error) => {
+        authenticatedProbe(op, connection, (error) => {
           inFlight = false
           if (!isAlive(op.child)) return
           if (error) {
+            if (error.unsafeEndpoint) {
+              return op.finish({
+                ok: false,
+                status: 'protocol_error',
+                message: '本地端口上的服务未启用认证，请切换端口或重新检查引擎',
+              })
+            }
             clearRetry = op.timer(tryConnect, limits.retry)
             return
           }
@@ -379,9 +399,10 @@ function createEngineStartup({
     })
   }
 
-  function connect(connection) {
+  function connect(connection, requireLocalAuth = false) {
     return operation('connect', (op) => {
-      probe(op, connection, (error, data) => {
+      const connectProbe = requireLocalAuth ? authenticatedProbe : probe
+      connectProbe(op, connection, (error, data) => {
         if (error) return op.finish({ ok: false, status: 'dial_error', message: '引擎连接失败，请检查地址和认证信息' })
         try {
           commitConnection(connection)

--- a/app/main/ipc.js
+++ b/app/main/ipc.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const PROTO_PATH = path.join(__dirname, '../protos/grpc.proto')
 const { HttpSetting } = require('./state')
 const grpc = require('@grpc/grpc-js')
+const { createEngineGrpcClient } = require('./handlers/utils/engineGrpcClient')
 const protoLoader = require('@grpc/proto-loader')
 const { printLogOutputFile } = require('./logFile')
 const { assertTrustedAppSender, normalizeHttpBaseUrl } = require('./security')
@@ -68,49 +69,8 @@ const options = {
   interceptors: [createGrpcInterceptor()],
 }
 
-function newClient() {
-  const md = new grpc.Metadata()
-  md.set('authorization', `bearer ${global.password}`)
-  if (global.caPem !== '') {
-    const creds = grpc.credentials.createFromMetadataGenerator((params, callback) => {
-      return callback(null, md)
-    })
-    return new Yak(
-      global.defaultYakGRPCAddr,
-      // grpc.credentials.createInsecure(),
-      grpc.credentials.combineChannelCredentials(
-        grpc.credentials.createSsl(Buffer.from(global.caPem, 'latin1'), null, null, {
-          checkServerIdentity: (hostname, cert) => {
-            return undefined
-          },
-        }),
-        creds,
-      ),
-      options,
-    )
-  } else if (global.password && global.password !== '') {
-    // 非 TLS 连接（可能需要密码认证，例如 secret-local 模式）
-    // 对于非 TLS 连接，不能使用 combineChannelCredentials
-    // 需要通过拦截器在每次调用时添加 metadata
-    const optionsWithInterceptors = {
-      ...options,
-      interceptors: [
-        (options, nextCall) => {
-          return new grpc.InterceptingCall(nextCall(options), {
-            start: function (metadata, listener, next) {
-              metadata.set('authorization', `bearer ${global.password}`)
-              next(metadata, listener)
-            },
-          })
-        },
-        createGrpcInterceptor(),
-      ],
-    }
-    return new Yak(global.defaultYakGRPCAddr, grpc.credentials.createInsecure(), optionsWithInterceptors)
-  } else {
-    // 普通非 TLS 连接（无密码）
-    return new Yak(global.defaultYakGRPCAddr, grpc.credentials.createInsecure(), options)
-  }
+function newClient(settings = global) {
+  return createEngineGrpcClient(Yak, settings, options)
 }
 
 function getClient(createNew) {
@@ -542,7 +502,7 @@ module.exports = {
     // asyncEcho wrapper
     const asyncEcho = (params) => {
       return new Promise((resolve, reject) => {
-        getClient().Echo(params, (err, data) => {
+        getClient().Echo(params, { deadline: new Date(Date.now() + 5000) }, (err, data) => {
           if (err) {
             reject(err)
             return

--- a/app/renderer/engine-link-startup/src/global.d.ts
+++ b/app/renderer/engine-link-startup/src/global.d.ts
@@ -29,6 +29,7 @@ declare global {
   type YaklangEngineWatchDogCredential = StartupTypes.YaklangEngineWatchDogCredential
   type TypeCallbackExtra = StartupTypes.TypeCallbackExtra
   type StartLocalEngine = StartupTypes.StartLocalEngine
+  type CancelTasksResult = StartupTypes.CancelTasksResult
   type YakitAuthInfo = RemoteEngineTypes.YakitAuthInfo
   type CheckAllowSecretLocal = LocalEngineTypes.CheckAllowSecretLocal
   type FixupDatabase = LocalEngineTypes.FixupDatabase
@@ -202,7 +203,7 @@ declare global {
       calcEngineSha265: () => Promise<string[]>
       startSecretLocalYaklangEngine: (params: StartLocalEngine) => Promise<StartupExecResult>
       echo: (payload: EchoPayload) => Promise<EchoResult>
-      cancelAllTasks: () => Promise<any>
+      cancelAllTasks: () => Promise<CancelTasksResult>
       killYakGrpc: (pid: number) => Promise<any>
       listYakGrpc: () => Promise<YakProcessInfo[]>
       fetchYaklangEngineAddr: () => Promise<YaklangEngineAddr>

--- a/app/renderer/engine-link-startup/src/locales/en/link.json
+++ b/app/renderer/engine-link-startup/src/locales/en/link.json
@@ -74,11 +74,9 @@
     "try_start_local_process": "Attempting to start local process",
     "remote_mode_no_auto_start": "Remote mode does not auto-start local engine",
     "start_local_engine_with_port": "Starting local engine with standard permissions on port {{port}}",
-    "engine_start_failed": "Engine start failed: {{status}}: {{message}}",
     "engine_start_interrupted": "Engine start command interrupted or unexpected error: {{error}}",
     "engine_ready_to_connect": "Engine is ready to connect",
     "engine_not_fully_started": "Engine not fully started, unable to connect. Failed attempts: {{count}}",
-    "command_timeout_retry": "Command timed out. Click to retry",
     "engine_start_interrupted_check_log": "Engine start command interrupted or unexpected error. Check logs for details..."
   },
   "YakitLoading": {
@@ -111,7 +109,8 @@
     "exit": "Exit",
     "open_engine_files": "Open Engine Files",
     "disconnect": "Disconnect",
-    "more_engine_versions": "More Engine Versions"
+    "more_engine_versions": "More Engine Versions",
+    "port_denied_retry": "Retry as Administrator"
   },
   "UpdateYakitHint": {
     "download_complete": "Download complete",
@@ -201,19 +200,11 @@
     }
   },
   "LocalEngine": {
-    "checking_secret_password_mode": "Checking random password mode...",
-    "secret_password_check_passed": "Check passed, random password mode is supported",
-    "command_timeout_check_log": "Command timed out. Check logs for details...",
-    "engine_connect_timeout_check_log": "Engine connection timed out. Check logs for details...",
+    "checking_secret_password_mode": "Checking engine environment...",
+    "secret_password_check_passed": "Engine environment check passed",
     "engine_version_low_reset": "Engine version is outdated. Click to reset engine version...",
     "engine_version_low_download": "Engine version is outdated. Click to download engine update...",
-    "port_unavailable_check_log": "Port unavailable. Check log errors for details...",
-    "antivirus_blocked_check_log": "Blocked by antivirus. Add the app to the allowlist and restart...",
     "engine_connect_error_reset": "Engine connection failed. Click to reset engine version...",
-    "database_error_check_log": "Local database error detected. Click to repair...",
-    "cannot_start_contact_staff": "Unable to start. Send logs to support for assistance...",
-    "failure_reason": "[Reason]: {{status}}: {{message}}",
-    "none": "None",
     "dev_env_direct_connect": "Development environment, connecting engine directly",
     "checking_software_update": "Checking for software updates...",
     "skip_check_hint": "Check skipped (can be enabled in software update settings)",

--- a/app/renderer/engine-link-startup/src/locales/en/link.json
+++ b/app/renderer/engine-link-startup/src/locales/en/link.json
@@ -1,4 +1,24 @@
 {
+  "EngineFailure": {
+    "port_occupied": "The port is in use. Choose another port or inspect the process using it.",
+    "port_denied": "The system denied access to this port. Choose another port or check system policies.",
+    "endpoint_unreachable": "The engine could not listen on the endpoint. Check the port settings and retry.",
+    "database_error": "Database initialization failed. Save the logs and back up your data before attempting a repair.",
+    "build_yak_error": "The engine service could not be created. Check the logs or reinstall the engine.",
+    "engine_init_failed": "Engine initialization failed. Check the logs and run the engine check again.",
+    "dial_error": "The engine connection failed. Check the address and credentials, then retry.",
+    "call_error": "Engine authentication failed. Check the connection credentials again.",
+    "timeout": "Timed out waiting for the engine. Save the logs and retry; data migration may take longer.",
+    "antivirus_blocked": "The engine exited without diagnostic output. Security software may have blocked it, or the process may have failed. Check security-software events and engine logs, verify the file is trusted, then retry.",
+    "old_version": "This engine does not support secure local startup. Choose another engine version or update it.",
+    "protocol_error": "The engine returned invalid connection information. Run the engine check again or update the engine.",
+    "process_error": "The engine process did not finish normally. Save the engine logs and exit code, check the file and permissions, then retry.",
+    "engine_exited": "The engine exited unexpectedly. Check its logs and retry."
+  },
+  "UIEngineList": {
+    "switch_engine": "Switch engine",
+    "authenticated_switch_required": "A process listing cannot verify engine credentials, so direct switching is unavailable. Enter the address and password in the connection settings instead. The current engine will not be closed automatically."
+  },
   "StartupPage": {
     "born_for_cybersecurity": "Born for cybersecurity",
     "checking_environment": "Checking environment...",
@@ -200,6 +220,7 @@
     }
   },
   "LocalEngine": {
+    "migration_wait_hint": "The engine is still preparing. Upgrading across major versions may take extra time to migrate the database, usually once per major-version upgrade. Please wait; this stage allows up to 180 seconds. If it times out, check the logs and retry.",
     "checking_secret_password_mode": "Checking engine environment...",
     "secret_password_check_passed": "Engine environment check passed",
     "engine_version_low_reset": "Engine version is outdated. Click to reset engine version...",

--- a/app/renderer/engine-link-startup/src/locales/en/link.json
+++ b/app/renderer/engine-link-startup/src/locales/en/link.json
@@ -77,7 +77,8 @@
     "engine_start_interrupted": "Engine start command interrupted or unexpected error: {{error}}",
     "engine_ready_to_connect": "Engine is ready to connect",
     "engine_not_fully_started": "Engine not fully started, unable to connect. Failed attempts: {{count}}",
-    "engine_start_interrupted_check_log": "Engine start command interrupted or unexpected error. Check logs for details..."
+    "engine_start_interrupted_check_log": "Engine start command interrupted or unexpected error. Check logs for details...",
+    "startup_failed": "Engine startup failed. Retry or view the logs."
   },
   "YakitLoading": {
     "agreement_check_prefix": "I agree to the",
@@ -109,8 +110,7 @@
     "exit": "Exit",
     "open_engine_files": "Open Engine Files",
     "disconnect": "Disconnect",
-    "more_engine_versions": "More Engine Versions",
-    "port_denied_retry": "Retry as Administrator"
+    "more_engine_versions": "More Engine Versions"
   },
   "UpdateYakitHint": {
     "download_complete": "Download complete",
@@ -224,7 +224,8 @@
     "abnormal_cannot_verify_source": "Abnormal error, unable to verify source",
     "preparing_start_connect_engine": "Preparing to start engine connection",
     "waiting_engine_fully_started": "Waiting for the engine to fully start",
-    "database_initializing": "Database is initializing..."
+    "database_initializing": "Database is initializing...",
+    "check_failed": "Engine check failed. Retry or view the logs."
   },
   "EngineLog": {
     "welcome": "Welcome to {{name}}!",

--- a/app/renderer/engine-link-startup/src/locales/en/link.json
+++ b/app/renderer/engine-link-startup/src/locales/en/link.json
@@ -61,6 +61,7 @@
     "remote_connection_disconnected": "Remote connection disconnected",
     "engine_reconnecting": "Engine connection failed, retrying...",
     "manual_disconnect_triggered": "Manual disconnect triggered",
+    "stop_owned_engine_failed": "Unable to stop this Yakit instance's engine process. Retry after checking the engine logs.",
     "fix_database_unexpected_console": "Unexpected error while repairing database: {{error}}",
     "reclaim_database_unexpected_console": "Unexpected error during reclaim: {{error}}",
     "no_image": "No image"

--- a/app/renderer/engine-link-startup/src/locales/zh-TW/link.json
+++ b/app/renderer/engine-link-startup/src/locales/zh-TW/link.json
@@ -61,6 +61,7 @@
     "remote_connection_disconnected": "遠端連接已斷開",
     "engine_reconnecting": "引擎連接未成功, 正在嘗試重連",
     "manual_disconnect_triggered": "手動觸發中斷連接",
+    "stop_owned_engine_failed": "無法停止目前 Yakit 實例的引擎進程，請查看引擎日誌後重試",
     "fix_database_unexpected_console": "修復資料庫出現意外情況：{{error}}",
     "reclaim_database_unexpected_console": "回收出現意外情況：{{error}}",
     "no_image": "暫無圖片"

--- a/app/renderer/engine-link-startup/src/locales/zh-TW/link.json
+++ b/app/renderer/engine-link-startup/src/locales/zh-TW/link.json
@@ -1,4 +1,24 @@
 {
+  "EngineFailure": {
+    "port_occupied": "連接埠被占用，請切換連接埠或檢查占用程序。",
+    "port_denied": "系統拒絕使用此連接埠，請切換連接埠或檢查系統原則。",
+    "endpoint_unreachable": "引擎監聽失敗，請檢查連接埠設定後重試。",
+    "database_error": "資料庫初始化失敗，請先保留日誌並備份資料，再嘗試修復。",
+    "build_yak_error": "引擎服務建立失敗，請查看日誌或重新安裝引擎。",
+    "engine_init_failed": "引擎初始化失敗，請查看日誌並重新檢查引擎。",
+    "dial_error": "引擎連線失敗，請檢查位址與驗證資訊後重試。",
+    "call_error": "引擎驗證失敗，請重新檢查連線。",
+    "timeout": "等待引擎逾時，請保留日誌並重試；資料遷移可能需要較長時間。",
+    "antivirus_blocked": "引擎未輸出診斷資訊便結束，可能遭安全軟體攔截，也可能是程序異常。請檢查攔截記錄與引擎日誌，確認檔案可信後重試。",
+    "old_version": "目前引擎不支援安全本機啟動，請選擇其他引擎版本或更新引擎。",
+    "protocol_error": "引擎傳回無效的連線資訊，請重新檢查或更新引擎。",
+    "process_error": "引擎程序未正常完成，請保留引擎日誌與結束代碼，檢查檔案和權限後重試。",
+    "engine_exited": "引擎程序意外結束，請查看引擎日誌並重試。"
+  },
+  "UIEngineList": {
+    "switch_engine": "切換引擎",
+    "authenticated_switch_required": "程序清單無法驗證引擎的驗證資訊，暫不支援直接切換。請在連線設定中填入位址與密碼後連線；目前引擎不會被自動關閉。"
+  },
   "StartupPage": {
     "born_for_cybersecurity": "為網路安全而生",
     "checking_environment": "正在進行環境檢查...",
@@ -200,6 +220,7 @@
     }
   },
   "LocalEngine": {
+    "migration_wait_hint": "引擎仍在準備中。跨大版本升級可能需要額外時間遷移資料庫，通常同一大版本升級只需遷移一次。請耐心等候，此階段最多等待 180 秒；如逾時，可查看日誌後重試。",
     "checking_secret_password_mode": "正在檢查引擎環境...",
     "secret_password_check_passed": "引擎環境檢查通過",
     "engine_version_low_reset": "引擎版本低，可點擊重置引擎版本更新...",

--- a/app/renderer/engine-link-startup/src/locales/zh-TW/link.json
+++ b/app/renderer/engine-link-startup/src/locales/zh-TW/link.json
@@ -74,11 +74,9 @@
     "try_start_local_process": "嘗試啟動本機進程",
     "remote_mode_no_auto_start": "遠端模式不自動啟動本機引擎",
     "start_local_engine_with_port": "開始以普通權限啟動本機引擎進程，本機埠為: {{port}}",
-    "engine_start_failed": "引擎啟動失敗:{{status}}:{{message}}",
     "engine_start_interrupted": "引擎啟動命令被中斷或意外情況：{{error}}",
     "engine_ready_to_connect": "引擎已準備好，可以進行連接",
     "engine_not_fully_started": "引擎未完全啟動，無法連接，失敗次數：{{count}}",
-    "command_timeout_retry": "命令執行逾時，請點擊重新執行",
     "engine_start_interrupted_check_log": "引擎啟動命令被中斷或意外情況，可查看日誌詳細資訊..."
   },
   "YakitLoading": {
@@ -111,7 +109,8 @@
     "exit": "退出",
     "open_engine_files": "開啟引擎檔案",
     "disconnect": "中斷連接",
-    "more_engine_versions": "更多引擎版本"
+    "more_engine_versions": "更多引擎版本",
+    "port_denied_retry": "以管理員身分重試"
   },
   "UpdateYakitHint": {
     "download_complete": "下載完畢",
@@ -201,19 +200,11 @@
     }
   },
   "LocalEngine": {
-    "checking_secret_password_mode": "開始檢查隨機密碼模式中...",
-    "secret_password_check_passed": "檢查通過，已支援隨機密碼模式",
-    "command_timeout_check_log": "命令執行逾時，可查看日誌詳細資訊...",
-    "engine_connect_timeout_check_log": "引擎連接逾時，可查看日誌詳細資訊...",
+    "checking_secret_password_mode": "正在檢查引擎環境...",
+    "secret_password_check_passed": "引擎環境檢查通過",
     "engine_version_low_reset": "引擎版本低，可點擊重置引擎版本更新...",
     "engine_version_low_download": "引擎版本低，可點擊下載引擎更新...",
-    "port_unavailable_check_log": "埠不可用，可查看日誌報錯資訊進行處理...",
-    "antivirus_blocked_check_log": "被防毒軟體攔截，可將應用加入白名單後重新啟動...",
     "engine_connect_error_reset": "連接引擎出現問題，可點擊重置引擎版本更新...",
-    "database_error_check_log": "偵測到本機資料庫出現錯誤，可點擊修復進行處理...",
-    "cannot_start_contact_staff": "無法啟動，可將日誌資訊傳送給工作人員處理...",
-    "failure_reason": "[Reason]：{{status}}：{{message}}",
-    "none": "無",
     "dev_env_direct_connect": "開發環境，直接連接引擎",
     "checking_software_update": "檢查軟體是否有更新...",
     "skip_check_hint": "跳過檢查(可在軟體更新處設定啟動)",

--- a/app/renderer/engine-link-startup/src/locales/zh-TW/link.json
+++ b/app/renderer/engine-link-startup/src/locales/zh-TW/link.json
@@ -77,7 +77,8 @@
     "engine_start_interrupted": "引擎啟動命令被中斷或意外情況：{{error}}",
     "engine_ready_to_connect": "引擎已準備好，可以進行連接",
     "engine_not_fully_started": "引擎未完全啟動，無法連接，失敗次數：{{count}}",
-    "engine_start_interrupted_check_log": "引擎啟動命令被中斷或意外情況，可查看日誌詳細資訊..."
+    "engine_start_interrupted_check_log": "引擎啟動命令被中斷或意外情況，可查看日誌詳細資訊...",
+    "startup_failed": "引擎啟動失敗，請重試或查看日誌"
   },
   "YakitLoading": {
     "agreement_check_prefix": "勾選同意",
@@ -109,8 +110,7 @@
     "exit": "退出",
     "open_engine_files": "開啟引擎檔案",
     "disconnect": "中斷連接",
-    "more_engine_versions": "更多引擎版本",
-    "port_denied_retry": "以管理員身分重試"
+    "more_engine_versions": "更多引擎版本"
   },
   "UpdateYakitHint": {
     "download_complete": "下載完畢",
@@ -224,7 +224,8 @@
     "abnormal_cannot_verify_source": "異常情況，無法偵測來源",
     "preparing_start_connect_engine": "準備開始啟動連接引擎",
     "waiting_engine_fully_started": "正在等待引擎完全啟動",
-    "database_initializing": "資料庫正在初始化中..."
+    "database_initializing": "資料庫正在初始化中...",
+    "check_failed": "引擎檢查失敗，請重試或查看日誌"
   },
   "EngineLog": {
     "welcome": "歡迎使用 {{name}}!",

--- a/app/renderer/engine-link-startup/src/locales/zh/link.json
+++ b/app/renderer/engine-link-startup/src/locales/zh/link.json
@@ -1,4 +1,24 @@
 {
+  "EngineFailure": {
+    "port_occupied": "端口被占用，请切换端口或检查占用进程。",
+    "port_denied": "系统拒绝使用该端口，请切换端口或检查系统策略。",
+    "endpoint_unreachable": "引擎监听失败，请检查端口配置后重试。",
+    "database_error": "数据库初始化失败，请先保留日志并备份数据，再尝试修复。",
+    "build_yak_error": "引擎服务构建失败，请查看日志或重新安装引擎。",
+    "engine_init_failed": "引擎初始化失败，请查看日志并重新检查引擎。",
+    "dial_error": "引擎连接失败，请检查地址和认证信息后重试。",
+    "call_error": "引擎认证失败，请重新检查连接。",
+    "timeout": "等待引擎超时，请保留日志并重试；数据迁移可能需要更长时间。",
+    "antivirus_blocked": "引擎未输出诊断信息便退出，可能被安全软件拦截，也可能是进程异常。请检查拦截记录和引擎日志，确认文件可信后重试。",
+    "old_version": "当前引擎不支持安全本地启动，请选择其他引擎版本或更新引擎。",
+    "protocol_error": "引擎返回了无效的连接信息，请重新检查或更新引擎。",
+    "process_error": "引擎进程未正常完成，请保留引擎日志与退出码，检查文件和权限后重试。",
+    "engine_exited": "引擎进程意外退出，请查看引擎日志并重试。"
+  },
+  "UIEngineList": {
+    "switch_engine": "切换引擎",
+    "authenticated_switch_required": "进程列表无法验证引擎的认证信息，暂不支持直接切换。请使用连接配置填写地址和密码后连接；当前引擎不会被自动关闭。"
+  },
   "StartupPage": {
     "born_for_cybersecurity": "为网络安全而生",
     "checking_environment": "正在进行环境检查...",
@@ -200,6 +220,7 @@
     }
   },
   "LocalEngine": {
+    "migration_wait_hint": "引擎仍在准备中。跨大版本升级可能需要额外时间迁移数据库，通常同一大版本升级只需迁移一次。请耐心等待，本阶段最多等待 180 秒；如超时，可查看日志后重试。",
     "checking_secret_password_mode": "正在检查引擎环境...",
     "secret_password_check_passed": "引擎环境检查通过",
     "engine_version_low_reset": "引擎版本低，可点击重置引擎版本更新...",

--- a/app/renderer/engine-link-startup/src/locales/zh/link.json
+++ b/app/renderer/engine-link-startup/src/locales/zh/link.json
@@ -61,6 +61,7 @@
     "remote_connection_disconnected": "远程连接已断开",
     "engine_reconnecting": "引擎连接未成功, 正在尝试重连",
     "manual_disconnect_triggered": "手动触发中断连接",
+    "stop_owned_engine_failed": "无法停止当前 Yakit 实例的引擎进程，请查看引擎日志后重试",
     "fix_database_unexpected_console": "修复数据库出现意外情况：{{error}}",
     "reclaim_database_unexpected_console": "回收出现意外情况：{{error}}",
     "no_image": "暂无图片"

--- a/app/renderer/engine-link-startup/src/locales/zh/link.json
+++ b/app/renderer/engine-link-startup/src/locales/zh/link.json
@@ -74,11 +74,9 @@
     "try_start_local_process": "尝试启动本地进程",
     "remote_mode_no_auto_start": "远程模式不自动启动本地引擎",
     "start_local_engine_with_port": "开始以普通权限启动本地引擎进程，本地端口为: {{port}}",
-    "engine_start_failed": "引擎启动失败:{{status}}:{{message}}",
     "engine_start_interrupted": "引擎启动命令被中断或意外情况：{{error}}",
     "engine_ready_to_connect": "引擎已准备好，可以进行连接",
     "engine_not_fully_started": "引擎未完全启动，无法连接，失败次数：{{count}}",
-    "command_timeout_retry": "命令执行超时，请点击重新执行",
     "engine_start_interrupted_check_log": "引擎启动命令被中断或意外情况，可查看日志详细信息..."
   },
   "YakitLoading": {
@@ -111,7 +109,8 @@
     "exit": "退出",
     "open_engine_files": "打开引擎文件",
     "disconnect": "中断连接",
-    "more_engine_versions": "更多引擎版本"
+    "more_engine_versions": "更多引擎版本",
+    "port_denied_retry": "以管理员身份重试"
   },
   "UpdateYakitHint": {
     "download_complete": "下载完毕",
@@ -201,19 +200,11 @@
     }
   },
   "LocalEngine": {
-    "checking_secret_password_mode": "开始检查随机密码模式中...",
-    "secret_password_check_passed": "检查通过，已支持随机密码模式",
-    "command_timeout_check_log": "命令执行超时，可查看日志详细信息...",
-    "engine_connect_timeout_check_log": "引擎连接超时，可查看日志详细信息...",
+    "checking_secret_password_mode": "正在检查引擎环境...",
+    "secret_password_check_passed": "引擎环境检查通过",
     "engine_version_low_reset": "引擎版本低，可点击重置引擎版本更新...",
     "engine_version_low_download": "引擎版本低，可点击下载引擎更新...",
-    "port_unavailable_check_log": "端口不可用，可查看日志报错信息进行处理...",
-    "antivirus_blocked_check_log": "被杀软拦截，可将应用加入白名单后重启...",
     "engine_connect_error_reset": "连接引擎出现问题，可点击重置引擎版本更新...",
-    "database_error_check_log": "检测到本地数据库出现错误，可点击修复进行处理...",
-    "cannot_start_contact_staff": "无法启动，可将日志信息发送给工作人员处理...",
-    "failure_reason": "[Reason]：{{status}}：{{message}}",
-    "none": "无",
     "dev_env_direct_connect": "开发环境，直接连接引擎",
     "checking_software_update": "检查软件是否有更新...",
     "skip_check_hint": "跳过检查(可在软件更新处设置启动)",

--- a/app/renderer/engine-link-startup/src/locales/zh/link.json
+++ b/app/renderer/engine-link-startup/src/locales/zh/link.json
@@ -77,7 +77,8 @@
     "engine_start_interrupted": "引擎启动命令被中断或意外情况：{{error}}",
     "engine_ready_to_connect": "引擎已准备好，可以进行连接",
     "engine_not_fully_started": "引擎未完全启动，无法连接，失败次数：{{count}}",
-    "engine_start_interrupted_check_log": "引擎启动命令被中断或意外情况，可查看日志详细信息..."
+    "engine_start_interrupted_check_log": "引擎启动命令被中断或意外情况，可查看日志详细信息...",
+    "startup_failed": "引擎启动失败，请重试或查看日志"
   },
   "YakitLoading": {
     "agreement_check_prefix": "勾选同意",
@@ -109,8 +110,7 @@
     "exit": "退出",
     "open_engine_files": "打开引擎文件",
     "disconnect": "中断连接",
-    "more_engine_versions": "更多引擎版本",
-    "port_denied_retry": "以管理员身份重试"
+    "more_engine_versions": "更多引擎版本"
   },
   "UpdateYakitHint": {
     "download_complete": "下载完毕",
@@ -224,7 +224,8 @@
     "abnormal_cannot_verify_source": "异常情况，无法检测来源",
     "preparing_start_connect_engine": "准备开始启动连接引擎",
     "waiting_engine_fully_started": "正在等待引擎完全启动",
-    "database_initializing": "数据库正在初始化中..."
+    "database_initializing": "数据库正在初始化中...",
+    "check_failed": "引擎检查失败，请重试或查看日志"
   },
   "EngineLog": {
     "welcome": "欢迎使用 {{name}}!",

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/__test__/engineFailure.test.ts
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/__test__/engineFailure.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { engineFailureMessage } from '../engineFailure'
+import zh from '../../../locales/zh/link.json'
+import en from '../../../locales/en/link.json'
+import zhTW from '../../../locales/zh-TW/link.json'
+
+describe('localized engine recovery advice', () => {
+  it.each([
+    ['en', en],
+    ['en-US', en],
+    ['zh-TW', zhTW],
+  ] as const)('uses %s recovery advice for every legacy failure without localized engine data', (language, locale) => {
+    const messages: Record<string, string> = locale.EngineFailure
+    const translate = (key: string) => messages[key.replace('EngineFailure.', '')]
+    for (const [status, expected] of Object.entries(messages)) {
+      expect(engineFailureMessage({ status, message: '旧引擎中文错误' }, language, 'fallback', translate)).toBe(
+        expected,
+      )
+    }
+  })
+
+  it('prefers localized structured engine details', () => {
+    expect(
+      engineFailureMessage({ engineEvent: { reasonI18n: { en: 'Specific engine error' } } }, 'en', 'fallback'),
+    ).toBe('Specific engine error')
+  })
+
+  it('does not leak Chinese fallback text into another locale or use an arbitrary status as a key', () => {
+    expect(
+      engineFailureMessage({ message: '中文错误', engineEvent: { reasonI18n: { zh: '中文原因' } } }, 'en', 'Retry'),
+    ).toBe('Retry')
+    expect(engineFailureMessage({ message: '中文错误' }, 'zh-TW', '請重試')).toBe('請重試')
+    expect(engineFailureMessage({ status: '__proto__', message: '中文错误' }, 'en', 'Retry', () => 'unsafe')).toBe(
+      'Retry',
+    )
+  })
+
+  it('preserves detailed Chinese diagnostics for Chinese users', () => {
+    expect(engineFailureMessage({ message: '退出码 2，请查看日志' }, 'zh', '失败')).toBe('退出码 2，请查看日志')
+  })
+
+  it('has migration and authenticated-switch guidance in all three locales', () => {
+    for (const locale of [zh, en, zhTW]) {
+      expect(locale.LocalEngine.migration_wait_hint).toContain('180')
+      expect(locale.UIEngineList.authenticated_switch_required.length).toBeGreaterThan(20)
+    }
+  })
+})

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/__test__/startupRecovery.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/__test__/startupRecovery.test.tsx
@@ -1,0 +1,410 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import enLink from '../../../locales/en/link.json'
+import zhLink from '../../../locales/zh/link.json'
+import zhTWLink from '../../../locales/zh-TW/link.json'
+
+const mocks = vi.hoisted(() => ({
+  cancelAllTasks: vi.fn(),
+  localInit: vi.fn(),
+  localLink: vi.fn(),
+  installYakEngine: vi.fn(),
+  emit: vi.fn(),
+  mainWindowHandler: undefined as undefined | ((data: { yakitStatus: string }) => void),
+}))
+
+vi.mock('@/i18n/useI18nNamespaces', () => ({
+  normalizeLang: (lang: string) => lang,
+  useI18nNamespaces: () => ({ t: (key: string) => key, i18nRefresh: 0 }),
+}))
+vi.mock('@/i18n/i18n', () => ({ default: { changeLanguage: vi.fn() } }))
+vi.mock('@/utils/logCollection', () => ({ debugToPrintLog: vi.fn() }))
+vi.mock('@/utils/notification', () => ({ yakitNotify: vi.fn() }))
+vi.mock('@/utils/kv', () => ({
+  getLocalValue: vi.fn(() => new Promise(() => {})),
+  setLocalValue: vi.fn(),
+}))
+vi.mock('@/utils/eventBus/eventBus', () => ({ default: { emit: mocks.emit } }))
+vi.mock('@/hooks/useTheme', () => ({ useTheme: () => ({ theme: 'light', setTheme: vi.fn() }) }))
+vi.mock('@/utils/envfile', () => ({
+  FetchSoftwareVersion: vi.fn(),
+  GetConnectPort: () => 9011,
+  getReleaseEditionName: () => 'Yakit',
+  isCommunityEdition: () => true,
+  isCommunityIRify: () => false,
+  isCommunityMemfit: () => false,
+  isEnpriTrace: () => false,
+  isEnpriTraceAgent: () => false,
+  isEnpriTraceIRify: () => false,
+  isIRify: () => false,
+  isMemfit: () => false,
+}))
+vi.mock('@/utils/electronBridge', () => ({
+  yakitEngine: {
+    cancelAllTasks: mocks.cancelAllTasks,
+    clearLocalYaklangVersionCache: vi.fn(),
+    fetchYaklangVersionList: vi.fn().mockResolvedValue(''),
+    installYakEngine: mocks.installYakEngine,
+    onStartYaklangEngineError: vi.fn(() => vi.fn()),
+    verifyYakEngineVersion: vi.fn().mockResolvedValue(true),
+  },
+  yakitApp: {
+    completeEngineLink: vi.fn(),
+    getYakitHomeConfig: vi.fn().mockResolvedValue({ softLange: 'zh' }),
+    onCredentialUpdate: vi.fn(() => vi.fn()),
+    onFromMainWindow: vi.fn((handler) => {
+      mocks.mainWindowHandler = handler
+      return vi.fn()
+    }),
+  },
+}))
+vi.mock('../grpc', () => ({
+  grpcFetchBuildInYakVersion: vi.fn(() => new Promise(() => {})),
+  grpcFetchLocalYakitVersion: vi.fn(() => new Promise(() => {})),
+  grpcFetchYakInstallResult: vi.fn(() => new Promise(() => {})),
+  grpcFixupDatabase: vi.fn(),
+  grpcInitCVEDatabase: vi.fn().mockResolvedValue(undefined),
+  grpcReclaimDatabaseSpace: vi.fn(),
+  grpcRelaunch: vi.fn(),
+  grpcUnpackBuildInYak: vi.fn(),
+  grpcWriteEngineKeyToYakitProjects: vi.fn(),
+}))
+vi.mock('../utils', () => ({
+  DragHeaderHeight: 0,
+  SystemInfo: {},
+  handleFetchArchitecture: vi.fn(),
+  handleFetchIsDev: vi.fn(),
+  handleFetchSystem: vi.fn((callback) => callback('Darwin')),
+  outputToWelcomeConsole: vi.fn(),
+}))
+vi.mock('../components/SoftwareBasics', () => ({
+  SoftwareBasics: ({ onConfirm }: { onConfirm: () => void }) => <button onClick={onConfirm}>confirm workspace</button>,
+}))
+vi.mock('../components/LocalEngine', async () => {
+  const React = await import('react')
+  return {
+    LocalEngine: React.forwardRef((_props, ref) => {
+      React.useImperativeHandle(ref, () => ({
+        init: mocks.localInit,
+        link: mocks.localLink,
+        checkEngine: vi.fn(),
+        checkEngineSource: vi.fn(),
+      }))
+      return null
+    }),
+  }
+})
+vi.mock('../components/YakitLoading', () => ({
+  YakitLoading: (props: any) => (
+    <div>
+      <div data-testid="status">{props.yakitStatus}</div>
+      <div data-testid="check-log">{props.checkLog.join('|')}</div>
+      <div data-testid="recovery-busy">{String(props.restartLoading)}</div>
+      <button onClick={() => props.btnClickCallback('error')}>retry error</button>
+      <button onClick={() => props.btnClickCallback('start_timeout')}>retry start timeout</button>
+      <button onClick={() => props.btnClickCallback('port_occupied', { port: 9022 })}>switch port</button>
+      <button onClick={() => props.setYaklangSpecifyVersion('v1.2.3')}>install version</button>
+      <button onClick={() => props.btnClickCallback('remote')}>switch directly to remote</button>
+      <button onClick={() => props.btnClickCallback('break', { isRemote: true })}>disconnect to remote</button>
+    </div>
+  ),
+}))
+vi.mock('../components/DownloadYaklang', () => ({ DownloadYaklang: () => null }))
+vi.mock('../components/EngineLog', () => ({ EngineLog: () => null }))
+vi.mock('../components/RemoteEngine/RemoteEngine', () => ({
+  RemoteEngine: () => <div data-testid="remote-engine">remote engine</div>,
+}))
+vi.mock('../components/YaklangEngineWatchDog', () => ({ YaklangEngineWatchDog: () => null }))
+
+import { StartupPage } from '../index'
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+function renderErrorPage() {
+  render(<StartupPage />)
+  act(() => {
+    fireEvent.click(screen.getByRole('button', { name: 'confirm workspace' }))
+    mocks.mainWindowHandler?.({ yakitStatus: 'error' })
+  })
+  expect(screen.getByTestId('status').textContent).toBe('error')
+}
+
+describe('StartupPage owned-engine recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    mocks.mainWindowHandler = undefined
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('waits for owned-engine cleanup before retrying a failed check', async () => {
+    const cleanup = deferred<{ ok: true; canceled: number; status: 'cancelled' }>()
+    mocks.cancelAllTasks.mockReturnValue(cleanup.promise)
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'retry error' }))
+
+    expect(mocks.localLink).not.toHaveBeenCalled()
+    cleanup.resolve({ ok: true, canceled: 1, status: 'cancelled' })
+    await act(async () => {
+      await cleanup.promise
+    })
+    expect(mocks.localLink).toHaveBeenCalledOnce()
+  })
+
+  it('blocks other recovery actions while owned-engine cleanup is pending', async () => {
+    mocks.cancelAllTasks.mockReturnValue(new Promise(() => {}))
+    renderErrorPage()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'retry error' }))
+      fireEvent.click(screen.getByRole('button', { name: 'switch port' }))
+      fireEvent.click(screen.getByRole('button', { name: 'install version' }))
+    })
+
+    expect(mocks.cancelAllTasks).toHaveBeenCalledOnce()
+    expect(mocks.localInit).not.toHaveBeenCalled()
+    expect(mocks.localLink).not.toHaveBeenCalled()
+    expect(mocks.installYakEngine).not.toHaveBeenCalled()
+  })
+
+  it('does not retry when owned-engine cleanup resolves with a process error', async () => {
+    mocks.cancelAllTasks.mockResolvedValue({
+      ok: false,
+      canceled: 0,
+      status: 'process_error',
+      message: 'private process detail',
+    })
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'retry error' }))
+    await act(async () => {})
+
+    expect(mocks.localLink).not.toHaveBeenCalled()
+    expect(screen.getByTestId('check-log').textContent).toContain('StartupPage.stop_owned_engine_failed')
+    expect(screen.getByTestId('check-log').textContent).not.toContain('private process detail')
+  })
+
+  it('allows a retry after an owned-engine cleanup failure settles', async () => {
+    mocks.cancelAllTasks
+      .mockResolvedValueOnce({
+        ok: false,
+        canceled: 0,
+        status: 'process_error',
+        message: 'still alive',
+      })
+      .mockResolvedValueOnce({ ok: true, canceled: 1, status: 'cancelled' })
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'retry error' }))
+    await act(async () => {})
+    fireEvent.click(screen.getByRole('button', { name: 'retry error' }))
+    await act(async () => {})
+
+    expect(mocks.cancelAllTasks).toHaveBeenCalledTimes(2)
+    expect(mocks.localLink).toHaveBeenCalledOnce()
+  })
+
+  it('does not switch ports when owned-engine cleanup rejects', async () => {
+    mocks.cancelAllTasks.mockRejectedValue(new Error('raw ipc failure'))
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'switch port' }))
+    await act(async () => {})
+
+    expect(mocks.localInit).not.toHaveBeenCalled()
+    expect(mocks.localLink).not.toHaveBeenCalled()
+    expect(screen.getByTestId('check-log').textContent).toContain('StartupPage.stop_owned_engine_failed')
+    expect(screen.getByTestId('check-log').textContent).not.toContain('raw ipc failure')
+  })
+
+  it('checks the selected port after owned-engine cleanup succeeds', async () => {
+    mocks.cancelAllTasks.mockResolvedValue({ ok: true, canceled: 1, status: 'cancelled' })
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'switch port' }))
+    await act(async () => {})
+
+    expect(mocks.localInit).toHaveBeenCalledExactlyOnceWith(9022)
+  })
+
+  it('does not install a selected version when owned-engine cleanup fails', async () => {
+    mocks.cancelAllTasks.mockResolvedValue({
+      ok: false,
+      canceled: 0,
+      status: 'process_error',
+      message: 'still alive',
+    })
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'install version' }))
+    await act(async () => {})
+
+    expect(mocks.installYakEngine).not.toHaveBeenCalled()
+  })
+
+  it('keeps the local recovery view when disconnect cleanup fails', async () => {
+    mocks.cancelAllTasks.mockResolvedValue({
+      ok: false,
+      canceled: 0,
+      status: 'process_error',
+      message: 'still alive',
+    })
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'disconnect to remote' }))
+    await act(async () => {})
+
+    expect(screen.queryByTestId('remote-engine')).toBeNull()
+    expect(screen.getByTestId('status').textContent).toBe('check_error')
+    expect(screen.getByTestId('check-log').textContent).toContain('StartupPage.stop_owned_engine_failed')
+    expect(mocks.emit).not.toHaveBeenCalled()
+  })
+
+  it('keeps the local recovery view when disconnect cleanup rejects', async () => {
+    mocks.cancelAllTasks.mockRejectedValue(new Error('raw ipc failure'))
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'disconnect to remote' }))
+    await act(async () => {})
+
+    expect(screen.queryByTestId('remote-engine')).toBeNull()
+    expect(screen.getByTestId('status').textContent).toBe('check_error')
+    expect(screen.getByTestId('check-log').textContent).toContain('StartupPage.stop_owned_engine_failed')
+    expect(mocks.emit).not.toHaveBeenCalled()
+  })
+
+  it('waits for cleanup before retrying a failed startup', async () => {
+    const cleanup = deferred<{ ok: true; canceled: number; status: 'cancelled' }>()
+    mocks.cancelAllTasks.mockReturnValue(cleanup.promise)
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'retry start timeout' }))
+
+    expect(mocks.cancelAllTasks).toHaveBeenCalledOnce()
+    cleanup.resolve({ ok: true, canceled: 1, status: 'cancelled' })
+    await act(async () => {
+      await cleanup.promise
+      vi.advanceTimersByTime(100)
+    })
+    expect(mocks.emit).toHaveBeenCalledExactlyOnceWith('startAndCreateEngineProcess')
+  })
+
+  it('does not retry a failed startup when cleanup fails', async () => {
+    mocks.cancelAllTasks.mockResolvedValue({
+      ok: false,
+      canceled: 0,
+      status: 'process_error',
+      message: 'still alive',
+    })
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'retry start timeout' }))
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+
+    expect(mocks.cancelAllTasks).toHaveBeenCalledOnce()
+    expect(mocks.emit).not.toHaveBeenCalled()
+    expect(screen.getByTestId('status').textContent).toBe('check_error')
+  })
+
+  it('allows selecting the same version after cleanup failure', async () => {
+    mocks.cancelAllTasks
+      .mockResolvedValueOnce({
+        ok: false,
+        canceled: 0,
+        status: 'process_error',
+        message: 'still alive',
+      })
+      .mockResolvedValueOnce({ ok: true, canceled: 1, status: 'cancelled' })
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'install version' }))
+    await act(async () => {})
+    fireEvent.click(screen.getByRole('button', { name: 'install version' }))
+    await act(async () => {})
+
+    expect(mocks.cancelAllTasks).toHaveBeenCalledTimes(2)
+  })
+
+  it('switches to remote mode after disconnect cleanup succeeds', async () => {
+    mocks.cancelAllTasks.mockResolvedValue({ ok: true, canceled: 1, status: 'cancelled' })
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'disconnect to remote' }))
+    await act(async () => {})
+
+    expect(screen.getByTestId('remote-engine').textContent).toBe('remote engine')
+  })
+
+  it('waits for owned-engine cleanup before switching directly to remote mode', async () => {
+    const cleanup = deferred<{ ok: true; canceled: number; status: 'cancelled' }>()
+    mocks.cancelAllTasks.mockReturnValue(cleanup.promise)
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'switch directly to remote' }))
+    expect(screen.queryByTestId('remote-engine')).toBeNull()
+    expect(screen.getByTestId('recovery-busy').textContent).toBe('true')
+
+    cleanup.resolve({ ok: true, canceled: 1, status: 'cancelled' })
+    await act(async () => {
+      await cleanup.promise
+    })
+
+    expect(screen.getByTestId('remote-engine').textContent).toBe('remote engine')
+  })
+
+  it('keeps the local recovery view when direct remote cleanup reports a process error', async () => {
+    mocks.cancelAllTasks.mockResolvedValue({
+      ok: false,
+      canceled: 0,
+      status: 'process_error',
+      message: 'private process detail',
+    })
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'switch directly to remote' }))
+    await act(async () => {})
+
+    expect(screen.queryByTestId('remote-engine')).toBeNull()
+    expect(screen.getByTestId('check-log').textContent).toContain('StartupPage.stop_owned_engine_failed')
+    expect(screen.getByTestId('check-log').textContent).not.toContain('private process detail')
+  })
+
+  it('keeps the local recovery view when direct remote cleanup rejects', async () => {
+    mocks.cancelAllTasks.mockRejectedValue(new Error('raw ipc failure'))
+    renderErrorPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'switch directly to remote' }))
+    await act(async () => {})
+
+    expect(screen.queryByTestId('remote-engine')).toBeNull()
+    expect(screen.getByTestId('check-log').textContent).toContain('StartupPage.stop_owned_engine_failed')
+    expect(screen.getByTestId('check-log').textContent).not.toContain('raw ipc failure')
+  })
+
+  it.each([
+    ['en', enLink.StartupPage.stop_owned_engine_failed],
+    ['zh', zhLink.StartupPage.stop_owned_engine_failed],
+    ['zh-TW', zhTWLink.StartupPage.stop_owned_engine_failed],
+  ])('provides a localized owned-engine cleanup failure message for %s', (_language, message) => {
+    expect(message.trim()).not.toBe('')
+    expect(message).not.toContain('raw ipc failure')
+  })
+})

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/__test__/startupRecovery.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/__test__/startupRecovery.test.tsx
@@ -102,6 +102,7 @@ vi.mock('../components/YakitLoading', () => ({
       <div data-testid="recovery-busy">{String(props.restartLoading)}</div>
       <button onClick={() => props.btnClickCallback('error')}>retry error</button>
       <button onClick={() => props.btnClickCallback('start_timeout')}>retry start timeout</button>
+      <button onClick={() => props.btnClickCallback('endpoint_unreachable')}>retry bind failure</button>
       <button onClick={() => props.btnClickCallback('port_occupied', { port: 9022 })}>switch port</button>
       <button onClick={() => props.setYaklangSpecifyVersion('v1.2.3')}>install version</button>
       <button onClick={() => props.btnClickCallback('remote')}>switch directly to remote</button>
@@ -286,6 +287,22 @@ describe('StartupPage owned-engine recovery', () => {
     expect(screen.queryByTestId('remote-engine')).toBeNull()
     expect(screen.getByTestId('status').textContent).toBe('check_error')
     expect(screen.getByTestId('check-log').textContent).toContain('StartupPage.stop_owned_engine_failed')
+    expect(mocks.emit).not.toHaveBeenCalled()
+  })
+
+  it('rechecks the engine after cleaning up a failed bind instead of starting with old credentials', async () => {
+    const cleanup = deferred<{ ok: true; canceled: number; status: 'cancelled' }>()
+    mocks.cancelAllTasks.mockReturnValue(cleanup.promise)
+    renderErrorPage()
+    fireEvent.click(screen.getByRole('button', { name: 'retry bind failure' }))
+    expect(mocks.localLink).not.toHaveBeenCalled()
+    expect(mocks.emit).not.toHaveBeenCalled()
+    cleanup.resolve({ ok: true, canceled: 1, status: 'cancelled' })
+    await act(async () => {
+      await cleanup.promise
+    })
+    expect(mocks.localInit).toHaveBeenCalledOnce()
+    expect(mocks.localLink).not.toHaveBeenCalled()
     expect(mocks.emit).not.toHaveBeenCalled()
   })
 

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/LocalEngineType.d.ts
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/LocalEngineType.d.ts
@@ -80,6 +80,7 @@ export interface EngineEvent {
 export interface ExecResult {
   ok: boolean
   status: string
+  stage?: 'check' | 'start' | 'connect'
   message: string
   engineEvent?: EngineEvent | null
 }

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/LocalEngineType.d.ts
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/LocalEngineType.d.ts
@@ -36,6 +36,10 @@ export interface AllowSecretLocalJson {
   address: string
   secret: string
   version: string
+  phase?: string
+  elapsedMs?: number
+  phaseI18n?: { zh: string; en: string } | null
+  reasonI18n?: { zh: string; en: string } | null
 }
 
 export interface LocalLinkParams {
@@ -57,14 +61,32 @@ interface FixupDatabaseJson {
   path: string[]
   info: string
 }
+export interface EngineEvent {
+  type: 'ready' | 'failed' | 'log_ok'
+  schemaVersion?: number
+  address?: string
+  transport?: string
+  instanceId?: string
+  engineVersion?: string
+  phase?: string
+  reason?: string
+  reasonCode?: string
+  elapsedMs?: number
+  version?: string
+  phaseI18n?: { zh: string; en: string } | null
+  reasonI18n?: { zh: string; en: string } | null
+}
+
 export interface ExecResult {
   ok: boolean
   status: string
   message: string
+  engineEvent?: EngineEvent | null
 }
 
 export interface AllowSecretLocalExecResult extends ExecResult {
   json: null | AllowSecretLocalJson
+  engineEvent?: EngineEvent | null
 }
 
 export interface FixupDatabaseExecResult extends ExecResult {

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/__test__/index.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/__test__/index.test.tsx
@@ -180,7 +180,7 @@ describe('LocalEngine Component', () => {
       await initEngine()
 
       await waitFor(() => {
-        expect(props.setYakitStatus).toHaveBeenCalledWith('check_timeout')
+        expect(props.setYakitStatus).toHaveBeenCalledWith('timeout')
       })
     })
 
@@ -206,7 +206,7 @@ describe('LocalEngine Component', () => {
       await initEngine()
 
       await waitFor(() => {
-        expect(props.setYakitStatus).toHaveBeenCalledWith('port_occupied_prev')
+        expect(props.setYakitStatus).toHaveBeenCalledWith('port_occupied')
       })
     })
 
@@ -232,7 +232,7 @@ describe('LocalEngine Component', () => {
       await initEngine()
 
       await waitFor(() => {
-        expect(props.setYakitStatus).toHaveBeenCalledWith('skipAgreement_Install')
+        expect(props.setYakitStatus).toHaveBeenCalledWith('build_yak_error')
       })
     })
 
@@ -259,7 +259,7 @@ describe('LocalEngine Component', () => {
       await initEngine()
 
       await waitFor(() => {
-        expect(props.setYakitStatus).toHaveBeenCalledWith('allow-secret-error')
+        expect(props.setYakitStatus).toHaveBeenCalledWith('unknown')
       })
     })
 

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/__test__/index.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/__test__/index.test.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { LocalEngine } from '../index'
 import type { LocalEngineProps, LocalEngineLinkFuncProps } from '../LocalEngineType'
 import {
@@ -259,7 +259,7 @@ describe('LocalEngine Component', () => {
       await initEngine()
 
       await waitFor(() => {
-        expect(props.setYakitStatus).toHaveBeenCalledWith('unknown')
+        expect(props.setYakitStatus).toHaveBeenCalledWith('check_error')
       })
     })
 
@@ -269,6 +269,79 @@ describe('LocalEngine Component', () => {
       await initEngine()
 
       expect(grpcCheckAllowSecretLocal).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('安全重试与过期响应', () => {
+    afterEach(() => vi.useRealTimers())
+
+    it('IPC 异常应显示可重新检查的错误', async () => {
+      vi.mocked(grpcCheckAllowSecretLocal).mockRejectedValueOnce(new Error('IPC closed'))
+      renderComponent()
+      await act(async () => ref.current!.init(9011))
+      expect(props.setYakitStatus).toHaveBeenCalledWith('check_error')
+      expect(props.setRestartLoading).toHaveBeenCalledWith(false)
+    })
+
+    it('取消检查不应显示失败或继续启动', async () => {
+      vi.mocked(grpcCheckAllowSecretLocal).mockResolvedValueOnce({ ok: false, status: 'cancelled' } as any)
+      renderComponent()
+      await act(async () => ref.current!.init(9011))
+      expect(props.setYakitStatus).not.toHaveBeenCalled()
+      expect(props.onLinkEngine).not.toHaveBeenCalled()
+    })
+
+    it('旧检查晚返回不能覆盖新端口的凭据', async () => {
+      vi.useFakeTimers()
+      systemInfoDevSpy.mockReturnValue(true)
+      let finishOld!: (value: any) => void
+      vi.mocked(grpcCheckAllowSecretLocal).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishOld = resolve
+          }),
+      )
+      vi.mocked(grpcCheckAllowSecretLocal).mockResolvedValueOnce({
+        ok: true,
+        status: 'success',
+        json: { port: 9012, secret: 'new' },
+      } as any)
+      renderComponent()
+      await act(async () => ref.current!.init(9011))
+      await act(async () => ref.current!.init(9012))
+      await act(async () => finishOld({ ok: true, status: 'success', json: { port: 9011, secret: 'old' } }))
+      await act(async () => vi.advanceTimersByTimeAsync(1500))
+      expect(props.onLinkEngine).toHaveBeenCalledExactlyOnceWith({ port: 9012, secret: 'new' })
+    })
+
+    it.each(['unmount', 'break'])('%s 后延迟启动不得执行', async (operation) => {
+      vi.useFakeTimers()
+      systemInfoDevSpy.mockReturnValue(true)
+      const view = renderComponent()
+      await act(async () => ref.current!.init(9011))
+      if (operation === 'unmount') view.unmount()
+      else view.rerender(<LocalEngine ref={ref} {...props} yakitStatus="break" />)
+      await act(async () => vi.advanceTimersByTimeAsync(2000))
+      expect(props.onLinkEngine).not.toHaveBeenCalled()
+    })
+
+    it('重试失败后旧版本检查不能重新启动', async () => {
+      vi.useFakeTimers()
+      let finishVersion!: (value: string) => void
+      vi.mocked(grpcFetchLatestYakitVersion).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishVersion = resolve
+          }),
+      )
+      renderComponent()
+      await act(async () => ref.current!.init(9011))
+      vi.mocked(grpcCheckAllowSecretLocal).mockResolvedValueOnce({ ok: false, status: 'unknownReason' } as any)
+      await act(async () => ref.current!.init(9012))
+      await act(async () => finishVersion('1.4.7-0429'))
+      await act(async () => vi.advanceTimersByTimeAsync(5000))
+      expect(props.setYakitStatus).toHaveBeenLastCalledWith('check_error')
+      expect(props.onLinkEngine).not.toHaveBeenCalled()
     })
   })
 

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/__test__/index.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/__test__/index.test.tsx
@@ -180,7 +180,7 @@ describe('LocalEngine Component', () => {
       await initEngine()
 
       await waitFor(() => {
-        expect(props.setYakitStatus).toHaveBeenCalledWith('timeout')
+        expect(props.setYakitStatus).toHaveBeenCalledWith('check_timeout')
       })
     })
 
@@ -206,7 +206,7 @@ describe('LocalEngine Component', () => {
       await initEngine()
 
       await waitFor(() => {
-        expect(props.setYakitStatus).toHaveBeenCalledWith('port_occupied')
+        expect(props.setYakitStatus).toHaveBeenCalledWith('port_occupied_prev')
       })
     })
 

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/__test__/index.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/__test__/index.test.tsx
@@ -140,6 +140,25 @@ describe('LocalEngine Component', () => {
 
   const renderComponent = () => render(<LocalEngine ref={ref} {...props} />)
 
+  it('keeps the migration hint alongside later progress and ignores notifications after cancellation', () => {
+    let logs: string[] = ['checking']
+    props.setLog = vi.fn((value) => {
+      logs = typeof value === 'function' ? value(logs) : value
+    })
+    const view = renderComponent()
+    const notify = vi.mocked(yakitEngine.onStartUpEngineMessage).mock.calls[0][0]
+    act(() => {
+      notify('LocalEngine.migration_wait_hint')
+      notify('LocalEngine.database_initializing')
+      notify('LocalEngine.database_initializing')
+    })
+    expect(logs).toEqual(['checking', 'LocalEngine.migration_wait_hint', 'LocalEngine.database_initializing'])
+    view.rerender(<LocalEngine ref={ref} {...props} yakitStatus="break" />)
+    vi.mocked(props.setLog).mockClear()
+    act(() => notify('LocalEngine.migration_wait_hint'))
+    expect(props.setLog).not.toHaveBeenCalled()
+  })
+
   // 辅助函数：等待 ref 可用并调用 init
   const initEngine = async (port = 9011) => {
     await waitFor(() => expect(ref.current).toBeDefined())

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/index.tsx
@@ -76,53 +76,20 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
           return
         }
         allowSecretLocalJson.current = null
-        switch (res.status) {
-          case 'timeout':
-            setLog((arr) => arr.concat([t('LocalEngine.command_timeout_check_log')]))
-            setYakitStatus('check_timeout')
-            break
-          case 'call_error':
-            setLog((arr) => arr.concat([t('LocalEngine.engine_connect_timeout_check_log')]))
-            setYakitStatus('check_timeout')
-            break
-          case 'old_version':
-            setLog((arr) =>
-              arr.concat([
-                buildInEngineVersion
-                  ? t('LocalEngine.engine_version_low_reset')
-                  : t('LocalEngine.engine_version_low_download'),
-              ]),
-            )
-            setYakitStatus('old_version')
-            break
-          case 'port_occupied':
-            setLog((arr) => arr.concat([t('LocalEngine.port_unavailable_check_log')]))
-            setYakitStatus('port_occupied_prev')
-            break
-          case 'antivirus_blocked':
-            setLog((arr) => arr.concat([t('LocalEngine.antivirus_blocked_check_log')]))
-            setYakitStatus('antivirus_blocked')
-            break
-          case 'build_yak_error':
-          case 'dial_error':
-            setLog((arr) => arr.concat([t('LocalEngine.engine_connect_error_reset')]))
-            setYakitStatus('skipAgreement_Install')
-            break
-          case 'database_error':
-            setLog((arr) => arr.concat([t('LocalEngine.database_error_check_log')]))
-            setYakitStatus('database_error')
-            break
-          default:
-            setLog((arr) =>
-              arr.concat([
-                t('LocalEngine.cannot_start_contact_staff'),
-                t('LocalEngine.failure_reason', {
-                  status: res.status,
-                  message: res.message || t('LocalEngine.none'),
-                }),
-              ]),
-            )
-            setYakitStatus('allow-secret-error')
+        // 主进程已组装好用户可读的 message，前端只管显示 + 切换 UI 状态
+        setLog((arr) => arr.concat([res.message || '引擎环境检查失败，请查看日志详细信息']))
+        // 旧版本场景保留特殊处理
+        if (res.status === 'old_version') {
+          setLog((arr) =>
+            arr.concat([
+              buildInEngineVersion
+                ? t('LocalEngine.engine_version_low_reset')
+                : t('LocalEngine.engine_version_low_download'),
+            ]),
+          )
+          setYakitStatus('old_version')
+        } else {
+          setYakitStatus(res.status)
         }
       } catch (error) {
         // 旧调用直接跳过

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/index.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, memo, useEffect, useImperativeHandle, useRef } from 'react'
 import type { AllowSecretLocalJson, LocalEngineProps } from './LocalEngineType'
+import type { YakitStatusType } from '../../types'
 import { useMemoizedFn } from 'ahooks'
 import { debugToPrintLog } from '@/utils/logCollection'
 import {
@@ -89,7 +90,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
           )
           setYakitStatus('old_version')
         } else {
-          setYakitStatus(res.status)
+          setYakitStatus(res.status as YakitStatusType)
         }
       } catch (error) {
         // 旧调用直接跳过

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/index.tsx
@@ -99,7 +99,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
         }
         allowSecretLocalJson.current = null
         // 主进程已组装好用户可读的 message，前端只管显示 + 切换 UI 状态
-        setLog((arr) => arr.concat([engineFailureMessage(res, i18n.language, t('LocalEngine.check_failed'))]))
+        setLog((arr) => arr.concat([engineFailureMessage(res, i18n.language, t('LocalEngine.check_failed'), t)]))
         // 旧版本场景保留特殊处理
         if (res.status === 'old_version') {
           setLog((arr) =>
@@ -380,7 +380,9 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
     // 主进程推送 i18n key（如 LocalEngine.xxx），渲染端翻译后输出日志
     useEffect(() => {
       const offStartUpMessage = yakitEngine.onStartUpEngineMessage((key: string) => {
-        setLog([t(key)])
+        if (yakitStatusRef.current === 'break') return
+        // Keep the migration hint visible when later progress messages arrive.
+        setLog((lines) => [...lines.filter((line) => line !== t(key)), t(key)])
       })
       return () => {
         offStartUpMessage()

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/index.tsx
@@ -90,7 +90,15 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
           )
           setYakitStatus('old_version')
         } else {
-          setYakitStatus(res.status as YakitStatusType)
+          // check 阶段：主进程返回的 status 需要映射到前端 UI 分支
+          // port_occupied -> port_occupied_prev（杀旧进程 / 换端口二选一）
+          // timeout       -> check_timeout（重试按钮）
+          // 其余 status 直接透传
+          const checkStatusMap: Record<string, YakitStatusType> = {
+            port_occupied: 'port_occupied_prev',
+            timeout: 'check_timeout',
+          }
+          setYakitStatus(checkStatusMap[res.status as string] || (res.status as YakitStatusType))
         }
       } catch (error) {
         // 旧调用直接跳过

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/LocalEngine/index.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, memo, useEffect, useImperativeHandle, useRef } from 'react'
 import type { AllowSecretLocalJson, LocalEngineProps } from './LocalEngineType'
-import type { YakitStatusType } from '../../types'
+import { engineFailureMessage, engineFailureStatus } from '../../engineFailure'
 import { useMemoizedFn } from 'ahooks'
 import { debugToPrintLog } from '@/utils/logCollection'
 import {
@@ -37,7 +37,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
       yakitUpdate,
       setYakitUpdate,
     } = props
-    const { t } = useI18nNamespaces(['link'])
+    const { t, i18n } = useI18nNamespaces(['link'])
     // check Json
     const allowSecretLocalJson = useRef<AllowSecretLocalJson>(null)
     // 本地 yakit 版本
@@ -55,8 +55,26 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
     }, [yakitStatus])
 
     const latestCheckCallIdRef = useRef(0)
+    const isCurrentCheck = (id: number) => id === latestCheckCallIdRef.current && yakitStatusRef.current !== 'break'
+    const startTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+    useEffect(
+      () => () => {
+        latestCheckCallIdRef.current++
+        clearTimeout(startTimer.current)
+      },
+      [],
+    )
+    useEffect(() => {
+      if (yakitStatus === 'break') {
+        latestCheckCallIdRef.current++
+        clearTimeout(startTimer.current)
+        allowSecretLocalJson.current = null
+      }
+    }, [yakitStatus])
     const handleAllowSecretLocal = useMemoizedFn(async (port: number, checkVersion: boolean) => {
       const callId = ++latestCheckCallIdRef.current
+      clearTimeout(startTimer.current)
+      allowSecretLocalJson.current = null
       // 中断连接 后续不执行
       if (yakitStatusRef.current === 'break') {
         debugToPrintLog(`------ 开始 check 被阻止 ------`)
@@ -68,6 +86,9 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
       setLog([t('LocalEngine.checking_secret_password_mode')])
       try {
         const res = await grpcCheckAllowSecretLocal({ port, softwareVersion: FetchSoftwareVersion() })
+        if (!isCurrentCheck(callId)) return
+        const failureStatus = engineFailureStatus(res.status, 'check')
+        if (!res.ok && failureStatus === null) return
         setRestartLoading(false)
         if (res.ok && res.status === 'success') {
           setLog((arr) => arr.concat([t('LocalEngine.secret_password_check_passed')]))
@@ -78,7 +99,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
         }
         allowSecretLocalJson.current = null
         // 主进程已组装好用户可读的 message，前端只管显示 + 切换 UI 状态
-        setLog((arr) => arr.concat([res.message || '引擎环境检查失败，请查看日志详细信息']))
+        setLog((arr) => arr.concat([engineFailureMessage(res, i18n.language, t('LocalEngine.check_failed'))]))
         // 旧版本场景保留特殊处理
         if (res.status === 'old_version') {
           setLog((arr) =>
@@ -90,19 +111,14 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
           )
           setYakitStatus('old_version')
         } else {
-          // check 阶段：主进程返回的 status 需要映射到前端 UI 分支
-          // port_occupied -> port_occupied_prev（杀旧进程 / 换端口二选一）
-          // timeout       -> check_timeout（重试按钮）
-          // 其余 status 直接透传
-          const checkStatusMap: Record<string, YakitStatusType> = {
-            port_occupied: 'port_occupied_prev',
-            timeout: 'check_timeout',
-          }
-          setYakitStatus(checkStatusMap[res.status as string] || (res.status as YakitStatusType))
+          setYakitStatus(failureStatus || 'check_error')
         }
       } catch (error) {
         // 旧调用直接跳过
-        if (callId !== latestCheckCallIdRef.current) return
+        if (!isCurrentCheck(callId)) return
+        setRestartLoading(false)
+        setLog([t('LocalEngine.check_failed')])
+        setYakitStatus('check_error')
       }
     })
 
@@ -143,6 +159,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
      * - 未开启 yakit 更新检查，不进行 yakit 更新检查，直接检查引擎和内置的版本
      */
     const handleCheckYakitLatestVersion = useMemoizedFn(() => {
+      const checkId = latestCheckCallIdRef.current
       // 中断连接 后续不执行
       if (yakitStatusRef.current === 'break') {
         debugToPrintLog(`------ 开始检查yakit是否有版本更新 被阻止 ------`)
@@ -153,6 +170,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
       let showUpdateYakit = false
       getLocalValue(LocalGVS.NoAutobootLatestVersionCheck)
         .then(async (val: boolean) => {
+          if (!isCurrentCheck(checkId)) return
           if (!val) {
             debugToPrintLog(`------ 开始检查软件版本更新逻辑 ------`)
             try {
@@ -163,6 +181,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
                 grpcFetchLocalYakitVersion(true),
                 Promise.race([grpcFetchLatestYakitVersion({ timeout: 3000 }, true), promise]),
               ])
+              if (!isCurrentCheck(checkId)) return
               if (res1.status === 'fulfilled') {
                 currentYakit.current = res1.value || ''
                 debugToPrintLog(`------ 当前软件版本: ${currentYakit.current} ------`)
@@ -183,13 +202,14 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
         })
         .catch(() => {})
         .finally(() => {
+          if (!isCurrentCheck(checkId)) return
           if (showUpdateYakit) {
             setLog([t('LocalEngine.new_version_detected', { name: getReleaseEditionName() })])
             setYakitStatus('update_yakit')
           } else {
             setLog((old) => old.concat([t('LocalEngine.software_no_update')]))
             setTimeout(() => {
-              handleCheckEngineVersion()
+              if (isCurrentCheck(checkId)) handleCheckEngineVersion()
             }, 500)
           }
         })
@@ -203,6 +223,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
      */
 
     const handleCheckEngineVersion = useMemoizedFn(async () => {
+      const checkId = latestCheckCallIdRef.current
       // 中断连接 后续不执行
       if (yakitStatusRef.current === 'break') {
         debugToPrintLog(`------ 开始检查引擎本地版本和内置版本 被阻止 ------`)
@@ -212,6 +233,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
 
       try {
         const res = await getLocalValue(LocalGVS.NoYakVersionCheck)
+        if (!isCurrentCheck(checkId) || !allowSecretLocalJson.current) return
         if (res) {
           setLog([t('LocalEngine.fetching_engine_version')])
         } else {
@@ -222,6 +244,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
         const localVersionPromise = localVersion ? Promise.resolve(localVersion) : grpcFetchLocalYakVersion(true)
         const buildInVersionPromise = grpcFetchBuildInYakVersion(true)
         const [res1, res2] = await Promise.allSettled([localVersionPromise, buildInVersionPromise])
+        if (!isCurrentCheck(checkId)) return
         if (!res && res2.status === 'fulfilled') {
           const buildIn = res2.value || ''
           buildInYak.current = buildIn.startsWith('v') ? buildIn.substring(1) : buildIn
@@ -261,6 +284,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
           startYakEngine()
         }
       } catch (error) {
+        if (!isCurrentCheck(checkId)) return
         setLog((old) => old.concat([t('LocalEngine.error_with_reason', { reason: error })]))
         setYakitStatus('check_yak_version_error')
       }
@@ -271,6 +295,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
      * - 通过相同版本的线上hash和本地hash对比，判断是否一样
      */
     const handleCheckEngineSource = useMemoizedFn(async (version?: string) => {
+      const checkId = latestCheckCallIdRef.current
       // 中断连接 后续不执行
       if (yakitStatusRef.current === 'break') {
         debugToPrintLog(`------ 开始校验引擎是否来源正确 被阻止 ------`)
@@ -295,6 +320,7 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
           grpcFetchLocalYakVersionHash(true),
         ])
 
+        if (!isCurrentCheck(checkId)) return
         if (!res1 || !Array.isArray(res2) || res2.length === 0) {
           setLog((old) => old.concat([t('LocalEngine.unknown_error_cannot_verify_source')]))
         } else {
@@ -306,9 +332,10 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
           }
         }
       } catch (error) {
+        if (!isCurrentCheck(checkId)) return
         setLog((old) => old.concat([t('LocalEngine.abnormal_cannot_verify_source')]))
       } finally {
-        startYakEngine()
+        if (isCurrentCheck(checkId)) startYakEngine()
       }
     })
 
@@ -323,10 +350,14 @@ export const LocalEngine: React.FC<LocalEngineProps> = memo(
       if (allowSecretLocalJson.current) {
         debugToPrintLog(`------ 准备开始启动连接引擎逻辑 ------`)
         setLog([t('LocalEngine.preparing_start_connect_engine')])
-        setTimeout(() => {
+        const checked = allowSecretLocalJson.current
+        const checkId = latestCheckCallIdRef.current
+        clearTimeout(startTimer.current)
+        startTimer.current = setTimeout(() => {
+          if (checkId !== latestCheckCallIdRef.current || yakitStatusRef.current === 'break') return
           onLinkEngine({
-            port: allowSecretLocalJson.current.port,
-            secret: allowSecretLocalJson.current.secret,
+            port: checked.port,
+            secret: checked.secret,
           })
           // 启动本地连接后，重置所有检查状态，并后续不会在进行检查
           handleResetAllStatus()

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/UIEngineList/__test__/index.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/UIEngineList/__test__/index.test.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react'
+import type * as Ahooks from 'ahooks'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UIEngineList } from '../index'
+import { yakitEngine } from '@/utils/electronBridge'
+import { showYakitModal } from '@/components/yakitUI/YakitModal/YakitModalConfirm'
+
+vi.mock('@/i18n/useI18nNamespaces', () => ({ useI18nNamespaces: () => ({ t: (key: string) => key }) }))
+vi.mock('ahooks', async (importOriginal) => ({
+  ...(await importOriginal<typeof Ahooks>()),
+  useInViewport: () => [true],
+}))
+vi.mock('@/utils/electronBridge', () => ({
+  yakitEngine: {
+    listYakGrpc: vi.fn(),
+    fetchYaklangEngineAddr: vi.fn(),
+    connectYaklangEngine: vi.fn(),
+    killYakGrpc: vi.fn(),
+  },
+  yakitApp: {},
+}))
+vi.mock('@/components/yakitUI/YakitPopover/YakitPopover', () => ({
+  YakitPopover: ({ content }: { content: ReactNode }) => <div>{content}</div>,
+}))
+vi.mock('@/components/yakitUI/YakitModal/YakitModalConfirm', () => ({ showYakitModal: vi.fn() }))
+
+describe('authenticated engine process management', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(yakitEngine.listYakGrpc).mockResolvedValue([
+      {
+        pid: 4242,
+        ppid: 42,
+        port: 19011,
+        cmd: 'yak grpc --local-password private-password',
+        origin: { password: 'private-password' },
+      },
+    ])
+    vi.mocked(yakitEngine.fetchYaklangEngineAddr).mockResolvedValue({ addr: '127.0.0.1:9011' })
+  })
+
+  it('disables credentialless switching and never connects or kills the current engine', async () => {
+    const onChange = vi.fn()
+    render(<UIEngineList engineMode="local" engineLink typeCallback={onChange} />)
+    const button = await screen.findByRole('button', { name: 'UIEngineList.switch_engine' })
+    expect((button as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.click(button)
+    expect(yakitEngine.connectYaklangEngine).not.toHaveBeenCalled()
+    expect(yakitEngine.killYakGrpc).not.toHaveBeenCalled()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('shows diagnostic PID and port but never displays command-line passwords', async () => {
+    render(<UIEngineList engineMode="local" engineLink typeCallback={vi.fn()} />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Details' }))
+    const content = vi.mocked(showYakitModal).mock.calls[0][0].content
+    render(<div>{content}</div>)
+    expect(screen.getByText(/"pid":4242/).textContent).toContain('"port":19011')
+    expect(screen.queryByText(/private-password/)).toBeNull()
+  })
+})

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/UIEngineList/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/UIEngineList/index.tsx
@@ -1,10 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import type {
-  TypeCallbackExtra,
-  YakitStatusType,
-  YaklangEngineMode,
-  YaklangEngineWatchDogCredential,
-} from '../../types'
+import type { TypeCallbackExtra, YakitStatusType, YaklangEngineMode } from '../../types'
 import { useInViewport, useMemoizedFn } from 'ahooks'
 import { YakitPopover } from '@/components/yakitUI/YakitPopover/YakitPopover'
 import classNames from 'classnames'
@@ -14,19 +9,19 @@ import { getReleaseEditionName } from '@/utils/envfile'
 import { yakitNotify } from '@/utils/notification'
 import { YakitPopconfirm } from '@/components/yakitUI/YakitPopconfirm/YakitPopconfirm'
 import { LoadingOutlined } from '@ant-design/icons'
+import { Tooltip } from 'antd'
 import { CheckedSvgIcon } from '@yakit-libs/yakit-ui-icons/oldicon/CheckedSvgIcon'
 import { GooglePhotosLogoSvgIcon } from '@yakit-libs/yakit-ui-icons/oldicon/GooglePhotosLogoSvgIcon'
 import { YakitTag } from '@/components/yakitUI/YakitTag/YakitTag'
 import { grpcRelaunch, grpcUnpackBuildInYak, grpcWriteEngineKeyToYakitProjects } from '../../grpc'
 import { yakitEngine } from '@/utils/electronBridge'
+import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import styles from './UIEngineList.module.scss'
 
 interface yakProcess {
   port: number
   pid: number
   ppid?: number
-  cmd: string
-  origin: any
 }
 
 interface UIEngineListProp {
@@ -38,6 +33,7 @@ interface UIEngineListProp {
 /** @name 已启动引擎列表 */
 export const UIEngineList: React.FC<UIEngineListProp> = React.memo((props) => {
   const { engineMode, typeCallback, engineLink } = props
+  const { t } = useI18nNamespaces(['link'])
 
   const [show, setShow] = useState<boolean>(false)
 
@@ -60,8 +56,7 @@ export const UIEngineList: React.FC<UIEngineListProp> = React.memo((props) => {
             return {
               port: element.port,
               pid: element.pid,
-              cmd: element.cmd,
-              origin: element.origin,
+              ppid: element.ppid,
             }
           }),
         )
@@ -178,52 +173,16 @@ export const UIEngineList: React.FC<UIEngineListProp> = React.memo((props) => {
                         Details
                       </YakitButton>
 
-                      <YakitPopconfirm
-                        title={<>确定是否切换连接的引擎</>}
-                        onConfirm={async () => {
-                          if (!isLocal) {
-                            yakitNotify('info', '远程模式，不支持切换引擎')
-                            return
-                          }
-                          const oldPort = port
-                          const switchEngine: YaklangEngineWatchDogCredential = {
-                            Port: i.port,
-                            Host: '127.0.0.1',
-                          }
-                          yakitEngine
-                            .connectYaklangEngine(switchEngine)
-                            .then(() => {
-                              setTimeout(() => {
-                                yakitNotify('success', `切换核心引擎成功！`)
-                              }, 500)
-                            })
-                            .catch((e) => {
-                              yakitNotify('error', '切换引擎失败，请尝试切换其他端口重连')
-                              process.forEach((item) => {
-                                if (item.port == oldPort) {
-                                  yakitEngine
-                                    .killYakGrpc(item.pid)
-                                    .then((val) => {
-                                      if (!val) {
-                                        yakitNotify('success', '引擎进程关闭中...')
-                                        typeCallback('break')
-                                      }
-                                    })
-                                    .catch((e: any) => {})
-                                    .finally(fetchPSList)
-                                }
-                              })
-                            })
-                        }}
-                      >
-                        <YakitButton
-                          type="outline1"
-                          colors="success"
-                          disabled={+i.port === 0 || (isLocal && +i.port === port)}
-                        >
-                          切换引擎
-                        </YakitButton>
-                      </YakitPopconfirm>
+                      {/* A process listing does not provide trusted credentials. Never
+                          probe anonymously, extract passwords from argv, or kill the
+                          current engine as a side effect of a failed switch. */}
+                      <Tooltip title={t('UIEngineList.authenticated_switch_required')}>
+                        <span>
+                          <YakitButton type="outline1" colors="success" disabled>
+                            {t('UIEngineList.switch_engine')}
+                          </YakitButton>
+                        </span>
+                      </Tooltip>
                       <YakitPopconfirm
                         title={
                           <>

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/__test__/startupRecovery.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/__test__/startupRecovery.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { YakitLoading, type YakitLoadingProp } from '../index'
+import { engineFailureStatus } from '../../../engineFailure'
+
+vi.mock('@/i18n/useI18nNamespaces', () => ({
+  useI18nNamespaces: () => ({ t: (key: string) => key, i18n: { language: 'zh' }, i18nRefresh: 0 }),
+}))
+vi.mock('@/utils/kv', () => ({ getLocalValue: async () => true, setLocalValue: vi.fn() }))
+vi.mock('@/utils/electronBridge', () => ({ yakitApp: {}, yakitEngine: {} }))
+vi.mock('../../AgreementContentModal', () => ({ AgreementContentModal: () => null }))
+vi.mock('../../MoreYaklangVersion', () => ({ MoreYaklangVersion: () => null }))
+
+function show(status: YakitLoadingProp['yakitStatus']) {
+  const callback = vi.fn()
+  render(
+    <YakitLoading
+      yakitLoadingTip=""
+      disableYakitLoading={false}
+      isTop={0}
+      setIsTop={vi.fn()}
+      system="Windows_NT"
+      buildInEngineVersion=""
+      yakitStatus={status}
+      engineMode="local"
+      checkLog={['failed']}
+      restartLoading={false}
+      dbPath={[]}
+      port={9011}
+      moreYaklangVersionList={[]}
+      setYaklangSpecifyVersion={vi.fn()}
+      btnClickCallback={callback}
+    />,
+  )
+  return callback
+}
+
+describe('startup recovery buttons', () => {
+  beforeEach(() => {
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  })
+  afterEach(() => vi.unstubAllGlobals())
+  it.each(['unknown', 'unknownReason', 'process_error', 'exception', 'protocol_error', 'call_error'])(
+    'check %s retries the complete check before credentials exist',
+    (failure) => {
+      const status = engineFailureStatus(failure, 'check')!
+      const callback = show(status)
+      fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.retry' }))
+      expect(callback).toHaveBeenCalledExactlyOnceWith('check_timeout')
+    },
+  )
+
+  it('a start timeout can retry with the existing credentials', () => {
+    const callback = show('start_timeout')
+    fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.retry' }))
+    expect(callback).toHaveBeenCalledExactlyOnceWith('start_timeout')
+  })
+
+  it('an occupied port never offers to kill an unrelated engine implicitly', () => {
+    const callback = show('port_occupied_prev')
+    fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.reconnect' }))
+    expect(callback).toHaveBeenLastCalledWith('check_timeout')
+    fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.switch_port' }))
+    expect(callback).toHaveBeenLastCalledWith('port_occupied_prev')
+  })
+
+  it('Windows denied ports allow a regular retry or a different port', () => {
+    const callback = show('port_denied')
+    fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.retry' }))
+    expect(callback).toHaveBeenLastCalledWith('port_denied')
+    fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.switch_port' }))
+    expect(callback).toHaveBeenLastCalledWith('port_occupied_prev')
+  })
+})

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/__test__/startupRecovery.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/__test__/startupRecovery.test.tsx
@@ -65,6 +65,12 @@ describe('startup recovery buttons', () => {
     },
   )
 
+  it('a start bind failure retains the full check recovery action', () => {
+    const { callback } = show(engineFailureStatus('endpoint_unreachable', 'start')!)
+    fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.retry' }))
+    expect(callback).toHaveBeenCalledExactlyOnceWith('endpoint_unreachable')
+  })
+
   it('a start timeout can retry with the existing credentials', () => {
     const { callback } = show('start_timeout')
     fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.retry' }))

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/__test__/startupRecovery.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/__test__/startupRecovery.test.tsx
@@ -6,13 +6,18 @@ import { engineFailureStatus } from '../../../engineFailure'
 vi.mock('@/i18n/useI18nNamespaces', () => ({
   useI18nNamespaces: () => ({ t: (key: string) => key, i18n: { language: 'zh' }, i18nRefresh: 0 }),
 }))
-vi.mock('@/utils/kv', () => ({ getLocalValue: async () => true, setLocalValue: vi.fn() }))
+vi.mock('@/utils/kv', () => ({ getLocalValue: vi.fn(() => new Promise(() => {})), setLocalValue: vi.fn() }))
 vi.mock('@/utils/electronBridge', () => ({ yakitApp: {}, yakitEngine: {} }))
 vi.mock('../../AgreementContentModal', () => ({ AgreementContentModal: () => null }))
-vi.mock('../../MoreYaklangVersion', () => ({ MoreYaklangVersion: () => null }))
+vi.mock('../../MoreYaklangVersion', () => ({
+  MoreYaklangVersion: ({ onClosePop }: { onClosePop: (visible: boolean, version: string) => void }) => (
+    <button onClick={() => onClosePop(false, 'v1.2.3')}>choose v1.2.3</button>
+  ),
+}))
 
-function show(status: YakitLoadingProp['yakitStatus']) {
+function show(status: YakitLoadingProp['yakitStatus'], overrides: Partial<YakitLoadingProp> = {}) {
   const callback = vi.fn()
+  const setYaklangSpecifyVersion = vi.fn()
   render(
     <YakitLoading
       yakitLoadingTip=""
@@ -28,11 +33,12 @@ function show(status: YakitLoadingProp['yakitStatus']) {
       dbPath={[]}
       port={9011}
       moreYaklangVersionList={[]}
-      setYaklangSpecifyVersion={vi.fn()}
+      setYaklangSpecifyVersion={setYaklangSpecifyVersion}
       btnClickCallback={callback}
+      {...overrides}
     />,
   )
-  return callback
+  return { callback, setYaklangSpecifyVersion }
 }
 
 describe('startup recovery buttons', () => {
@@ -53,20 +59,20 @@ describe('startup recovery buttons', () => {
     'check %s retries the complete check before credentials exist',
     (failure) => {
       const status = engineFailureStatus(failure, 'check')!
-      const callback = show(status)
+      const { callback } = show(status)
       fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.retry' }))
       expect(callback).toHaveBeenCalledExactlyOnceWith('check_timeout')
     },
   )
 
   it('a start timeout can retry with the existing credentials', () => {
-    const callback = show('start_timeout')
+    const { callback } = show('start_timeout')
     fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.retry' }))
     expect(callback).toHaveBeenCalledExactlyOnceWith('start_timeout')
   })
 
   it('an occupied port never offers to kill an unrelated engine implicitly', () => {
-    const callback = show('port_occupied_prev')
+    const { callback } = show('port_occupied_prev')
     fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.reconnect' }))
     expect(callback).toHaveBeenLastCalledWith('check_timeout')
     fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.switch_port' }))
@@ -74,10 +80,27 @@ describe('startup recovery buttons', () => {
   })
 
   it('Windows denied ports allow a regular retry or a different port', () => {
-    const callback = show('port_denied')
+    const { callback } = show('port_denied')
     fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.retry' }))
     expect(callback).toHaveBeenLastCalledWith('port_denied')
     fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.switch_port' }))
     expect(callback).toHaveBeenLastCalledWith('port_occupied_prev')
+  })
+
+  it('shows cleanup failure details instead of the disconnected message', () => {
+    show('check_error')
+    expect(screen.getByText('failed')).toBeTruthy()
+  })
+
+  it('does not open or select more engine versions while recovery is busy', () => {
+    const { setYaklangSpecifyVersion } = show('check_error', {
+      restartLoading: true,
+      moreYaklangVersionList: ['v1.2.3'],
+    })
+
+    fireEvent.click(screen.getByTestId('engine-more-versions'))
+
+    expect(screen.queryByRole('button', { name: 'choose v1.2.3' })).toBeNull()
+    expect(setYaklangSpecifyVersion).not.toHaveBeenCalled()
   })
 })

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/index.tsx
@@ -855,7 +855,7 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
                   {unLinkStatus && (
                     <div className={styles['more-version-btn']}>
                       <YakitPopover
-                        open={moreVersionPopShow}
+                        open={!restartLoading && moreVersionPopShow}
                         classNames={{ root: styles['more-versions-popover'] }}
                         placement="topLeft"
                         trigger="click"
@@ -863,16 +863,23 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
                           <MoreYaklangVersion
                             moreYaklangVersionList={moreYaklangVersionList}
                             onClosePop={(visible, version) => {
+                              if (restartLoading) return
                               setMoreVersionPopShow(visible)
                               setYaklangSpecifyVersion(version)
                             }}
                           />
                         }
                         onOpenChange={(visible) => {
+                          if (restartLoading) return
                           setMoreVersionPopShow(visible)
                         }}
                       >
-                        <span className={classNames(styles['primary-btn'])}>
+                        <span
+                          data-testid="engine-more-versions"
+                          className={classNames(styles['primary-btn'], {
+                            [styles['primary-btn-disable']]: restartLoading,
+                          })}
+                        >
                           {t('YakitLoading.more_engine_versions')}
                         </span>
                       </YakitPopover>

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/index.tsx
@@ -298,7 +298,7 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
       )
     }
 
-    if (yakitStatus === 'allow-secret-error') {
+    if (yakitStatus === 'allow-secret-error' || yakitStatus === 'build_yak_error' || yakitStatus === 'dial_error') {
       return (
         <>
           <YakitButton
@@ -321,6 +321,41 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
             size="large"
             loading={restartLoading}
             onClick={() => btnClickCallback('start_timeout')}
+          >
+            {t('YakitLoading.retry')}
+          </YakitButton>
+        </>
+      )
+    }
+
+    if (yakitStatus === 'port_denied') {
+      return (
+        <>
+          <YakitButton
+            className={styles['btn-style']}
+            size="large"
+            loading={restartLoading}
+            onClick={() => btnClickCallback('port_denied')}
+          >
+            {t('YakitLoading.port_denied_retry')}
+          </YakitButton>
+        </>
+      )
+    }
+
+    if (
+      yakitStatus === 'endpoint_unreachable' ||
+      yakitStatus === 'engine_exited' ||
+      yakitStatus === 'engine_init_failed' ||
+      yakitStatus === 'engine_failed'
+    ) {
+      return (
+        <>
+          <YakitButton
+            className={styles['btn-style']}
+            size="large"
+            loading={restartLoading}
+            onClick={() => btnClickCallback(yakitStatus)}
           >
             {t('YakitLoading.retry')}
           </YakitButton>
@@ -575,6 +610,22 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
       )
     }
 
+    // 兜底: 未知状态显示重试按钮，不让用户卡住
+    if (yakitStatus) {
+      return (
+        <>
+          <YakitButton
+            className={styles['btn-style']}
+            size="large"
+            loading={restartLoading}
+            onClick={() => btnClickCallback('start_timeout')}
+          >
+            {t('YakitLoading.retry')}
+          </YakitButton>
+        </>
+      )
+    }
+
     return null
   }, [yakitStatus, restartLoading, engineMode, checkStatus, buildInEngineVersion, dbPathKey, countdown, i18nRefresh])
 
@@ -597,6 +648,20 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
       'allow-secret-error',
       'check_yak_version_error',
       'start_timeout',
+      'port_denied',
+      'endpoint_unreachable',
+      'engine_exited',
+      'engine_init_failed',
+      'engine_failed',
+      'timeout',
+      'process_error',
+      'exit',
+      'build_yak_error',
+      'dial_error',
+      'call_error',
+      'unknownReason',
+      'unknown',
+      'exception',
       'error',
       'break',
     ]

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/index.tsx
@@ -214,7 +214,18 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
       )
     }
 
-    if (yakitStatus === 'check_timeout') {
+    if (
+      [
+        'check_timeout',
+        'check_error',
+        'unknown',
+        'unknownReason',
+        'process_error',
+        'exception',
+        'call_error',
+        'antivirus_blocked',
+      ].includes(yakitStatus)
+    ) {
       return (
         <>
           <YakitButton
@@ -262,7 +273,7 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
             className={styles['btn-style']}
             size="large"
             loading={restartLoading}
-            onClick={() => btnClickCallback('port_occupied_prev', { killCurProcess: true })}
+            onClick={() => btnClickCallback('check_timeout')}
           >
             {t('YakitLoading.reconnect')}
           </YakitButton>
@@ -337,7 +348,16 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
             loading={restartLoading}
             onClick={() => btnClickCallback('port_denied')}
           >
-            {t('YakitLoading.port_denied_retry')}
+            {t('YakitLoading.retry')}
+          </YakitButton>
+          <YakitButton
+            className={styles['btn-style']}
+            size="large"
+            type="secondary2"
+            loading={restartLoading}
+            onClick={() => btnClickCallback('port_occupied_prev')}
+          >
+            {t('YakitLoading.switch_port')}
           </YakitButton>
         </>
       )
@@ -610,15 +630,15 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
       )
     }
 
-    // 兜底: 未知状态显示重试按钮，不让用户卡住
-    if (yakitStatus) {
+    // Active startup states must not offer a second concurrent start.
+    if (yakitStatus && !['ready', 'init', 'link', 'reclaimDatabaseSpace_start'].includes(yakitStatus)) {
       return (
         <>
           <YakitButton
             className={styles['btn-style']}
             size="large"
             loading={restartLoading}
-            onClick={() => btnClickCallback('start_timeout')}
+            onClick={() => btnClickCallback('check_timeout')}
           >
             {t('YakitLoading.retry')}
           </YakitButton>
@@ -635,6 +655,7 @@ export const YakitLoading: React.FC<YakitLoadingProp> = (props) => {
     }
     const statusArr: YakitStatusType[] = [
       'check_timeout',
+      'check_error',
       'old_version',
       'skipAgreement_InstallNetWork',
       'skipAgreement_Install',

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/__test__/index.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/__test__/index.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { YaklangEngineWatchDog } from '../index'
 import type { YaklangEngineWatchDogProps } from '../index'
 import emiter from '@/utils/eventBus/eventBus'
@@ -185,7 +185,7 @@ describe('YaklangEngineWatchDog 组件测试', () => {
     })
   })
 
-  describe('自动启动本地引擎（autoStartProgress 触发的 useDebounceEffect）', () => {
+  describe('自动启动本地引擎', () => {
     it('启动成功时，应调用 onKeepaliveShouldChange(true)', async () => {
       render(<YaklangEngineWatchDog {...props} />)
       triggerEngineTest()
@@ -204,6 +204,73 @@ describe('YaklangEngineWatchDog 组件测试', () => {
       triggerEngineTest()
 
       expect(props.onKeepaliveShouldChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('并发与取消', () => {
+    it('连续点击启动只发出一次连接和启动请求', async () => {
+      let finish!: () => void
+      vi.mocked(yakitEngine.connectYaklangEngine).mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            finish = () => reject(new Error('offline'))
+          }),
+      )
+      render(<YaklangEngineWatchDog {...props} />)
+      triggerEngineTest()
+      triggerEngineTest()
+      await act(async () => finish())
+      expect(yakitEngine.connectYaklangEngine).toHaveBeenCalledOnce()
+      expect(grpcStartLocalEngine).toHaveBeenCalledOnce()
+    })
+
+    it.each(['unmount', 'break', 'credential'])('%s 后旧连接失败不能启动子进程', async (operation) => {
+      let finish!: () => void
+      vi.mocked(yakitEngine.connectYaklangEngine).mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            finish = () => reject(new Error('late'))
+          }),
+      )
+      const view = render(<YaklangEngineWatchDog {...props} />)
+      triggerEngineTest()
+      if (operation === 'unmount') view.unmount()
+      else
+        view.rerender(
+          <YaklangEngineWatchDog
+            {...props}
+            {...(operation === 'break'
+              ? { yakitStatus: 'break' }
+              : { credential: { ...props.credential, Port: 9012 } })}
+          />,
+        )
+      await act(async () => finish())
+      expect(grpcStartLocalEngine).not.toHaveBeenCalled()
+      expect(props.onKeepaliveShouldChange).not.toHaveBeenCalled()
+    })
+
+    it('cancelled 不显示失败；Windows 端口拒绝保留换端口操作', async () => {
+      vi.mocked(grpcStartLocalEngine).mockResolvedValueOnce({ ok: false, status: 'cancelled', message: '' })
+      render(<YaklangEngineWatchDog {...props} />)
+      await act(async () => triggerEngineTest())
+      expect(props.setYakitStatus).not.toHaveBeenCalled()
+      vi.mocked(grpcStartLocalEngine).mockResolvedValueOnce({ ok: false, status: 'port_denied', message: 'denied' })
+      await act(async () => triggerEngineTest())
+      expect(props.setYakitStatus).toHaveBeenCalledWith('port_denied')
+    })
+
+    it('保活取消后到达的成功响应不应进入主界面', async () => {
+      let finish!: () => void
+      vi.mocked(isEngineConnectionAlive).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finish = () => resolve(true)
+          }),
+      )
+      const view = render(<YaklangEngineWatchDog {...props} keepalive />)
+      view.rerender(<YaklangEngineWatchDog {...props} keepalive={false} />)
+      await act(async () => finish())
+      expect(props.onReady).not.toHaveBeenCalled()
     })
   })
 

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/__test__/index.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/__test__/index.test.tsx
@@ -7,13 +7,22 @@ import { yakitEngine } from '@/utils/electronBridge'
 import { grpcStartLocalEngine, isEngineConnectionAlive } from '../../../grpc'
 import { toEngineHandshakeName } from '@/utils/envfile'
 import type { YaklangEngineMode } from '@/pages/StartupPage/types'
+import { yakitNotify } from '@/utils/notification'
+import enLink from '../../../../../locales/en/link.json'
+import zhLink from '../../../../../locales/zh/link.json'
+import zhTWLink from '../../../../../locales/zh-TW/link.json'
+
+const locale = vi.hoisted(() => ({ language: 'zh' as 'en' | 'zh' | 'zh-TW' }))
 
 // Mock 外部依赖
 vi.mock('@/i18n/useI18nNamespaces', () => ({
   useI18nNamespaces: () => ({
-    t: (key: string) => key,
+    t: (key: string) =>
+      key === 'EngineFailure.dial_error'
+        ? { en: enLink, zh: zhLink, 'zh-TW': zhTWLink }[locale.language].EngineFailure.dial_error
+        : key,
     i18n: {
-      language: 'zh',
+      language: locale.language,
       hasResourceBundle: () => true,
       loadNamespaces: vi.fn(async () => undefined),
       on: vi.fn(),
@@ -97,6 +106,7 @@ describe('YaklangEngineWatchDog 组件测试', () => {
     }
 
     vi.clearAllMocks()
+    locale.language = 'zh'
     vi.mocked(yakitEngine.connectYaklangEngine).mockRejectedValue(new Error('fail'))
     vi.mocked(grpcStartLocalEngine).mockResolvedValue({ ok: true, status: 'success', message: '' })
     vi.mocked(emiter.on).mockImplementation((event: any, callback) => {
@@ -174,6 +184,23 @@ describe('YaklangEngineWatchDog 组件测试', () => {
         },
         { timeout: 2000 },
       )
+    })
+
+    it.each([
+      ['en', enLink.EngineFailure.dial_error],
+      ['zh', zhLink.EngineFailure.dial_error],
+      ['zh-TW', zhTWLink.EngineFailure.dial_error],
+    ] as const)('remote failures use %s recovery text without raw IPC details', async (language, expected) => {
+      locale.language = language
+      props.credential.Mode = 'remote'
+      render(<YaklangEngineWatchDog {...props} />)
+      for (const detail of ['引擎连接超时', '引擎认证失败 private-ipc-detail']) {
+        vi.mocked(yakitEngine.connectYaklangEngine).mockRejectedValueOnce(new Error(detail))
+        await act(async () => triggerEngineTest())
+        expect(yakitNotify).toHaveBeenLastCalledWith('error', expected)
+      }
+      expect(grpcStartLocalEngine).not.toHaveBeenCalled()
+      expect(props.onKeepaliveShouldChange).not.toHaveBeenCalled()
     })
 
     it('连接失败且 mode = "remote" 时，不自动启动本地引擎', async () => {

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/__test__/index.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/__test__/index.test.tsx
@@ -234,6 +234,18 @@ describe('YaklangEngineWatchDog 组件测试', () => {
     })
   })
 
+  it('preserves a structured start bind failure for full check recovery', async () => {
+    vi.mocked(grpcStartLocalEngine).mockResolvedValueOnce({
+      ok: false,
+      status: 'endpoint_unreachable',
+      message: 'bind failed',
+    })
+    render(<YaklangEngineWatchDog {...props} />)
+    await act(async () => triggerEngineTest())
+    expect(props.setYakitStatus).toHaveBeenCalledExactlyOnceWith('endpoint_unreachable')
+    expect(props.onKeepaliveShouldChange).not.toHaveBeenCalled()
+  })
+
   describe('并发与取消', () => {
     it('连续点击启动只发出一次连接和启动请求', async () => {
       let finish!: () => void

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/index.tsx
@@ -139,19 +139,13 @@ export const YaklangEngineWatchDog: React.FC<YaklangEngineWatchDogProps> = React
                   props.onKeepaliveShouldChange(true)
                 }
               } else {
-                if (res.status === 'timeout') {
-                  props.setCheckLog([t('YaklangEngineWatchDog.command_timeout_retry')])
-                  props.setYakitStatus('start_timeout')
-                } else {
-                  outputToWelcomeConsole(
-                    t('YaklangEngineWatchDog.engine_start_failed', {
-                      status: res.status,
-                      message: res.message,
-                    }),
-                  )
-                }
-                debugToPrintLog(`[ERROR] 本地新引擎进程启动失败: ${res.status + ':' + res.message}`)
+                // 主进程已组装好用户可读的 message，前端只管显示
+                const failMsg = res.message || '引擎启动失败，请查看日志详细信息'
+                outputToWelcomeConsole(failMsg)
+                props.setCheckLog([failMsg])
+                props.setYakitStatus(res.status)
               }
+              debugToPrintLog(`[ERROR] 本地新引擎进程启动失败: ${res.status + ':' + res.message}`)
               startingUp.current = false
             })
             .catch((error) => {

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/index.tsx
@@ -143,7 +143,7 @@ export const YaklangEngineWatchDog: React.FC<YaklangEngineWatchDogProps> = React
                 const failMsg = res.message || '引擎启动失败，请查看日志详细信息'
                 outputToWelcomeConsole(failMsg)
                 props.setCheckLog([failMsg])
-                props.setYakitStatus(res.status)
+                props.setYakitStatus(res.status as YakitStatusType)
               }
               debugToPrintLog(`[ERROR] 本地新引擎进程启动失败: ${res.status + ':' + res.message}`)
               startingUp.current = false

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/index.tsx
@@ -91,7 +91,7 @@ export const YaklangEngineWatchDog: React.FC<YaklangEngineWatchDogProps> = React
       } else {
         const status = engineFailureStatus(result.status, 'start')
         if (!status) return
-        const message = engineFailureMessage(result, i18n.language, t('YaklangEngineWatchDog.startup_failed'))
+        const message = engineFailureMessage(result, i18n.language, t('YaklangEngineWatchDog.startup_failed'), t)
         outputToWelcomeConsole(message)
         props.setCheckLog([message])
         props.setYakitStatus(status)

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/index.tsx
@@ -69,10 +69,10 @@ export const YaklangEngineWatchDog: React.FC<YaklangEngineWatchDogProps> = React
         await yakitEngine.connectYaklangEngine(credential)
         if (isCurrent()) props.onKeepaliveShouldChange?.(true)
         return
-      } catch (error) {
+      } catch {
         if (!isCurrent()) return
         if (credential.Mode === 'remote') {
-          yakitNotify('error', String(error))
+          yakitNotify('error', t('EngineFailure.dial_error'))
           return
         }
       }

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YaklangEngineWatchDog/index.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef } from 'react'
 import type { YakitStatusType, YaklangEngineWatchDogCredential } from '../../types'
-import { useDebounceEffect, useMemoizedFn } from 'ahooks'
+import { useMemoizedFn } from 'ahooks'
 import { debugToPrintLog } from '@/utils/logCollection'
 import { yakitNotify } from '@/utils/notification'
 import { __PLATFORM__, FetchSoftwareVersion, isEnpriTraceAgent, toEngineHandshakeName } from '@/utils/envfile'
@@ -9,6 +9,7 @@ import { grpcStartLocalEngine, isEngineConnectionAlive } from '../../grpc'
 import { outputToWelcomeConsole } from '../../utils'
 import { yakitEngine } from '@/utils/electronBridge'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import { engineFailureMessage, engineFailureStatus } from '../../engineFailure'
 
 export interface YaklangEngineWatchDogProps {
   credential: YaklangEngineWatchDogCredential
@@ -26,144 +27,91 @@ export interface YaklangEngineWatchDogProps {
 }
 
 export const YaklangEngineWatchDog: React.FC<YaklangEngineWatchDogProps> = React.memo((props) => {
-  const { t } = useI18nNamespaces(['link'])
-  const yakitStatusRef = useRef<YakitStatusType>(props.yakitStatus)
-  // 是否自动重启引擎进程
-  const [autoStartProgress, setAutoStartProgress] = useState(false)
-  // 是否正在重启引擎进程
-  const startingUp = useRef<boolean>(false)
+  const { t, i18n } = useI18nNamespaces(['link'])
+  const yakitStatusRef = useRef(props.yakitStatus)
+  const credentialRef = useRef(props.credential)
+  const mounted = useRef(true)
+  const startingUp = useRef(false)
+  const pendingCredential = useRef(props.credential)
   const latestStartCallIdRef = useRef(0)
+  yakitStatusRef.current = props.yakitStatus
+  credentialRef.current = props.credential
 
   useEffect(() => {
-    yakitStatusRef.current = props.yakitStatus
-  }, [props.yakitStatus])
-
-  useEffect(() => {
-    if (!props.engineLink) setAutoStartProgress(false)
-  }, [props.engineLink])
-
-  /** 接受连接引擎的指令 */
-  useEffect(() => {
-    emiter.on('startAndCreateEngineProcess', () => {
-      engineTest()
-    })
+    mounted.current = true
     return () => {
-      emiter.off('startAndCreateEngineProcess')
+      mounted.current = false
+      latestStartCallIdRef.current++
     }
   }, [])
-
-  /** 引擎信息认证 */
-  const engineTest = useMemoizedFn(() => {
-    debugToPrintLog(`[IFNO] engine-test mode:${props.credential.Mode} port:${props.credential.Port}`)
-    // 重置状态
-    setAutoStartProgress(false)
-
-    const mode = props.credential.Mode
-    if (!mode) {
-      return
+  useEffect(() => {
+    if (props.yakitStatus === 'break') {
+      latestStartCallIdRef.current++
+      startingUp.current = false
     }
+  }, [props.yakitStatus])
 
-    if (props.credential.Port <= 0) {
-      outputToWelcomeConsole(t('YaklangEngineWatchDog.port_empty_cannot_connect'))
-      return
-    }
-
-    /**
-     * 认证要小心做，拿到准确的信息之后，尝试连接一次，确定连接成功之后才可以开始后续步骤
-     * 当然引擎没有启动的时候无法连接成功，要准备根据引擎状态选择合适的方式启动引擎
-     */
+  const engineTest = useMemoizedFn(async () => {
+    const credential = props.credential
+    if (!credential.Mode || credential.Port <= 0 || yakitStatusRef.current === 'break') return
+    if (startingUp.current && pendingCredential.current === credential) return
+    const callId = ++latestStartCallIdRef.current
+    pendingCredential.current = credential
+    startingUp.current = true
+    const isCurrent = () =>
+      mounted.current &&
+      callId === latestStartCallIdRef.current &&
+      credentialRef.current === credential &&
+      yakitStatusRef.current !== 'break'
     outputToWelcomeConsole(t('YaklangEngineWatchDog.start_connecting_core_engine'))
-    debugToPrintLog(`------ 测试目标引擎是否存在进程存活情况------`)
-    yakitEngine
-      .connectYaklangEngine(props.credential)
-      .then(() => {
-        debugToPrintLog(`------ 目标引擎进程存活 ------`)
-        outputToWelcomeConsole(t('YaklangEngineWatchDog.connect_core_engine_success'))
-        if (props.onKeepaliveShouldChange) {
-          props.onKeepaliveShouldChange(true)
+    try {
+      try {
+        await yakitEngine.connectYaklangEngine(credential)
+        if (isCurrent()) props.onKeepaliveShouldChange?.(true)
+        return
+      } catch (error) {
+        if (!isCurrent()) return
+        if (credential.Mode === 'remote') {
+          yakitNotify('error', String(error))
+          return
         }
+      }
+      outputToWelcomeConsole(t('YaklangEngineWatchDog.start_local_engine_with_port', { port: credential.Port }))
+      const result = await grpcStartLocalEngine({
+        port: credential.Port,
+        password: credential.Password,
+        version: toEngineHandshakeName(__PLATFORM__),
+        isEnpriTraceAgent: isEnpriTraceAgent(),
+        softwareVersion: FetchSoftwareVersion(),
       })
-      .catch((e) => {
-        debugToPrintLog(`------ 目标引擎进程不存在 ------`)
-        outputToWelcomeConsole(t('YaklangEngineWatchDog.engine_not_connected_try_start'))
-        switch (mode) {
-          case 'local':
-            outputToWelcomeConsole(t('YaklangEngineWatchDog.try_start_local_process'))
-            setAutoStartProgress(true)
-            return
-          case 'remote':
-            outputToWelcomeConsole(t('YaklangEngineWatchDog.remote_mode_no_auto_start'))
-            yakitNotify('error', e + '')
-            return
-        }
-      })
+      if (!isCurrent()) return
+      if (result.ok && result.status === 'success') {
+        debugToPrintLog('[INFO] 本地引擎认证连接成功')
+        props.onKeepaliveShouldChange?.(true)
+      } else {
+        const status = engineFailureStatus(result.status, 'start')
+        if (!status) return
+        const message = engineFailureMessage(result, i18n.language, t('YaklangEngineWatchDog.startup_failed'))
+        outputToWelcomeConsole(message)
+        props.setCheckLog([message])
+        props.setYakitStatus(status)
+      }
+    } catch (error) {
+      if (!isCurrent()) return
+      props.setCheckLog([t('YaklangEngineWatchDog.startup_failed')])
+      props.setYakitStatus('start_timeout')
+    } finally {
+      if (callId === latestStartCallIdRef.current) startingUp.current = false
+    }
   })
 
-  useDebounceEffect(
-    () => {
-      const mode = props.credential.Mode
-
-      if (!mode) {
-        return
-      }
-      if (mode === 'remote') {
-        return
-      }
-      if (props.credential.Port <= 0) {
-        return
-      }
-      if (!autoStartProgress) {
-        // 不启动进程的话，就直接退出
-        return
-      }
-      debugToPrintLog(`[INFO] 尝试启动新的引擎进程 port:${props.credential.Port}`)
-      // 只有普通模式才涉及到引擎启动的流程
-      outputToWelcomeConsole(t('YaklangEngineWatchDog.start_local_engine_with_port', { port: props.credential.Port }))
-
-      if (mode === 'local') {
-        if (!startingUp.current) {
-          const callId = ++latestStartCallIdRef.current
-          grpcStartLocalEngine({
-            port: props.credential.Port,
-            password: props.credential.Password,
-            version: toEngineHandshakeName(__PLATFORM__),
-            isEnpriTraceAgent: isEnpriTraceAgent(),
-            softwareVersion: FetchSoftwareVersion(),
-          })
-            .then((res) => {
-              if (yakitStatusRef.current === 'break') return
-
-              if (res.ok && res.status === 'success') {
-                debugToPrintLog(`[INFO] 本地新引擎进程启动成功`)
-                if (props.onKeepaliveShouldChange) {
-                  props.onKeepaliveShouldChange(true)
-                }
-              } else {
-                // 主进程已组装好用户可读的 message，前端只管显示
-                const failMsg = res.message || '引擎启动失败，请查看日志详细信息'
-                outputToWelcomeConsole(failMsg)
-                props.setCheckLog([failMsg])
-                props.setYakitStatus(res.status as YakitStatusType)
-              }
-              debugToPrintLog(`[ERROR] 本地新引擎进程启动失败: ${res.status + ':' + res.message}`)
-              startingUp.current = false
-            })
-            .catch((error) => {
-              // 旧调用直接跳过
-              if (callId !== latestStartCallIdRef.current) return
-              // 如果手动中断 显示中断界面 意外情况暂时不做处理
-              outputToWelcomeConsole(t('YaklangEngineWatchDog.engine_start_interrupted', { error }))
-              props.setCheckLog([t('YaklangEngineWatchDog.engine_start_interrupted_check_log')])
-            })
-        }
-      }
-    },
-    [autoStartProgress, props.onKeepaliveShouldChange, props.credential],
-    {
-      leading: false,
-      wait: 1000,
-    },
-  )
+  useEffect(() => {
+    const start = () => {
+      void engineTest()
+    }
+    emiter.on('startAndCreateEngineProcess', start)
+    return () => emiter.off('startAndCreateEngineProcess', start)
+  }, [engineTest])
 
   /**
    * 引擎连接尝试逻辑
@@ -179,15 +127,17 @@ export const YaklangEngineWatchDog: React.FC<YaklangEngineWatchDogProps> = React
     }
     debugToPrintLog(`------ 开始启动引擎进程探活逻辑------`)
 
-    let count = 0
+    let disposed = false
+    let pending = false
     let failedCount = 0
     let notified = false
 
     const connect = () => {
-      count++
+      if (pending || disposed) return
+      pending = true
       isEngineConnectionAlive()
         .then(() => {
-          if (!keepalive) {
+          if (disposed) {
             return
           }
           if (!notified) {
@@ -199,7 +149,8 @@ export const YaklangEngineWatchDog: React.FC<YaklangEngineWatchDogProps> = React
             props.onReady()
           }
         })
-        .catch((e) => {
+        .catch(() => {
+          if (disposed) return
           failedCount++
           if (failedCount > 0 && failedCount <= 10) {
             outputToWelcomeConsole(t('YaklangEngineWatchDog.engine_not_fully_started', { count: failedCount }))
@@ -208,10 +159,14 @@ export const YaklangEngineWatchDog: React.FC<YaklangEngineWatchDogProps> = React
             props.onFailed(failedCount)
           }
         })
+        .finally(() => {
+          pending = false
+        })
     }
     connect()
     const id = setInterval(connect, 3000)
     return () => {
+      disposed = true
       clearInterval(id)
     }
   }, [props.keepalive, props.onReady, props.onFailed])

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/engineFailure.ts
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/engineFailure.ts
@@ -1,0 +1,33 @@
+import type { YakitStatusType } from './types'
+
+// Recovery is chosen at the IPC boundary, while the failing stage is still known.
+// Unknown check errors must never be retried with credentials that do not exist yet.
+export function engineFailureStatus(status: string, stage: 'check' | 'start'): YakitStatusType | null {
+  if (status === 'cancelled') return null
+  if (status === 'port_occupied') return 'port_occupied_prev'
+  if (status === 'port_denied') return 'port_denied'
+  if (status === 'database_error') return 'database_error'
+  if (status === 'protocol_error') return 'check_error'
+  if (stage === 'check') {
+    if (status === 'old_version') return 'old_version'
+    if (status === 'timeout' || status === 'call_error') return 'check_timeout'
+    if (status === 'build_yak_error' || status === 'dial_error') return status
+    if (status === 'antivirus_blocked' || status === 'endpoint_unreachable') return status
+    return 'check_error'
+  }
+  return 'start_timeout'
+}
+
+export function engineFailureMessage(
+  result: { message?: string; engineEvent?: { reasonI18n?: { zh?: string; en?: string; 'zh-TW'?: string } | null } },
+  language: string,
+  fallback: string,
+): string {
+  const labels = result.engineEvent?.reasonI18n
+  const localized = language.startsWith('en')
+    ? labels?.en
+    : language === 'zh-TW'
+      ? labels?.['zh-TW'] || labels?.zh
+      : labels?.zh
+  return (typeof localized === 'string' && localized) || result.message || fallback
+}

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/engineFailure.ts
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/engineFailure.ts
@@ -5,14 +5,14 @@ import type { YakitStatusType } from './types'
 export function engineFailureStatus(status: string, stage: 'check' | 'start'): YakitStatusType | null {
   if (status === 'cancelled') return null
   if (status === 'port_occupied') return 'port_occupied_prev'
-  if (status === 'port_denied') return 'port_denied'
+  if (status === 'port_denied' || status === 'endpoint_unreachable') return status
   if (status === 'database_error') return 'database_error'
   if (status === 'protocol_error') return 'check_error'
   if (stage === 'check') {
     if (status === 'old_version') return 'old_version'
     if (status === 'timeout' || status === 'call_error') return 'check_timeout'
     if (status === 'build_yak_error' || status === 'dial_error') return status
-    if (status === 'antivirus_blocked' || status === 'endpoint_unreachable') return status
+    if (status === 'antivirus_blocked') return status
     return 'check_error'
   }
   return 'start_timeout'

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/engineFailure.ts
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/engineFailure.ts
@@ -19,15 +19,39 @@ export function engineFailureStatus(status: string, stage: 'check' | 'start'): Y
 }
 
 export function engineFailureMessage(
-  result: { message?: string; engineEvent?: { reasonI18n?: { zh?: string; en?: string; 'zh-TW'?: string } | null } },
+  result: {
+    status?: string
+    message?: string
+    engineEvent?: { reasonI18n?: { zh?: string; en?: string; 'zh-TW'?: string } | null }
+  },
   language: string,
   fallback: string,
+  translate?: (key: string, options?: { defaultValue: string }) => string,
 ): string {
   const labels = result.engineEvent?.reasonI18n
-  const localized = language.startsWith('en')
-    ? labels?.en
-    : language === 'zh-TW'
-      ? labels?.['zh-TW'] || labels?.zh
-      : labels?.zh
-  return (typeof localized === 'string' && localized) || result.message || fallback
+  const localized = language.startsWith('en') ? labels?.en : language === 'zh-TW' ? labels?.['zh-TW'] : labels?.zh
+  if (typeof localized === 'string' && localized.trim()) return localized
+  // Legacy engines and main-process failures may only supply Chinese diagnostics.
+  // Preserve those details in the logs, but use translated recovery advice in the UI.
+  if (language === 'zh' && result.message) return result.message
+  const statuses = [
+    'port_occupied',
+    'port_denied',
+    'endpoint_unreachable',
+    'database_error',
+    'build_yak_error',
+    'engine_init_failed',
+    'dial_error',
+    'call_error',
+    'timeout',
+    'antivirus_blocked',
+    'old_version',
+    'protocol_error',
+    'process_error',
+    'engine_exited',
+  ]
+  if (result.status && statuses.includes(result.status) && translate) {
+    return translate(`EngineFailure.${result.status}`, { defaultValue: fallback })
+  }
+  return fallback
 }

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/index.tsx
@@ -332,58 +332,21 @@ export const StartupPage: React.FC = () => {
     }
   })
 
-  const killCurrentProcess = useMemoizedFn((callback: () => void, extraPorts?: number[]) => {
-    // ---------- 1. PS 查询所有 yak 进程 ----------
-    yakitEngine
-      .listYakGrpc()
-      .then(async (res) => {
-        // 查找 PID
-        const pidsToKill = extraPorts
-          ? res
-              .filter((p) => extraPorts.includes(Number(p.port)))
-              .map((p) => p.pid)
-              .filter(Boolean)
-          : []
-
-        if (pidsToKill.length === 0) {
-          callback()
-          return
-        }
-
-        // ---------- 2. kill ----------
-        for (const pid of pidsToKill) {
-          try {
-            await yakitEngine.killYakGrpc(pid)
-            yakitNotify('info', `KILL yak PROCESS: ${pid}`)
-          } catch (err) {
-            yakitNotify('error', `Kill yak process failed: ${err}`)
-          }
-        }
-
-        callback()
-      })
-      .catch(() => {
-        callback()
-      })
-  })
-
-  // 在 3 秒内，不断尝试让主进程取消所有正在执行的任务
+  // Wait for the main process to settle cancellation before offering another startup.
+  // Only processes owned by this Yakit instance are stopped.
   const cancelAllTasks = async () => {
-    const start = Date.now()
-    while (Date.now() - start < 3000) {
-      let res: any = null
-      try {
-        res = await yakitEngine.cancelAllTasks()
-      } catch (e) {
-        debugToPrintLog(`------ cancel-all-tasks failed: ${e}`)
-      }
-      if (!res || res.canceled === 0) {
-        await new Promise((r) => setTimeout(r, 300))
-      } else {
-        await new Promise((r) => setTimeout(r, 500))
-      }
-    }
+    await yakitEngine.cancelAllTasks()
   }
+  const stopOwnedEngine = useMemoizedFn(async (callback: () => void) => {
+    try {
+      await cancelAllTasks()
+      callback()
+    } catch (error) {
+      setRestartLoading(false)
+      safeSetYakitStatus('check_error')
+      setCheckLog([String(error)])
+    }
+  })
 
   const setTimeoutLoading = useMemoizedFn((setLoading: (v: boolean) => any, time = 2000) => {
     setLoading(true)
@@ -834,21 +797,15 @@ export const StartupPage: React.FC = () => {
         setRestartLoading(true)
         setYaklangDownload(true)
         return
+      case 'check_error':
       case 'check_timeout':
         // 超时手动校验引擎
         setRestartLoading(true)
         handleStartLocalLink(isCheckVersion.current)
         return
       case 'port_occupied_prev':
-        // 端口被占用前置操作
-        if (extra?.killCurProcess) {
-          setRestartLoading(true)
-          killCurrentProcess(() => {
-            handleStartLocalLink(isCheckVersion.current)
-          }, [getCustomPort()])
-        } else {
-          safeSetYakitStatus('port_occupied')
-        }
+        // An occupied port may belong to another Yakit instance; offer a new port.
+        safeSetYakitStatus('port_occupied')
         return
       case 'port_occupied':
         // 端口被占用
@@ -954,11 +911,11 @@ export const StartupPage: React.FC = () => {
           } else {
             breakHandleRef.current = false
             safeSetYakitStatus('')
-            killCurrentProcess(() => {
+            stopOwnedEngine(() => {
               setTimeout(() => {
                 handleStartLocalLink(isCheckVersion.current)
               }, 500)
-            }, [getCustomPort()])
+            })
           }
         } else {
           // 否则执行断开
@@ -971,14 +928,13 @@ export const StartupPage: React.FC = () => {
           setYakitLoadingTip(t('StartupPage.interrupting'))
           setRestartLoading(false)
           setDisableYakitLoading(true)
-          cancelAllTasks()
-          setTimeout(() => {
-            setYakitLoadingTip('')
-            setDisableYakitLoading(false)
-            if (extra.isRemote) {
-              handleLinkRemoteMode()
-            }
-          }, 3000)
+          void cancelAllTasks()
+            .catch((error) => setCheckLog([String(error)]))
+            .finally(() => {
+              setYakitLoadingTip('')
+              setDisableYakitLoading(false)
+              if (extra?.isRemote) handleLinkRemoteMode()
+            })
         }
         return
       case 'link_countdown':
@@ -1046,7 +1002,7 @@ export const StartupPage: React.FC = () => {
   // 下载指定版本引擎
   useUpdateEffect(() => {
     if (yaklangSpecifyVersion) {
-      killCurrentProcess(() => {
+      stopOwnedEngine(() => {
         yakEngineVersionExistsAndCorrectness(
           yaklangSpecifyVersion,
           () => {
@@ -1071,7 +1027,7 @@ export const StartupPage: React.FC = () => {
             setYaklangDownload(true)
           },
         )
-      }, [getCustomPort()])
+      })
     }
   }, [yaklangSpecifyVersion])
   // #endregion

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/index.tsx
@@ -856,8 +856,34 @@ export const StartupPage: React.FC = () => {
         setCustomPort(extra.port)
         handleStartLocalLink(isCheckVersion.current)
         return
+      case 'port_denied':
+      case 'endpoint_unreachable':
+      case 'timeout':
+      case 'process_error':
+      case 'unknownReason':
+      case 'unknown':
+      case 'exception':
+        // check 阶段失败，重新走完整 check 流程
+        setRestartLoading(true)
+        handleStartLocalLink(isCheckVersion.current)
+        return
+      case 'build_yak_error':
+      case 'dial_error':
+        // 引擎服务构建或连接失败，重置引擎版本
+        setRestartLoading(true)
+        safeSetYakitStatus('skipAgreement_Install')
+        return
+      case 'call_error':
+        // 认证失败，重新连接
+        setRestartLoading(true)
+        handleStartLocalLink(isCheckVersion.current)
+        return
       case 'start_timeout':
-        // 启动yak超时
+      case 'engine_exited':
+      case 'engine_init_failed':
+      case 'engine_failed':
+      case 'exit':
+        // start 阶段失败，重新启动引擎
         setTimeoutLoading(setRestartLoading, 5000)
         onStartLinkEngine()
         return

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/index.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/index.tsx
@@ -160,6 +160,8 @@ export const StartupPage: React.FC = () => {
   // 回收数据库空间
   const reclaimDbSpacePath = useRef<string[]>([])
   const [remoteLinkLoading, setRemoteLinkLoading] = useState<boolean>(false)
+  const [ownedEngineCleanupBusy, setOwnedEngineCleanupBusy] = useState<boolean>(false)
+  const stoppingOwnedEngineRef = useRef<boolean>(false)
 
   // #region 工作空间确认回调
   const handleWorkspaceConfirmed = useMemoizedFn(() => {
@@ -334,18 +336,38 @@ export const StartupPage: React.FC = () => {
 
   // Wait for the main process to settle cancellation before offering another startup.
   // Only processes owned by this Yakit instance are stopped.
-  const cancelAllTasks = async () => {
-    await yakitEngine.cancelAllTasks()
-  }
-  const stopOwnedEngine = useMemoizedFn(async (callback: () => void) => {
+  const showStopOwnedEngineError = useMemoizedFn((reason: 'process_error' | 'ipc_error') => {
+    debugToPrintLog(`------ 停止本实例所属引擎进程失败: ${reason} ------`)
+    breakHandleRef.current = false
+    setRestartLoading(false)
+    safeSetYakitStatus('check_error')
+    setCheckLog([t('StartupPage.stop_owned_engine_failed')])
+  })
+  const stopOwnedEngine = useMemoizedFn(async (callback: () => void): Promise<boolean> => {
+    if (stoppingOwnedEngineRef.current) return false
+    stoppingOwnedEngineRef.current = true
+    setOwnedEngineCleanupBusy(true)
     try {
-      await cancelAllTasks()
-      callback()
-    } catch (error) {
-      setRestartLoading(false)
-      safeSetYakitStatus('check_error')
-      setCheckLog([String(error)])
+      const result = await yakitEngine.cancelAllTasks()
+      if (!result.ok) {
+        showStopOwnedEngineError('process_error')
+        return false
+      }
+    } catch {
+      showStopOwnedEngineError('ipc_error')
+      return false
+    } finally {
+      stoppingOwnedEngineRef.current = false
+      setOwnedEngineCleanupBusy(false)
     }
+    callback()
+    return true
+  })
+
+  const selectYaklangSpecifyVersion = useMemoizedFn((version: string) => {
+    if (restartLoading || ownedEngineCleanupBusy || stoppingOwnedEngineRef.current) return
+    setRestartLoading(true)
+    setYaklangSpecifyVersion(version)
   })
 
   const setTimeoutLoading = useMemoizedFn((setLoading: (v: boolean) => any, time = 2000) => {
@@ -801,7 +823,7 @@ export const StartupPage: React.FC = () => {
       case 'check_timeout':
         // 超时手动校验引擎
         setRestartLoading(true)
-        handleStartLocalLink(isCheckVersion.current)
+        void stopOwnedEngine(() => handleStartLocalLink(isCheckVersion.current))
         return
       case 'port_occupied_prev':
         // An occupied port may belong to another Yakit instance; offer a new port.
@@ -811,7 +833,7 @@ export const StartupPage: React.FC = () => {
         // 端口被占用
         setRestartLoading(true)
         setCustomPort(extra.port)
-        handleStartLocalLink(isCheckVersion.current)
+        void stopOwnedEngine(() => handleStartLocalLink(isCheckVersion.current))
         return
       case 'port_denied':
       case 'endpoint_unreachable':
@@ -822,7 +844,7 @@ export const StartupPage: React.FC = () => {
       case 'exception':
         // check 阶段失败，重新走完整 check 流程
         setRestartLoading(true)
-        handleStartLocalLink(isCheckVersion.current)
+        void stopOwnedEngine(() => handleStartLocalLink(isCheckVersion.current))
         return
       case 'build_yak_error':
       case 'dial_error':
@@ -833,7 +855,7 @@ export const StartupPage: React.FC = () => {
       case 'call_error':
         // 认证失败，重新连接
         setRestartLoading(true)
-        handleStartLocalLink(isCheckVersion.current)
+        void stopOwnedEngine(() => handleStartLocalLink(isCheckVersion.current))
         return
       case 'start_timeout':
       case 'engine_exited':
@@ -841,11 +863,14 @@ export const StartupPage: React.FC = () => {
       case 'engine_failed':
       case 'exit':
         // start 阶段失败，重新启动引擎
-        setTimeoutLoading(setRestartLoading, 5000)
-        onStartLinkEngine()
+        setRestartLoading(true)
+        void stopOwnedEngine(() => {
+          setTimeoutLoading(setRestartLoading, 5000)
+          onStartLinkEngine()
+        })
         return
       case 'remote':
-        handleLinkRemoteMode()
+        void stopOwnedEngine(handleLinkRemoteMode)
         return
       case 'local':
         handleLinkLocalMode()
@@ -885,10 +910,10 @@ export const StartupPage: React.FC = () => {
         return
       case 'error':
         // 引擎连接超时或意外断掉连接
-        setTimeoutLoading(setRestartLoading)
-        handleStartLocalLink(false)
+        setRestartLoading(true)
         isCheckVersion.current = false
         setKeepalive(false)
+        void stopOwnedEngine(() => handleStartLocalLink(false))
         return
       case 'reclaimDatabaseSpace_success':
       case 'reclaimDatabaseSpace_error':
@@ -928,13 +953,12 @@ export const StartupPage: React.FC = () => {
           setYakitLoadingTip(t('StartupPage.interrupting'))
           setRestartLoading(false)
           setDisableYakitLoading(true)
-          void cancelAllTasks()
-            .catch((error) => setCheckLog([String(error)]))
-            .finally(() => {
-              setYakitLoadingTip('')
-              setDisableYakitLoading(false)
-              if (extra?.isRemote) handleLinkRemoteMode()
-            })
+          void stopOwnedEngine(() => {
+            if (extra?.isRemote) handleLinkRemoteMode()
+          }).finally(() => {
+            setYakitLoadingTip('')
+            setDisableYakitLoading(false)
+          })
         }
         return
       case 'link_countdown':
@@ -1001,34 +1025,37 @@ export const StartupPage: React.FC = () => {
 
   // 下载指定版本引擎
   useUpdateEffect(() => {
-    if (yaklangSpecifyVersion) {
-      stopOwnedEngine(() => {
-        yakEngineVersionExistsAndCorrectness(
-          yaklangSpecifyVersion,
-          () => {
-            setYaklangSpecifyVersion('')
-            breakHandleRef.current = false
-            isCheckVersion.current = false
+    if (!yaklangSpecifyVersion) return
+    void stopOwnedEngine(() => {
+      void yakEngineVersionExistsAndCorrectness(
+        yaklangSpecifyVersion,
+        () => {
+          setYaklangSpecifyVersion('')
+          breakHandleRef.current = false
+          isCheckVersion.current = false
+          setLinkLocalEngine()
+        },
+        (err) => {
+          setYaklangSpecifyVersion('')
+          breakHandleRef.current = false
+          isCheckVersion.current = false
+          if (err.message === 'operation not permitted') {
             setLinkLocalEngine()
-          },
-          (err) => {
-            setYaklangSpecifyVersion('')
-            breakHandleRef.current = false
-            isCheckVersion.current = false
-            if (err.message === 'operation not permitted') {
-              setLinkLocalEngine()
-            } else {
-              // 引擎文件已经被删除了
-              safeSetYakitStatus('')
-              handleOperations('install')
-            }
-          },
-          () => {
-            setYaklangDownload(true)
-          },
-        )
-      })
-    }
+          } else {
+            // 引擎文件已经被删除了
+            setRestartLoading(false)
+            safeSetYakitStatus('')
+            handleOperations('install')
+          }
+        },
+        () => {
+          setRestartLoading(false)
+          setYaklangDownload(true)
+        },
+      )
+    }).then((stopped) => {
+      if (!stopped) setYaklangSpecifyVersion('')
+    })
   }, [yaklangSpecifyVersion])
   // #endregion
 
@@ -1254,13 +1281,13 @@ export const StartupPage: React.FC = () => {
                       checkLog={checkLog}
                       yakitStatus={yakitStatus}
                       engineMode={engineMode || 'local'}
-                      restartLoading={restartLoading}
+                      restartLoading={restartLoading || ownedEngineCleanupBusy}
                       dbPath={dbPath}
                       btnClickCallback={loadingClickCallback}
                       port={customPort}
                       countdown={countdown}
                       moreYaklangVersionList={moreYaklangVersionList}
-                      setYaklangSpecifyVersion={setYaklangSpecifyVersion}
+                      setYaklangSpecifyVersion={selectYaklangSpecifyVersion}
                     />
                     {/* 更新引擎 */}
                     {yaklangDownload && (

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/types.ts
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/types.ts
@@ -42,11 +42,25 @@ export type YakitStatusType =
   | 'skipAgreement_Install' // 重置yak引擎 不需要勾选用户协议
   | 'port_occupied_prev' // 端口被占用前操作
   | 'port_occupied' // 端口被占用
+  | 'port_denied' // 端口被系统策略阻止(权限不足)
+  | 'endpoint_unreachable' // 网络监听失败(其他原因)
   | 'database_error' // 数据库错误
   | 'fix_database_timeout' // 数据库修复超时
   | 'fix_database_error' // 数据库修复失败
   | 'antivirus_blocked' // 检查随机密码模式失败(杀软)
   | 'allow-secret-error' // 检查随机密码模式失败(未知)
+  | 'build_yak_error' // 引擎服务构建失败
+  | 'dial_error' // gRPC Dial 失败
+  | 'call_error' // 认证或版本校验失败
+  | 'engine_exited' // 引擎服务异常退出
+  | 'engine_init_failed' // 引擎初始化失败
+  | 'engine_failed' // 引擎启动失败(未分类)
+  | 'timeout' // 引擎检查超时
+  | 'process_error' // 引擎进程启动失败
+  | 'exception' // 引擎检查异常
+  | 'unknownReason' // 未知原因失败
+  | 'unknown' // 未知错误
+  | 'exit' // 引擎进程提前退出
   | 'update_yakit' // 检测到新版yakit
   | 'update_yak' // 检测到新版yak
   | 'check_yak_version_error' // 检测新版yak出错

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/types.ts
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/types.ts
@@ -36,6 +36,7 @@ export type YakitStatusType =
   | 'init' // 初始
   | 'install' // 解压内置引擎
   | 'installNetWork' // 初始内置引擎不存在，联网安装
+  | 'check_error' // 检查失败，重试完整检查流程
   | 'check_timeout' // 引擎check超时
   | 'old_version' // 检查随机密码模式失败(引擎版本低)
   | 'skipAgreement_InstallNetWork' // 下载yak引擎 不需要勾选用户协议

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/types.ts
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/types.ts
@@ -142,3 +142,7 @@ export interface TypeCallbackExtra {
   message?: string
   dbPath?: string[]
 }
+
+export type CancelTasksResult =
+  | { ok: true; canceled: number; status: 'cancelled' }
+  | { ok: false; canceled: number; status: 'process_error'; message: string }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "release-memfit": "node scripts/release-memfit.js",
     "release-yakit": "node scripts/prod-pack.js",
     "test:vitest": "vitest",
+    "test:engine-startup": "vitest run --config scripts/engine-startup/vitest.config.mts",
     "test:icon-migration": "vitest run --config scripts/icon-migration/vitest.config.mts",
     "perf:mitm": "MITM_PERF_PROFILE=smoke vitest bench app/renderer/src/main/src/pages/mitm/MITMManual/__test__/MITMManual.perf.bench.ts --run --maxWorkers=1",
     "perf:mitm:electron:compare": "node scripts/compare-electron-mitm-performance.mjs",

--- a/scripts/engine-startup/README.md
+++ b/scripts/engine-startup/README.md
@@ -15,6 +15,7 @@ their promises, and terminate only child processes owned by this manager.
 
 ```sh
 yarn test:engine-startup
+yarn test:vitest app/main/handlers/__test__/newEngineStatus.test.js --run --maxWorkers=1
 cd app/renderer/engine-link-startup
 yarn type-check
 yarn i18n:check
@@ -109,13 +110,34 @@ existing Electron channels; it does not add Unix socket or named-pipe support.
 - The real-engine verifier rebinds the original startup port after disposal;
   reserving a different port is not evidence that cleanup succeeded.
 
-Self-check and engine-start stages each have a 180-second deadline. Per-RPC probes
-stay short and cancellable; initial connection probes and cleanup deadlines are
-not expanded. At 20 seconds, each still-pending check/start emits a one-time hint
+Self-check and engine-start stages each have a 180-second deadline. Startup RPC
+probes remain cancellable with a 2-second deadline per probe. An explicit connection
+has one 10-second budget; local authenticated and anonymous-rejection probes share
+that absolute deadline. Authentication rejection fails immediately. Cleanup retains
+its bounded 4-second process-exit wait. At 20 seconds, each still-pending check/start emits a one-time hint
 explaining that a major-version database migration may take extra time and is
 usually a one-time operation. The hint does not assert that migration is occurring.
 Timers are cleared on success, failure, cancellation and supersession. Subsequent
 progress messages do not erase the migration hint.
+
+Recovery actions first await cleanup of this manager's owned processes before
+checking or starting again. External port owners are never terminated. Concurrent
+cleanup calls share the same result, and new operations wait for cleanup to settle.
+After a cleanup failure, the user can retry cancellation; another check/start is
+blocked until cleanup succeeds.
+
+`cancel()`, `dispose()`, and `EngineLink:cancel-all-tasks` return either
+`{ ok: true, canceled, status: 'cancelled' }` or
+`{ ok: false, canceled, status: 'process_error', message }`. The count includes
+confirmed completed cancellations only: an active operation counts once, including
+its child; each retained child counts once. Failed cleanup does not authorize
+check, start, installation, or mode switching. The renderer displays localized
+recovery guidance for both business failures and rejected IPC calls.
+
+Cleanup logs use the existing engine log sink with `cleanup_start` and
+`cleanup_result` events. Fields are `operationId`, `stage`, `ownedChildPid`,
+`exitCode`, `signal`, `confirmedExit`, and `elapsedMs`; credentials and command-line
+arguments are excluded. Logging is best-effort and never changes the cleanup result.
 
 Local validation uses the installed Windows x64 `1.4.8-alpha0910ipc` engine,
 SHA-256 `351ba169c3ee77b936a619c3f649aa3a4b13d8a692b906176429d527b8ab9a0c`,
@@ -131,3 +153,22 @@ no errors, and the community Link production build passing. The real-engine
 experiment also passes under both Node 24.19.0 and Electron 27's Node 18.17.1.
 These are local verification results; PR comments are not marked resolved remotely
 until the corresponding changes have been reviewed and published.
+
+## Recovery and cancellation follow-up (macOS)
+
+The repair adds regressions for queued operations invalidated by a later cancel,
+cleanup failure blocking a replacement connection, and the parent page waiting
+before retry, port change, installation, or either remote-mode entry. Explicit
+connection tests cover a 3-second response, a 10-second timeout, immediate auth
+rejection, and a shared local authentication deadline. TCP and TLS tests use real
+loopback servers; their test certificate is not a production credential.
+
+The real-engine verifier also exercises a failed RPC while an owned child is
+still alive, then confirms cleanup before same-port restart and a later port
+change. Each check must produce new credentials. This simulates RPC failure with
+wrong credentials; it does not reproduce an operating-system network outage.
+
+macOS verification uses the already-installed engine with SHA-256
+`0e27d266de388c6e837beab7fc268b36136de4733836d28ad6ba22a2a98b147a`, disposable
+databases, Node 26.7.0 and Electron 27's Node 18.17.1. This local verification does
+not replace Windows process-tree CI or packaged Electron GUI checks on each OS.

--- a/scripts/engine-startup/README.md
+++ b/scripts/engine-startup/README.md
@@ -33,13 +33,10 @@ or native install scripts, uses bounded jobs and RPCs, and uploads JUnit results
 
 ## Real engine experiments
 
-Build the engine entry point at explicit revisions with its supported Go toolchain:
-
-```sh
-go build -mod=readonly -o /absolute/path/to/yak ./common/yak/cmd/yak.go
-```
-
-From the Yakit repository, pass only explicitly selected engine binaries:
+Download explicitly versioned, already published engine binaries from the CDN
+and verify their SHA-256 before executing them. Do not compile engines for this
+test or follow the moving `latest` pointer. From the Yakit repository, pass the
+verified binaries:
 
 ```sh
 node scripts/engine-startup/verify-real-engine.cjs /absolute/yak-old /absolute/yak-new
@@ -49,8 +46,22 @@ Each binary gets disposable databases and a temporary home containing spaces and
 Unicode. The experiment verifies random credentials, authenticated startup,
 rejection of empty/masked/wrong credentials, secret redaction, port conflict
 recovery, and owned-child cleanup. The JSON output includes binary SHA-256 hashes.
-The Windows CI job pins and builds both source revisions; it never downloads a
-moving `latest` engine.
+The Windows CI job downloads these Windows x64 binaries from
+`https://yaklang.oss-accelerate.aliyuncs.com/yak/<version>/yak_windows_amd64.exe`
+and checks the hashes pinned in the workflow before running the same experiments:
+
+| Coverage           | Published version    | SHA-256                                                            |
+| ------------------ | -------------------- | ------------------------------------------------------------------ |
+| Older release      | `1.4.8-beta17`       | `017d3fd2dcde3399f0b26940be94a8d4bb941be2504ccbf36949a67c01eb9d8a` |
+| Current test alpha | `1.4.8-alpha0910ipc` | `351ba169c3ee77b936a619c3f649aa3a4b13d8a692b906176429d527b8ab9a0c` |
+
+Updating a version or replacing an alpha artifact requires an explicit hash
+update. A failed download or mismatched hash fails the job; it does not fall back
+to source compilation or skip engine verification.
+
+The exact workflow download step and unchanged verifier were also run locally on
+Windows with Node 24.19.0: both CDN binaries passed hash verification and all
+startup, authentication, redaction, port-conflict and cleanup checks.
 
 To exercise the unmodified legacy Yakit IPC handlers against the repaired engine:
 
@@ -65,9 +76,11 @@ random password and still recognizes the legacy port-conflict reason.
 
 ## Verification scope
 
-The compatibility baseline is engine `65467f3cf73d9803b9cee7754008dd317611e3ca`
-and Yakit `de89a81859ab914f5b5aae7c842cd6cc630dfccc`. The repaired engine is
+Earlier source-built experiments used engine
+`65467f3cf73d9803b9cee7754008dd317611e3ca` and Yakit
+`de89a81859ab914f5b5aae7c842cd6cc630dfccc`, with repaired engine
 `4f7863298e6cabdeb4ad25e7321743d6a93dd2a3` in yaklang/yaklang#5043.
+CI now uses the published CDN versions listed above, not those source builds.
 These experiments exercise startup, authentication, and recovery; they do not
 replace a packaged Electron GUI smoke test or establish compatibility with every
 historical release. Engine IPC platform testing is tracked separately.

--- a/scripts/engine-startup/README.md
+++ b/scripts/engine-startup/README.md
@@ -71,3 +71,50 @@ and Yakit `de89a81859ab914f5b5aae7c842cd6cc630dfccc`. The repaired engine is
 These experiments exercise startup, authentication, and recovery; they do not
 replace a packaged Electron GUI smoke test or establish compatibility with every
 historical release. Engine IPC platform testing is tracked separately.
+
+## PR 4249 review follow-up (Windows, alpha0910ipc)
+
+The existing branch already verifies both authenticated Echo success and anonymous
+Echo rejection before committing a connection. This follow-up keeps TCP and all
+existing Electron channels; it does not add Unix socket or named-pipe support.
+
+- Closing-window notifications are best-effort, including delayed progress and
+  database messages from child-process output.
+- The process list has no trusted credentials. Its direct-switch button is
+  disabled with guidance to use connection settings. Switching must not probe
+  anonymously or terminate the current engine on failure. Process details display
+  PID, parent PID and port only, not command lines containing local passwords.
+- Silent checker exits retain the `antivirus_blocked` recovery route, but are not
+  asserted to be antivirus failures: a crash or other process failure is possible.
+  Exit code and signal remain in diagnostics; users are advised to inspect logs
+  and security-software events, not disable protection indiscriminately.
+- Legacy and main-process errors use localized recovery advice when the engine
+  supplies no message in the selected language. Unknown errors use the caller's
+  localized fallback; detailed Chinese diagnostics remain available in logs.
+- Check results are accepted from stdout or stderr. Multiple marked results are
+  rejected rather than accepting a contradictory success result.
+- The real-engine verifier rebinds the original startup port after disposal;
+  reserving a different port is not evidence that cleanup succeeded.
+
+Self-check and engine-start stages each have a 180-second deadline. Per-RPC probes
+stay short and cancellable; initial connection probes and cleanup deadlines are
+not expanded. At 20 seconds, each still-pending check/start emits a one-time hint
+explaining that a major-version database migration may take extra time and is
+usually a one-time operation. The hint does not assert that migration is occurring.
+Timers are cleared on success, failure, cancellation and supersession. Subsequent
+progress messages do not erase the migration hint.
+
+Local validation uses the installed Windows x64 `1.4.8-alpha0910ipc` engine,
+SHA-256 `351ba169c3ee77b936a619c3f649aa3a4b13d8a692b906176429d527b8ab9a0c`,
+with disposable homes/databases. This verifies authenticated startup, credential
+rejection, redaction, occupied-port recovery and release of the original port.
+It does not migrate or modify the user's existing project databases, and does not
+claim that a real large-database migration was reproduced. Timing behavior is
+covered with deterministic fake-clock tests at 20 and 180 seconds.
+
+Validation on Windows completed with 61 main-process tests and 65 startup-renderer
+tests passing, Link TypeScript and locale parity checks passing, ESLint reporting
+no errors, and the community Link production build passing. The real-engine
+experiment also passes under both Node 24.19.0 and Electron 27's Node 18.17.1.
+These are local verification results; PR comments are not marked resolved remotely
+until the corresponding changes have been reviewed and published.

--- a/scripts/engine-startup/README.md
+++ b/scripts/engine-startup/README.md
@@ -1,0 +1,73 @@
+# Engine startup compatibility
+
+Local startup deliberately uses the existing authenticated loopback TCP protocol.
+Do not automatically enable Unix sockets or Windows named pipes based on the engine
+version: older engines do not recognize those flags. IPC support in the engine is
+opt-in and is separate from this client compatibility change.
+
+The startup manager generates a fresh cryptographic password and probes with the
+same immutable credentials that it commits to the connection settings. It also
+checks that an anonymous Echo is rejected. A ready event or log line alone cannot
+complete startup. Failed or cancelled attempts close their RPC clients, settle
+their promises, and terminate only child processes owned by this manager.
+
+## Automated client tests
+
+```sh
+yarn test:engine-startup
+cd app/renderer/engine-link-startup
+yarn type-check
+yarn i18n:check
+yarn test run src/pages/StartupPage --maxWorkers=1
+```
+
+The main-process suite covers legacy and structured diagnostics, split output,
+timeouts, spawn failures, authentication, stale callbacks, cancellation, and real
+TCP connections using the production gRPC client factory. The Windows integration
+case starts and terminates an owned process tree. Mock process tests never invoke
+the host's real process termination command.
+
+The renderer suite covers retry recovery, credential invalidation, and stale
+check/connect responses. CI installs frozen dependencies without Electron download
+or native install scripts, uses bounded jobs and RPCs, and uploads JUnit results.
+
+## Real engine experiments
+
+Build the engine entry point at explicit revisions with its supported Go toolchain:
+
+```sh
+go build -mod=readonly -o /absolute/path/to/yak ./common/yak/cmd/yak.go
+```
+
+From the Yakit repository, pass only explicitly selected engine binaries:
+
+```sh
+node scripts/engine-startup/verify-real-engine.cjs /absolute/yak-old /absolute/yak-new
+```
+
+Each binary gets disposable databases and a temporary home containing spaces and
+Unicode. The experiment verifies random credentials, authenticated startup,
+rejection of empty/masked/wrong credentials, secret redaction, port conflict
+recovery, and owned-child cleanup. The JSON output includes binary SHA-256 hashes.
+The Windows CI job pins and builds both source revisions; it never downloads a
+moving `latest` engine.
+
+To exercise the unmodified legacy Yakit IPC handlers against the repaired engine:
+
+```sh
+git show de89a81859ab914f5b5aae7c842cd6cc630dfccc:app/main/handlers/newEngineStatus.js > /tmp/yakit-legacy-startup.js
+node scripts/engine-startup/verify-legacy-client.cjs /tmp/yakit-legacy-startup.js /absolute/yak-new
+```
+
+This harness supplies Electron IPC registration, disposable paths, and real gRPC
+clients to the original module. It verifies that the old client receives a usable
+random password and still recognizes the legacy port-conflict reason.
+
+## Verification scope
+
+The compatibility baseline is engine `65467f3cf73d9803b9cee7754008dd317611e3ca`
+and Yakit `de89a81859ab914f5b5aae7c842cd6cc630dfccc`. The repaired engine is
+`4f7863298e6cabdeb4ad25e7321743d6a93dd2a3` in yaklang/yaklang#5043.
+These experiments exercise startup, authentication, and recovery; they do not
+replace a packaged Electron GUI smoke test or establish compatibility with every
+historical release. Engine IPC platform testing is tracked separately.

--- a/scripts/engine-startup/fixtures/engine.cjs
+++ b/scripts/engine-startup/fixtures/engine.cjs
@@ -1,7 +1,6 @@
 // A bounded subprocess fixture for the old/new CLI contract. No user home or database access.
 const { grpc, Yak } = require(process.env.YAKIT_TEST_GRPC_HELPER)
 const { spawn } = require('node:child_process')
-const { writeFileSync } = require('node:fs')
 const args = process.argv.slice(2)
 const port = Number(args[args.indexOf('--port') + 1])
 const password = args[args.indexOf('--local-password') + 1]
@@ -17,14 +16,22 @@ function writeCheck(data) {
   })
 }
 
+function spawnHelper(ignoreTerm = false) {
+  const descendantPath = JSON.stringify(process.env.YAKIT_TEST_DESCENDANT)
+  spawn(
+    process.execPath,
+    [
+      '-e',
+      `${ignoreTerm ? "process.on('SIGTERM', () => {})" : ''}; require('node:fs').writeFileSync(${descendantPath}, String(process.pid)); setTimeout(() => process.exit(91), 15000)`,
+    ],
+    { stdio: 'ignore', windowsHide: true },
+  )
+}
+
 if (scenario === 'hang') {
   process.stdout.write('fixture waiting\n')
-} else if (scenario === 'tree') {
-  const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 12000)'], {
-    stdio: 'ignore',
-    windowsHide: true,
-  })
-  writeFileSync(process.env.YAKIT_TEST_DESCENDANT, String(child.pid))
+} else if (scenario === 'tree' || scenario === 'tree-ignore-term') {
+  spawnHelper(scenario === 'tree-ignore-term')
   process.stdout.write('fixture tree ready\n')
 } else if (scenario === 'crash') {
   process.exitCode = 7
@@ -45,6 +52,7 @@ if (scenario === 'hang') {
   })
 } else {
   if (args[0] !== 'grpc' || !password || args.includes('--transport')) process.exit(8)
+  if (scenario === 'success-parent-exit-tree') spawnHelper()
   const server = new grpc.Server()
   server.addService(Yak.service, {
     Echo(call, done) {
@@ -77,5 +85,6 @@ if (scenario === 'hang') {
       process.stdout.write(`dy ${event}\r\n`)
     }
     process.stdout.write(`{"secret":"${password}"}\n`)
+    if (scenario === 'success-parent-exit-tree') setTimeout(() => process.exit(0), 750)
   })
 }

--- a/scripts/engine-startup/fixtures/engine.cjs
+++ b/scripts/engine-startup/fixtures/engine.cjs
@@ -1,0 +1,78 @@
+// A bounded subprocess fixture for the old/new CLI contract. No user home or database access.
+const { grpc, Yak } = require(process.env.YAKIT_TEST_GRPC_HELPER)
+const { spawn } = require('node:child_process')
+const { writeFileSync } = require('node:fs')
+const args = process.argv.slice(2)
+const port = Number(args[args.indexOf('--port') + 1])
+const password = args[args.indexOf('--local-password') + 1]
+const mode = process.env.YAKIT_TEST_CONTRACT || 'v2'
+const scenario = process.env.YAKIT_TEST_SCENARIO || 'success'
+const marker = '50551aa97b5aa5ae8a3c3243ac60a8a7'
+const check = args[0] === 'check-secret-local-grpc'
+const budget = setTimeout(() => process.exit(90), 12000)
+
+function writeCheck(data) {
+  process.stdout.write(`<json-${marker}>\n${JSON.stringify(data)}\n</json-${marker}>\n`, () => {
+    clearTimeout(budget)
+  })
+}
+
+if (scenario === 'hang') {
+  process.stdout.write('fixture waiting\n')
+} else if (scenario === 'tree') {
+  const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 12000)'], {
+    stdio: 'ignore',
+    windowsHide: true,
+  })
+  writeFileSync(process.env.YAKIT_TEST_DESCENDANT, String(child.pid))
+  process.stdout.write('fixture tree ready\n')
+} else if (scenario === 'crash') {
+  process.exitCode = 7
+  clearTimeout(budget)
+} else if (check) {
+  const server = require('node:net').createServer()
+  server.once('error', () => {
+    writeCheck(
+      mode === 'legacy'
+        ? { ok: false, port, reason: ['unrelated', 'net.Listen error'], info: 'listen: address already in use' }
+        : { ok: false, port, phase: 'listen', reasonCode: 'tcp_bind_in_use', reason: ['[tcp_bind_in_use] occupied'] },
+    )
+  })
+  server.listen(port, '127.0.0.1', () => {
+    server.close(() =>
+      writeCheck({ ok: true, port, secret: mode === 'legacy' ? 'old-secret' : '***', version: 'test' }),
+    )
+  })
+} else {
+  if (args[0] !== 'grpc' || !password || args.includes('--transport')) process.exit(8)
+  const server = new grpc.Server()
+  server.addService(Yak.service, {
+    Echo(call, done) {
+      if (scenario === 'slow-rpc') return
+      if (scenario === 'wrong-auth' || call.metadata.get('authorization')[0] !== `bearer ${password}`) {
+        return done({ code: grpc.status.UNAUTHENTICATED, details: 'Invalid credentials' })
+      }
+      done(null, { result: call.request.text })
+    },
+  })
+  server.bindAsync(`127.0.0.1:${port}`, grpc.ServerCredentials.createInsecure(), (error) => {
+    if (error) {
+      process.stdout.write('yak grpc failed {"phase":"listen","reasonCode":"tcp_bind_in_use"}\n')
+      process.exitCode = 1
+      clearTimeout(budget)
+      return
+    }
+    server.start()
+    if (mode !== 'legacy' && scenario !== 'quiet') {
+      const event = JSON.stringify({
+        schemaVersion: mode === 'v1' ? 1 : 2,
+        address: `127.0.0.1:${port}`,
+        transport: scenario === 'wrong-transport' ? 'unix' : 'tcp',
+      })
+      // Deliberately split protocol output across writes, including CRLF.
+      process.stdout.write('yak grpc rea')
+      process.stdout.write(`dy ${event}\r\n`)
+    }
+    process.stdout.write(`{"secret":"${password}"}\n`)
+  })
+}

--- a/scripts/engine-startup/fixtures/engine.cjs
+++ b/scripts/engine-startup/fixtures/engine.cjs
@@ -49,7 +49,10 @@ if (scenario === 'hang') {
   server.addService(Yak.service, {
     Echo(call, done) {
       if (scenario === 'slow-rpc') return
-      if (scenario === 'wrong-auth' || call.metadata.get('authorization')[0] !== `bearer ${password}`) {
+      if (
+        scenario !== 'unauthenticated' &&
+        (scenario === 'wrong-auth' || call.metadata.get('authorization')[0] !== `bearer ${password}`)
+      ) {
         return done({ code: grpc.status.UNAUTHENTICATED, details: 'Invalid credentials' })
       }
       done(null, { result: call.request.text })

--- a/scripts/engine-startup/grpc.cjs
+++ b/scripts/engine-startup/grpc.cjs
@@ -1,0 +1,14 @@
+const grpc = require('@grpc/grpc-js')
+const loader = require('@grpc/proto-loader')
+const path = require('node:path')
+
+// Use the shipped protobuf and the same gRPC implementation as the desktop app.
+const definition = loader.loadSync(path.join(__dirname, '../../app/protos/grpc.proto'), {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+})
+const { Yak } = grpc.loadPackageDefinition(definition).ypb
+module.exports = { grpc, Yak }

--- a/scripts/engine-startup/verify-legacy-client.cjs
+++ b/scripts/engine-startup/verify-legacy-client.cjs
@@ -1,0 +1,184 @@
+// Run the unmodified old Yakit IPC module against a real, explicitly supplied engine.
+// Usage: node verify-legacy-client.cjs /absolute/legacy/newEngineStatus.js /absolute/yak
+const assert = require('node:assert/strict')
+const fs = require('node:fs/promises')
+const vm = require('node:vm')
+const { EventEmitter } = require('node:events')
+const os = require('node:os')
+const path = require('node:path')
+const net = require('node:net')
+const childProcess = require('node:child_process')
+const { setTimeout: delay } = require('node:timers/promises')
+const { createEngineGrpcClient } = require('../../app/main/handlers/utils/engineGrpcClient')
+const { stopEngineChild } = require('../../app/main/handlers/utils/engineStartup')
+const { grpc, Yak } = require('./grpc.cjs')
+
+async function main() {
+  const [sourcePath, binary] = process.argv.slice(2)
+  assert(path.isAbsolute(sourcePath) && path.isAbsolute(binary), 'Supply absolute source and engine paths')
+  const source = await fs.readFile(sourcePath, 'utf8')
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'Yakit legacy client '))
+  const children = [],
+    clients = [],
+    timers = new Set(),
+    handlers = new Map()
+  let connection
+  const dependencies = {
+    electron: { ipcMain: { handle: (name, handler) => handlers.set(name, handler) } },
+    child_process: {
+      ...childProcess,
+      spawn: (...args) => {
+        const child = childProcess.spawn(...args)
+        children.push(child)
+        return child
+      },
+    },
+    '../state': { GLOBAL_YAK_SETTING: {} },
+    '../filePath': { getLocalYaklangEngine: () => binary, getYakitHome: () => home },
+    '../logFile': { engineLogOutputFileAndUI: () => {}, engineLogOutputUI: () => {} },
+  }
+  const context = {
+    module: { exports: {} },
+    require: (name) => {
+      assert(Object.hasOwn(dependencies, name), `Unexpected legacy dependency ${name}`)
+      return dependencies[name]
+    },
+    process: Object.assign(new EventEmitter(), {
+      platform: process.platform,
+      kill: process.kill.bind(process),
+      env: {
+        ...process.env,
+        YAKIT_HOME: home,
+        YAK_DEFAULT_PROJECT_DATABASE_NAME: path.join(home, 'project.db'),
+        YAK_DEFAULT_PROFILE_DATABASE_NAME: path.join(home, 'profile.db'),
+        SSA_DATABASE_RAW: path.join(home, 'ssa.db'),
+      },
+    }),
+    Buffer,
+    // grpc-js validates deadlines with instanceof Date across the VM boundary.
+    Date,
+    setTimeout: (...args) => {
+      const timer = setTimeout(...args)
+      timers.add(timer)
+      return timer
+    },
+    clearTimeout,
+    setInterval: (...args) => {
+      const timer = setInterval(...args)
+      timers.add(timer)
+      return timer
+    },
+    clearInterval,
+  }
+  const makeClient = () => {
+    const client = createEngineGrpcClient(Yak, connection)
+    clients.push(client)
+    return client
+  }
+  vm.runInNewContext(source, context, { filename: sourcePath })
+  context.module.exports.registerNewIPC(
+    { webContents: { send: () => {} } },
+    (address, caPem, password) => {
+      connection = { defaultYakGRPCAddr: address, caPem, password }
+    },
+    makeClient,
+    makeClient,
+    'legacy:',
+  )
+  const invoke = (name, params) => handlers.get('legacy:' + name)({}, params)
+  const reserve = async () => {
+    const server = net.createServer()
+    await new Promise((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    return server
+  }
+  const echo = (password) => {
+    const client = createEngineGrpcClient(Yak, { ...connection, password })
+    return new Promise((resolve) =>
+      client.Echo({ text: 'legacy compatibility' }, { deadline: new Date(Date.now() + 3000) }, (error, data) => {
+        client.close()
+        resolve({ error, data })
+      }),
+    )
+  }
+  let occupied
+  try {
+    const reserved = await reserve()
+    const port = reserved.address().port
+    await new Promise((resolve) => reserved.close(resolve))
+    const checked = await invoke('check-allow-secret-local-yaklang-engine', { port, softwareVersion: 'yakit' })
+    assert.equal(checked.ok, true, `legacy check: ${checked.status}: ${checked.message}`)
+    assert.match(checked.json.secret, /^[0-9a-f]{64}$/)
+    // The legacy renderer first tries to connect, which also installs credentials
+    // in its global client settings, then starts the engine if that probe fails.
+    await assert.rejects(
+      () => invoke('connect-yaklang-engine', { Host: '127.0.0.1', Port: port, Password: checked.json.secret }),
+      (error) => /14 UNAVAILABLE/.test(String(error)),
+    )
+    const started = await invoke('start-secret-local-yaklang-engine', {
+      port,
+      password: checked.json.secret,
+      version: 'yakit',
+      softwareVersion: 'yakit',
+    })
+    assert.equal(started.ok, true, `legacy start: ${started.status}: ${started.message}`)
+    assert.equal(connection.password, checked.json.secret)
+    // The legacy renderer's keepalive retries every three seconds after its
+    // log-based startup result. Retry only transient UNAVAILABLE responses;
+    // never hide an authentication error or an indefinitely unavailable engine.
+    let positive = await echo(checked.json.secret)
+    let readinessRetries = 0
+    while (positive.error?.code === grpc.status.UNAVAILABLE && readinessRetries < 9) {
+      readinessRetries++
+      await delay(3000)
+      positive = await echo(checked.json.secret)
+    }
+    assert.equal(positive.data?.result, 'legacy compatibility', positive.error?.message)
+    await invoke('connect-yaklang-engine', { Host: '127.0.0.1', Port: port, Password: checked.json.secret })
+    assert.equal((await echo('')).error?.code, grpc.status.UNAUTHENTICATED)
+    const masked = await echo('***')
+    assert(masked.error && /secret verify failed/.test(masked.error.details))
+    occupied = await reserve()
+    const failure = await invoke('check-allow-secret-local-yaklang-engine', {
+      port: occupied.address().port,
+      softwareVersion: 'yakit',
+    })
+    assert.equal(failure.status, 'port_occupied')
+    assert(occupied.listening)
+    process.stdout.write(
+      JSON.stringify(
+        {
+          legacySource: sourcePath,
+          binary,
+          platform: process.platform,
+          randomCredential: 'passed',
+          authenticatedStartup: 'passed',
+          readinessRetries,
+          anonymousAndMaskDenied: 'passed',
+          legacyPortRecovery: 'passed',
+        },
+        null,
+        2,
+      ) + '\n',
+    )
+  } finally {
+    for (const timer of timers) {
+      clearTimeout(timer)
+      clearInterval(timer)
+    }
+    for (const client of clients) client.close()
+    await Promise.all(children.map((child) => stopEngineChild(child)))
+    assert(
+      children.every((child) => child.exitCode !== null || child.signalCode !== null),
+      'Legacy test left an engine running',
+    )
+    if (occupied) await new Promise((resolve) => occupied.close(resolve))
+    await fs.rm(home, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 })
+  }
+}
+main().catch((error) => {
+  console.error(error.message)
+  process.exitCode = 1
+})

--- a/scripts/engine-startup/verify-real-engine.cjs
+++ b/scripts/engine-startup/verify-real-engine.cjs
@@ -1,0 +1,107 @@
+// Usage: node scripts/engine-startup/verify-real-engine.cjs /absolute/path/to/yak [another/yak]
+// Only explicitly supplied binaries are executed. Each gets a disposable home and databases.
+const assert = require('node:assert/strict')
+const fs = require('node:fs/promises')
+const path = require('node:path')
+const os = require('node:os')
+const net = require('node:net')
+const { createHash } = require('node:crypto')
+const { createEngineStartup } = require('../../app/main/handlers/utils/engineStartup')
+const { createEngineGrpcClient } = require('../../app/main/handlers/utils/engineGrpcClient')
+const { grpc, Yak } = require('./grpc.cjs')
+
+const listen = () =>
+  new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolve(server))
+  })
+const close = (server) => new Promise((resolve) => server.close(resolve))
+async function verify(binary) {
+  assert(path.isAbsolute(binary), 'Supply an absolute engine path')
+  const sha256 = createHash('sha256')
+    .update(await fs.readFile(binary))
+    .digest('hex')
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'Yakit real engine 空格 '))
+  let committed
+  const logs = []
+  const manager = createEngineStartup({
+    getCommand: () => binary,
+    getEnv: () => ({
+      ...process.env,
+      YAKIT_HOME: home,
+      YAK_DEFAULT_PROJECT_DATABASE_NAME: path.join(home, 'project.db'),
+      YAK_DEFAULT_PROFILE_DATABASE_NAME: path.join(home, 'profile.db'),
+      SSA_DATABASE_RAW: path.join(home, 'ssa.db'),
+    }),
+    createClient: (connection) => createEngineGrpcClient(Yak, connection, { 'grpc.enable_http_proxy': 0 }),
+    commitConnection: (connection) => {
+      committed = connection
+    },
+    log: (line) => logs.push(line),
+  })
+  let occupied
+  try {
+    const reserved = await listen()
+    const port = reserved.address().port
+    await close(reserved)
+    const checked = await manager.check({ port })
+    assert.equal(checked.ok, true, checked.message)
+    assert.match(checked.json.secret, /^[a-f0-9]{64}$/)
+    const started = await manager.start({ port, password: checked.json.secret, version: 'yakit' })
+    assert.equal(started.ok, true, started.message)
+    assert.equal(committed.password, checked.json.secret)
+    const auth = []
+    for (const [label, password] of [
+      ['correct', committed.password],
+      ['empty', ''],
+      ['mask', '***'],
+      ['wrong', 'wrong'],
+    ]) {
+      const client = createEngineGrpcClient(Yak, { ...committed, password })
+      const result = await new Promise((resolve) =>
+        client.Echo({ text: 'compatibility' }, { deadline: new Date(Date.now() + 3000) }, (error, data) => {
+          client.close()
+          resolve({ error, data })
+        }),
+      )
+      if (label === 'correct') assert.equal(result.data?.result, 'compatibility')
+      else if (label === 'empty') assert.equal(result.error?.code, grpc.status.UNAUTHENTICATED)
+      else {
+        assert([grpc.status.UNKNOWN, grpc.status.UNAUTHENTICATED].includes(result.error?.code))
+        assert.match(result.error.details, /secret verify failed/i)
+      }
+      auth.push({ credential: label, code: result.error?.code || 0 })
+    }
+    assert(!logs.join('\n').includes(checked.json.secret), 'Production password leaked into logs')
+    await manager.dispose()
+    occupied = await listen()
+    const conflict = await manager.check({ port: occupied.address().port })
+    assert.equal(conflict.status, 'port_occupied')
+    assert.equal(occupied.listening, true)
+    return {
+      binary,
+      sha256,
+      check: 'passed',
+      authenticatedStart: 'passed',
+      auth,
+      secretRedaction: 'passed',
+      portConflictRecovery: 'passed',
+      cleanup: 'passed',
+    }
+  } finally {
+    await manager.dispose()
+    if (occupied) await close(occupied)
+    await fs.rm(home, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 })
+  }
+}
+async function main() {
+  assert(process.argv.length > 2, 'Supply at least one engine binary')
+  const results = []
+  for (const binary of process.argv.slice(2)) results.push(await verify(binary))
+  process.stdout.write(JSON.stringify({ platform: process.platform, node: process.version, results }, null, 2) + '\n')
+}
+main().catch((error) => {
+  console.error(error.message)
+  process.exitCode = 1
+})

--- a/scripts/engine-startup/verify-real-engine.cjs
+++ b/scripts/engine-startup/verify-real-engine.cjs
@@ -10,11 +10,11 @@ const { createEngineStartup } = require('../../app/main/handlers/utils/engineSta
 const { createEngineGrpcClient } = require('../../app/main/handlers/utils/engineGrpcClient')
 const { grpc, Yak } = require('./grpc.cjs')
 
-const listen = () =>
+const listen = (port = 0) =>
   new Promise((resolve, reject) => {
     const server = net.createServer()
     server.once('error', reject)
-    server.listen(0, '127.0.0.1', () => resolve(server))
+    server.listen(port, '127.0.0.1', () => resolve(server))
   })
 const close = (server) => new Promise((resolve) => server.close(resolve))
 async function verify(binary) {
@@ -75,7 +75,9 @@ async function verify(binary) {
     }
     assert(!logs.join('\n').includes(checked.json.secret), 'Production password leaked into logs')
     await manager.dispose()
-    occupied = await listen()
+    // Rebinding the *same* port proves disposal released the running engine.
+    // Reserving a different free port could hide a leaked child process.
+    occupied = await listen(port)
     const conflict = await manager.check({ port: occupied.address().port })
     assert.equal(conflict.status, 'port_occupied')
     assert.equal(occupied.listening, true)

--- a/scripts/engine-startup/verify-real-engine.cjs
+++ b/scripts/engine-startup/verify-real-engine.cjs
@@ -74,13 +74,45 @@ async function verify(binary) {
       auth.push({ credential: label, code: result.error?.code || 0 })
     }
     assert(!logs.join('\n').includes(checked.json.secret), 'Production password leaked into logs')
-    await manager.dispose()
+    assert.equal((await manager.dispose()).ok, true, 'Owned engine cleanup failed')
     // Rebinding the *same* port proves disposal released the running engine.
     // Reserving a different free port could hide a leaked child process.
     occupied = await listen(port)
     const conflict = await manager.check({ port: occupied.address().port })
     assert.equal(conflict.status, 'port_occupied')
     assert.equal(occupied.listening, true)
+    await close(occupied)
+    occupied = null
+
+    // A failed RPC can coexist with a live owned engine. Exercise both user
+    // recovery choices: restart on the same port and switch to another port.
+    let recoveryPort = port
+    let previousSecret = checked.json.secret
+    for (const changePort of [false, true]) {
+      const recoveryCheck = await manager.check({ port: recoveryPort })
+      assert.equal(recoveryCheck.ok, true, recoveryCheck.message)
+      assert.notEqual(recoveryCheck.json.secret, previousSecret)
+      previousSecret = recoveryCheck.json.secret
+      const recoveryStart = await manager.start({ port: recoveryPort, password: previousSecret })
+      assert.equal(recoveryStart.ok, true, recoveryStart.message)
+      const failedConnection = await manager.connect({ ...committed, password: 'wrong-recovery-credential' })
+      assert.equal(failedConnection.ok, false)
+      assert.equal((await manager.check({ port: recoveryPort })).status, 'port_occupied')
+      assert.deepEqual(await manager.dispose(), { ok: true, canceled: 1, status: 'cancelled' })
+      const released = await listen(recoveryPort)
+      await close(released)
+      if (changePort) {
+        const nextPort = await listen()
+        recoveryPort = nextPort.address().port
+        await close(nextPort)
+      }
+    }
+    const finalCheck = await manager.check({ port: recoveryPort })
+    assert.equal(finalCheck.ok, true, finalCheck.message)
+    assert.notEqual(finalCheck.json.secret, previousSecret)
+    assert.equal((await manager.start({ port: recoveryPort, password: finalCheck.json.secret })).ok, true)
+    assert(!logs.join('\n').includes(finalCheck.json.secret), 'Recovery password leaked into logs')
+    assert.equal((await manager.dispose()).ok, true)
     return {
       binary,
       sha256,
@@ -90,6 +122,7 @@ async function verify(binary) {
       secretRedaction: 'passed',
       portConflictRecovery: 'passed',
       cleanup: 'passed',
+      ownedEngineRecovery: 'passed',
     }
   } finally {
     await manager.dispose()

--- a/scripts/engine-startup/vitest.config.mts
+++ b/scripts/engine-startup/vitest.config.mts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  test: {
+    root: fileURLToPath(new URL('../..', import.meta.url)),
+    environment: 'node',
+    globals: true,
+    include: ['app/main/handlers/utils/__test__/engine*.test.js'],
+    fileParallelism: false,
+    maxWorkers: 1,
+    testTimeout: 15000,
+    hookTimeout: 15000,
+  },
+})


### PR DESCRIPTION
兼容旧引擎和新引擎的启动协议，修复启动误报成功、取消后残留进程和失败后无法正确重试的问题。配套引擎修复见 yaklang/yaklang#5043。

## 启动与故障恢复

- 本地启动沿用经过认证的 loopback TCP 参数，不向旧引擎发送 IPC flags。为每次检查生成新的随机凭证，并拒绝空密码、掩码密码和非法端口。
- 启动成功必须满足：使用当前凭证的 Echo 成功，同时匿名 Echo 返回未认证。日志和 ready 事件只提供进度与诊断，不能单独确认成功。只有当前操作完成验证后才提交全局连接设置。
- 检查、启动和连接统一管理超时、取消、临时 RPC 客户端及所属子进程。切换连接等待旧操作清理；迟到的回调不能覆盖新状态。Windows 使用有限时的 `taskkill.exe` 清理本次启动的进程树，不按端口或进程名终止其他进程。
- 按行解析分块 UTF-8 输出，兼容新结构化事件及旧错误数组，限制输出大小，并脱敏凭证。端口占用、权限、数据库和未知故障均保留可用的恢复入口。
- 自检失败后的重试先重新检查，不会使用过期或空凭证直接启动。前端屏蔽旧检查和连接的迟到结果，取消后等待主进程确认再允许下一次操作。

## 验证

- 主进程测试：本地 48 通过，1 项 Windows 专属进程树测试在 macOS 跳过。
- 启动页测试：55 通过；Link TypeScript、三种语言键一致性和生产构建通过。
- 真实旧引擎与修复引擎均通过新客户端的检查、认证启动、空/错误/掩码凭证拒绝、日志脱敏、端口冲突及清理实验。修复引擎也在 Electron 27 内置 Node 18.17.1 下通过。
- 旧 Yakit 原始 IPC 模块对修复引擎连续验证 3 次通过，覆盖先连接、启动、探活和端口占用。脚本保留旧客户端每 3 秒重试短暂 `UNAVAILABLE` 的行为，不把认证失败当作可忽略错误。
- 客户端 CI 覆盖 Windows/macOS/Linux 生命周期与真实 TCP 测试、启动页恢复，以及 Windows 构建并运行固定版本的旧/新引擎。上一版客户端提交的所有任务已通过；当前 Windows 实验已将新引擎固定到修复提交 `4f7863298e6cabdeb4ad25e7321743d6a93dd2a3`。

实验命令、测试范围和基线版本见 [`scripts/engine-startup/README.md`](scripts/engine-startup/README.md)。验证范围为启动、认证和故障恢复，尚未执行完整打包 Electron GUI 的交互验收。

## 改动类型

- [x] Bug 修复
- [x] 测试改动
- [x] 文档改动
- [x] CI 流程改动
