### PR TITLE
fix: 修复 AI Markdown 公式渲染缺失 KaTeX 样式

### DIFF
--- a/app/renderer/src/main/src/pages/assetViewer/reportRenders/markdownRender.tsx
+++ b/app/renderer/src/main/src/pages/assetViewer/reportRenders/markdownRender.tsx
@@ -11,6 +11,7 @@ import { CopyComponents } from '@/components/yakitUI/YakitTag/YakitTag'
 import { code } from '@streamdown/code'
 import { mermaid } from '@streamdown/mermaid'
 import { math } from '@streamdown/math'
+import 'katex/dist/katex.min.css'
 import rehypeSlug from 'rehype-slug'
 import { yakitNotify } from '@/utils/notification'
 


### PR DESCRIPTION
## 摘要

AI 对话 Markdown 渲染中公式块缺少 KaTeX 样式，导致公式排版错乱。为 `markdownRender.tsx` 补充引入 `katex/dist/katex.min.css`，使 `@streamdown/math` 渲染的公式获得正确样式。

## 改动内容

- `app/renderer/src/main/src/pages/assetViewer/reportRenders/markdownRender.tsx`：新增 `import 'katex/dist/katex.min.css'`

## 测试

- [x] 本地启动 AI 对话发送含 LaTeX 公式的 Markdown 内容，确认行内公式与块级公式渲染样式正常
- [x] PR CI 全部通过（i18n / ESLint / TypeScript / Prettier / 图片视频体积检查）

## 合并方式

使用 Rebase and merge（线性历史）方式合并