### PR TITLE
luoluo/refactor/ai-ui

### DIFF
--- a/app/renderer/engine-link-startup/package.json
+++ b/app/renderer/engine-link-startup/package.json
@@ -18,7 +18,7 @@
     "@ant-design/icons": "^5.6.1",
     "@xterm/addon-fit": "^0.10.0",
     "@yakit-libs/color": "1.4.1",
-    "@yakit-libs/yakit-ui-icons": "0.2.3",
+    "@yakit-libs/yakit-ui-icons": "0.2.5",
     "ahooks": "3.7.9",
     "antd": "5.29.2",
     "buffer": "^6.0.3",

--- a/app/renderer/engine-link-startup/src/theme/componentsTheme/notification.scss
+++ b/app/renderer/engine-link-startup/src/theme/componentsTheme/notification.scss
@@ -6,7 +6,7 @@
   .yakit-notification-failed,
   .yakit-notification-error {
     background: var(--Colors-Use-Basic-Background);
-    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow, rgba(23, 23, 23, 0.08));
+    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow);
     padding: 0;
     border-radius: 4px;
 
@@ -36,7 +36,7 @@
 
   .yakit-notification-success {
     background: var(--Colors-Use-Basic-Background);
-    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow, rgba(23, 23, 23, 0.08));
+    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow);
     padding: 0;
     border-radius: 4px;
 
@@ -66,7 +66,7 @@
 
   .yakit-notification-warning {
     background: var(--Colors-Use-Basic-Background);
-    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow, rgba(23, 23, 23, 0.08));
+    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow);
     padding: 0;
     border-radius: 4px;
 
@@ -96,7 +96,7 @@
 
   .yakit-notification-info {
     background: var(--Colors-Use-Basic-Background);
-    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow, rgba(23, 23, 23, 0.08));
+    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow);
     padding: 0;
     border-radius: 4px;
 

--- a/app/renderer/engine-link-startup/yarn.lock
+++ b/app/renderer/engine-link-startup/yarn.lock
@@ -1013,10 +1013,10 @@
   resolved "https://registry.npmjs.org/@yakit-libs/color/-/color-1.4.1.tgz#876a8314dab6bd9d83256eff6ab768a228c89f4a"
   integrity sha512-RK/Qm8IUaLrCBgfYn33411qpTu3JQ07EHc7jFYfeUxALDhwo4JqxST60CkOS2Mx0EY13mJLg6f/o7yPI+oe+Qw==
 
-"@yakit-libs/yakit-ui-icons@0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@yakit-libs/yakit-ui-icons/-/yakit-ui-icons-0.2.3.tgz#ece76295c7af368ba9da63801103f8485d534aa8"
-  integrity sha512-boSNuvUdgE/4FEG2ZBXFCul8CFKPd0PAmAq/6FRZIL35Dx6qiXfu2j/L0wgS7GG34nVnONbGd4oDSNIexoaFyQ==
+"@yakit-libs/yakit-ui-icons@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@yakit-libs/yakit-ui-icons/-/yakit-ui-icons-0.2.5.tgz#779a1ce91bef3521ee720f9be5ff109abfc82018"
+  integrity sha512-5zTl4rPkT3K2FsUJws7faIPbcUlOj4Bvu3Ci7lWhqXjInXT4U22Io/1KjccMcIza+Og1lC9aQBjekmk0JmB+LA==
   dependencies:
     "@yakit-libs/color" "1.4.1"
 

--- a/app/renderer/src/main/package.json
+++ b/app/renderer/src/main/package.json
@@ -33,7 +33,7 @@
     "@viz-js/viz": "^3.7.0",
     "@xterm/addon-fit": "^0.10.0",
     "@yakit-libs/color": "1.4.1",
-    "@yakit-libs/yakit-ui-icons": "0.2.3",
+    "@yakit-libs/yakit-ui-icons": "0.2.5",
     "ahooks": "3.7.9",
     "ali-react-table": "2.6.1",
     "antd": "5.29.2",

--- a/app/renderer/src/main/src/components/layout/FuncDomain.tsx
+++ b/app/renderer/src/main/src/components/layout/FuncDomain.tsx
@@ -1,15 +1,11 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Badge, Tooltip, Form, Divider } from 'antd'
-import { RiskStateSvgIcon } from '@yakit-libs/yakit-ui-icons/oldicon/RiskStateSvgIcon'
 import { UISettingSvgIcon } from '@yakit-libs/yakit-ui-icons/oldicon/UISettingSvgIcon'
 import { VersionUpdateSvgIcon } from '@yakit-libs/yakit-ui-icons/oldicon/VersionUpdateSvgIcon'
 import { YakitEllipsis } from '../basics/YakitEllipsis'
 import { useCreation, useDebounceEffect, useMemoizedFn, useUpdateEffect } from 'ahooks'
 import { showModal } from '@/utils/showModal'
 import { failed, info, yakitFailed, warn, yakitNotify } from '@/utils/notification'
-const ConfigPrivateDomain = React.lazy(() =>
-  import('../ConfigPrivateDomain/ConfigPrivateDomain').then((m) => ({ default: m.ConfigPrivateDomain })),
-)
 import { ConfigGlobalReverse } from '@/utils/ConfigGlobalReverse'
 import type { YakitSettingCallbackType, YakitSystem, YaklangEngineMode } from '@/yakitGVDefine'
 import { showConfigSystemProxyForm } from '@/utils/ConfigSystemProxy'
@@ -43,15 +39,9 @@ import { YakitInput } from '../yakitUI/YakitInput/YakitInput'
 import { NetWorkApi } from '@/services/fetch'
 import type { API } from '@/services/swagger/resposeType'
 import { addToTab } from '@/pages/MainTabs'
-const DatabaseUpdateModal = React.lazy(() =>
-  import('@/pages/cve/CVETable').then((m) => ({ default: m.DatabaseUpdateModal })),
-)
 import LoadingOutlined from '@ant-design/icons/lib/icons/LoadingOutlined'
 import { showYakitModal } from '../yakitUI/YakitModal/YakitModalConfirm'
 import { WinKeyborad } from '../yakitUI/YakitEditor/keyboardConstants'
-const ScrecorderModal = React.lazy(() =>
-  import('@/pages/screenRecorder/ScrecorderModal').then((m) => ({ default: m.ScrecorderModal })),
-)
 import { useScreenRecorder } from '@/store/screenRecorder'
 import { YakitRoute } from '@/enums/yakitRoute'
 import { useRunNodeStore } from '@/store/runNode'
@@ -67,7 +57,17 @@ import {
   Wrench1Outlined,
   CloudDownloadOutlined,
   TerminalOutlined,
+  BugOutlined,
 } from '@yakit-libs/yakit-ui-icons/outline'
+const ConfigPrivateDomain = React.lazy(() =>
+  import('../ConfigPrivateDomain/ConfigPrivateDomain').then((m) => ({ default: m.ConfigPrivateDomain })),
+)
+const DatabaseUpdateModal = React.lazy(() =>
+  import('@/pages/cve/CVETable').then((m) => ({ default: m.DatabaseUpdateModal })),
+)
+const ScrecorderModal = React.lazy(() =>
+  import('@/pages/screenRecorder/ScrecorderModal').then((m) => ({ default: m.ScrecorderModal })),
+)
 
 import { YakitEmpty } from '../yakitUI/YakitEmpty/YakitEmpty'
 import { type DebugPluginRequest, apiDebugPlugin } from '@/pages/plugins/utils'
@@ -75,12 +75,6 @@ import type { YakExecutorParam } from '@/pages/invoker/YakExecutorParams'
 import useHoldGRPCStream from '@/hook/useHoldGRPCStream/useHoldGRPCStream'
 import { type PerformanceSamplingLog, usePerformanceSampling } from '@/store/performanceSampling'
 import { isShowCodeScanDetail } from '@/pages/risks/YakitRiskTable/riskTableUtils'
-const YakitCodeScanRiskDetails = React.lazy(() =>
-  import('@/pages/risks/YakitRiskTable/YakitRiskTable').then((m) => ({ default: m.YakitCodeScanRiskDetails })),
-)
-const YakitRiskDetails = React.lazy(() =>
-  import('@/pages/risks/YakitRiskTable/YakitRiskTable').then((m) => ({ default: m.YakitRiskDetails })),
-)
 import { GitHubSolid, PlaySolid, UserCircleSolid, YakitSolid } from '@yakit-libs/yakit-ui-icons/solid'
 import type { YakParamProps } from '@/pages/plugins/pluginsType'
 import type { CustomPluginExecuteFormValue } from '@/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeardType'
@@ -96,40 +90,22 @@ import {
   grpcFetchLocalYakVersion,
 } from '@/apiUtils/grpc'
 import { WebsiteGV } from '@/enums/website'
+const YakitCodeScanRiskDetails = React.lazy(() =>
+  import('@/pages/risks/YakitRiskTable/YakitRiskTable').then((m) => ({ default: m.YakitCodeScanRiskDetails })),
+)
+const YakitRiskDetails = React.lazy(() =>
+  import('@/pages/risks/YakitRiskTable/YakitRiskTable').then((m) => ({ default: m.YakitRiskDetails })),
+)
 
 import YakitLogo from '@/assets/yakitLogo.png'
 import yakitImg from '../../assets/yakit.jpg'
 import classNames from 'classnames'
 import styles from './funcDomain.module.scss'
 import { useEETaskNotificationHook } from '../MessageCenter/useEETaskNotificationHook'
-const MessageCenter = React.lazy(() =>
-  import('../MessageCenter/MessageCenter').then((m) => ({ default: m.MessageCenter })),
-)
-const TaskNotification = React.lazy(() =>
-  import('../MessageCenter/MessageCenter').then((m) => ({ default: m.TaskNotification })),
-)
-const TaskErrNotification = React.lazy(() =>
-  import('../MessageCenter/MessageCenter').then((m) => ({ default: m.TaskErrNotification })),
-)
 import { apiFetchMessageRead, apiFetchQueryMessage } from '../MessageCenter/utils'
 import { YakitRadioButtons } from '../yakitUI/YakitRadioButtons/YakitRadioButtons'
 import { randomString } from '@/utils/randomUtil'
 import type { ExpandAndRetractExcessiveState } from '@/pages/plugins/operator/expandAndRetract/ExpandAndRetract'
-const PluginExecuteResult = React.lazy(() =>
-  import('@/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult').then((m) => ({
-    default: m.PluginExecuteResult,
-  })),
-)
-const ExecuteEnterNodeByPluginParams = React.lazy(() =>
-  import('@/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard').then((m) => ({
-    default: m.ExecuteEnterNodeByPluginParams,
-  })),
-)
-const PluginExecuteProgress = React.lazy(() =>
-  import('@/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard').then((m) => ({
-    default: m.PluginExecuteProgress,
-  })),
-)
 import { YakitHint } from '../yakitUI/YakitHint/YakitHint'
 import {
   apiNewRiskRead,
@@ -140,14 +116,8 @@ import type {
   QueryNewSSARisksResponse,
   SSARisk,
 } from '@/pages/yakRunnerAuditHole/YakitAuditHoleTable/YakitAuditHoleTableType'
-const YakitAuditRiskDetails = React.lazy(() =>
-  import('@/pages/yakRunnerAuditHole/YakitAuditHoleTable/YakitAuditHoleTable').then((m) => ({
-    default: m.YakitAuditRiskDetails,
-  })),
-)
 import type { ShortcutKeyPageName } from '@/utils/globalShortcutKey/events/pageMaps'
 import type { mcpStreamHooks } from './hooks/useMcp/useMcp'
-const ConfigMcpModal = React.lazy(() => import('@/utils/ConfigSystemMcp').then((m) => ({ default: m.ConfigMcpModal })))
 import { useCampare } from '@/hook/useCompare/useCompare'
 import { openConsoleNewWindow } from '@/utils/openWebsite'
 import useEngineConsole from './hooks/useEngineConsole/useEngineConsole'
@@ -163,6 +133,36 @@ import { syncAppSettings } from '@/auxWindow/utils/messaging'
 import { yakitApp, yakitEngine, yakitRisk, yakitShell, yakitStream, yakitUILayout } from '@/services/electronBridge'
 import { CeUserMenuContent } from '../CeUserMenu/CeUserMenu'
 import CeRechargeModal from '../CeUserMenu/CeRechargeModal'
+const MessageCenter = React.lazy(() =>
+  import('../MessageCenter/MessageCenter').then((m) => ({ default: m.MessageCenter })),
+)
+const TaskNotification = React.lazy(() =>
+  import('../MessageCenter/MessageCenter').then((m) => ({ default: m.TaskNotification })),
+)
+const TaskErrNotification = React.lazy(() =>
+  import('../MessageCenter/MessageCenter').then((m) => ({ default: m.TaskErrNotification })),
+)
+const PluginExecuteResult = React.lazy(() =>
+  import('@/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult').then((m) => ({
+    default: m.PluginExecuteResult,
+  })),
+)
+const ExecuteEnterNodeByPluginParams = React.lazy(() =>
+  import('@/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard').then((m) => ({
+    default: m.ExecuteEnterNodeByPluginParams,
+  })),
+)
+const PluginExecuteProgress = React.lazy(() =>
+  import('@/pages/plugins/operator/localPluginExecuteDetailHeard/LocalPluginExecuteDetailHeard').then((m) => ({
+    default: m.PluginExecuteProgress,
+  })),
+)
+const YakitAuditRiskDetails = React.lazy(() =>
+  import('@/pages/yakRunnerAuditHole/YakitAuditHoleTable/YakitAuditHoleTable').then((m) => ({
+    default: m.YakitAuditRiskDetails,
+  })),
+)
+const ConfigMcpModal = React.lazy(() => import('@/utils/ConfigSystemMcp').then((m) => ({ default: m.ConfigMcpModal })))
 
 // ===== 用户功能菜单拆分模块导入 =====
 import { randomAvatarColor } from './userMenu/constants'
@@ -2790,7 +2790,9 @@ const UIOpRisk: React.FC<UIOpRiskProp> = React.memo((props) => {
       <div className={styles['ui-op-btn-wrapper']}>
         <div className={classNames(styles['op-btn-body'], { [styles['op-btn-body-hover']]: show })}>
           <Badge count={risks.NewRiskTotal} offset={[2, 15]}>
-            <RiskStateSvgIcon className={show ? styles['icon-hover-style'] : styles['icon-style']} />
+            <BugOutlined
+              className={classNames(styles['size-style'], show ? styles['icon-hover-style'] : styles['icon-style'])}
+            />
           </Badge>
         </div>
       </div>
@@ -3041,7 +3043,9 @@ const UIOpIRifyRisk: React.FC<UIOpRiskProp> = React.memo((props) => {
       <div className={styles['ui-op-btn-wrapper']}>
         <div className={classNames(styles['op-btn-body'], { [styles['op-btn-body-hover']]: show })}>
           <Badge count={risks.NewRiskTotal} offset={[2, 15]}>
-            <RiskStateSvgIcon className={show ? styles['icon-hover-style'] : styles['icon-style']} />
+            <BugOutlined
+              className={classNames(styles['size-style'], show ? styles['icon-hover-style'] : styles['icon-style'])}
+            />
           </Badge>
         </div>
       </div>

--- a/app/renderer/src/main/src/components/yakitUI/YakitCollapse/YakitCollapse.module.scss
+++ b/app/renderer/src/main/src/components/yakitUI/YakitCollapse/YakitCollapse.module.scss
@@ -17,7 +17,7 @@
         font-weight: 500;
         line-height: 16px; /* 133.333% */
       }
-      .ant-collapse-arrow {
+      .ant-collapse-header .ant-collapse-expand-icon .ant-collapse-arrow {
         width: 16px;
         height: 16px;
         color: var(--Colors-Use-Neutral-Text-4-Help-text);

--- a/app/renderer/src/main/src/locales/en/aiAgent.json
+++ b/app/renderer/src/main/src/locales/en/aiAgent.json
@@ -69,9 +69,7 @@
     "configTitle": "AI Model Not Configured",
     "toConfigure": "Go to Configure",
     "configDesc": "No available AI model found. Please configure one before use.",
-    "openModelTabSuccess": "AI sidebar model configuration opened",
-    "selectModel": "Select AI Model",
-    "openConfigTooltip": "Open AI sidebar model configuration"
+    "selectModel": "Select AI Model"
   },
   "AIModelList": {
     "onlineTooltip": "Access models via API, receive AI info or send messages to AI, multiple configurations possible.",
@@ -344,7 +342,6 @@
     "session": "Session",
     "historyChat": "History Chat",
     "scheduled": "Scheduled",
-    "config": "Settings",
     "skill": "Skill",
     "tool": "Tool"
   },

--- a/app/renderer/src/main/src/locales/en/aiAgent.json
+++ b/app/renderer/src/main/src/locales/en/aiAgent.json
@@ -487,6 +487,7 @@
     "tooLarge": "The file is too large to preview"
   },
   "AIRightPanel": {
+    "aiSettings": "AI Settings",
     "taskBoard": "Task Board",
     "fileSystem": "File System",
     "traffic": "Traffic",
@@ -522,10 +523,6 @@
   },
   "AIAgentChatLayout": {
     "dockDisabledTip": "The screen is too small to dock this panel on the right"
-  },
-  "AIHorizontalScrollCard": {
-    "questionIdMissing": "currentChatStatus.questionID does not exist",
-    "taskDetailSourceMismatch": "The current session does not belong to the AIAgent data source and task details cannot be viewed"
   },
   "AIContextToken": {
     "pressure": "Context Pressure",

--- a/app/renderer/src/main/src/locales/en/aiAgent.json
+++ b/app/renderer/src/main/src/locales/en/aiAgent.json
@@ -486,6 +486,24 @@
     "warningTitle": "File Warning",
     "tooLarge": "The file is too large to preview"
   },
+  "AIRightPanel": {
+    "taskBoard": "Task Board",
+    "fileSystem": "File System",
+    "traffic": "Traffic",
+    "risk": "Risks",
+    "sessionHistory": "Session History",
+    "taskList": "Task List",
+    "timeline": "Timeline",
+    "exportLog": "Export Logs",
+    "viewLog": "View Logs",
+    "collapse": "Collapse",
+    "more": "More",
+    "duration": "Duration",
+    "toolCallStats": "Tool Call Stats",
+    "success": "Success",
+    "failed": "Failed",
+    "totalAttempts": "Total Attempts"
+  },
   "AIChatContent": {
     "noActiveChat": "There is no active session",
     "fileSystem": "File System",

--- a/app/renderer/src/main/src/locales/en/aiAgent.json
+++ b/app/renderer/src/main/src/locales/en/aiAgent.json
@@ -502,7 +502,8 @@
     "toolCallStats": "Tool Call Stats",
     "success": "Success",
     "failed": "Failed",
-    "totalAttempts": "Total Attempts"
+    "totalAttempts": "Total Attempts",
+    "running": "Running"
   },
   "AIChatContent": {
     "noActiveChat": "There is no active session",

--- a/app/renderer/src/main/src/locales/en/aiAgent.json
+++ b/app/renderer/src/main/src/locales/en/aiAgent.json
@@ -514,6 +514,9 @@
     "exportLog": "Export Log",
     "taskDetail": "Task Detail"
   },
+  "AIReActChatContents": {
+    "uiRendering": "Rendering UI..."
+  },
   "ChatSessionPane": {
     "sessionList": "Sessions"
   },

--- a/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
@@ -487,6 +487,7 @@
     "tooLarge": "檔案過大，無法預覽"
   },
   "AIRightPanel": {
+    "aiSettings": "AI 設定",
     "taskBoard": "任務詳情看板",
     "fileSystem": "檔案系統",
     "traffic": "流量",
@@ -522,10 +523,6 @@
   },
   "AIAgentChatLayout": {
     "dockDisabledTip": "螢幕過小，不支援該模組停靠在右邊"
-  },
-  "AIHorizontalScrollCard": {
-    "questionIdMissing": "currentChatStatus.questionID不存在",
-    "taskDetailSourceMismatch": "當前會話不屬於 AIAgent 資料來源，無法查看任務詳情"
   },
   "AIContextToken": {
     "pressure": "上下文壓力",

--- a/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
@@ -69,9 +69,7 @@
     "configTitle": "AI 模型未配置",
     "toConfigure": "去配置",
     "configDesc": "無可使用AI模型，請配置後使用",
-    "openModelTabSuccess": "已開啟AI側邊欄模型配置",
-    "selectModel": "AI 模型選擇",
-    "openConfigTooltip": "開啟ai側邊欄模型配置"
+    "selectModel": "AI 模型選擇"
   },
   "AIModelList": {
     "onlineTooltip": "透過api訪問模型,接受AI資訊或向AI傳送訊息,可配置多個",
@@ -344,7 +342,6 @@
     "session": "會話",
     "historyChat": "歷史會話",
     "scheduled": "定時任務",
-    "config": "配置",
     "skill": "技能",
     "tool": "工具"
   },

--- a/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
@@ -486,6 +486,24 @@
     "warningTitle": "檔案警告",
     "tooLarge": "檔案過大，無法預覽"
   },
+  "AIRightPanel": {
+    "taskBoard": "任務詳情看板",
+    "fileSystem": "檔案系統",
+    "traffic": "流量",
+    "risk": "漏洞",
+    "sessionHistory": "會話歷史",
+    "taskList": "任務列表",
+    "timeline": "時間線",
+    "exportLog": "匯出日誌",
+    "viewLog": "查看日誌",
+    "collapse": "折疊",
+    "more": "更多",
+    "duration": "執行時長",
+    "toolCallStats": "工具調用統計",
+    "success": "成功",
+    "failed": "失敗",
+    "totalAttempts": "總嘗試次數"
+  },
   "AIChatContent": {
     "noActiveChat": "當前沒有活躍的會話",
     "fileSystem": "檔案系統",

--- a/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
@@ -502,7 +502,8 @@
     "toolCallStats": "工具調用統計",
     "success": "成功",
     "failed": "失敗",
-    "totalAttempts": "總嘗試次數"
+    "totalAttempts": "總嘗試次數",
+    "running": "執行中"
   },
   "AIChatContent": {
     "noActiveChat": "當前沒有活躍的會話",

--- a/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
@@ -514,6 +514,9 @@
     "exportLog": "匯出日誌",
     "taskDetail": "任務詳情"
   },
+  "AIReActChatContents": {
+    "uiRendering": "UI渲染中..."
+  },
   "ChatSessionPane": {
     "sessionList": "會話"
   },

--- a/app/renderer/src/main/src/locales/zh/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh/aiAgent.json
@@ -487,6 +487,7 @@
     "tooLarge": "文件过大，无法预览"
   },
   "AIRightPanel": {
+    "aiSettings": "AI 设置",
     "taskBoard": "任务详情看板",
     "fileSystem": "文件系统",
     "traffic": "流量",
@@ -522,10 +523,6 @@
   },
   "AIAgentChatLayout": {
     "dockDisabledTip": "屏幕过小，不支持该模块停靠在右边"
-  },
-  "AIHorizontalScrollCard": {
-    "questionIdMissing": "currentChatStatus.questionID不存在",
-    "taskDetailSourceMismatch": "当前会话不属于 AIAgent 数据源，无法查看任务详情"
   },
   "AIContextToken": {
     "pressure": "上下文压力",

--- a/app/renderer/src/main/src/locales/zh/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh/aiAgent.json
@@ -514,6 +514,9 @@
     "exportLog": "导出日志",
     "taskDetail": "任务详情"
   },
+  "AIReActChatContents": {
+    "uiRendering": "UI渲染中..."
+  },
   "ChatSessionPane": {
     "sessionList": "会话"
   },

--- a/app/renderer/src/main/src/locales/zh/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh/aiAgent.json
@@ -69,9 +69,7 @@
     "configTitle": "AI 模型未配置",
     "toConfigure": "去配置",
     "configDesc": "无可使用AI模型，请配置后使用",
-    "openModelTabSuccess": "已打开AI侧边栏模型配置",
-    "selectModel": "AI 模型选择",
-    "openConfigTooltip": "打开ai侧边栏模型配置"
+    "selectModel": "AI 模型选择"
   },
   "AIModelList": {
     "onlineTooltip": "通过api访问模型,接受AI信息或向AI发送消息,可配置多个",
@@ -344,7 +342,6 @@
     "session": "会话",
     "historyChat": "历史",
     "scheduled": "定时任务",
-    "config": "配置",
     "skill": "技能",
     "tool": "工具"
   },

--- a/app/renderer/src/main/src/locales/zh/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh/aiAgent.json
@@ -502,7 +502,8 @@
     "toolCallStats": "工具调用统计",
     "success": "成功",
     "failed": "失败",
-    "totalAttempts": "总尝试次数"
+    "totalAttempts": "总尝试次数",
+    "running": "执行中"
   },
   "AIChatContent": {
     "noActiveChat": "当前没有活跃的会话",

--- a/app/renderer/src/main/src/locales/zh/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh/aiAgent.json
@@ -486,6 +486,24 @@
     "warningTitle": "文件警告",
     "tooLarge": "文件过大，无法预览"
   },
+  "AIRightPanel": {
+    "taskBoard": "任务详情看板",
+    "fileSystem": "文件系统",
+    "traffic": "流量",
+    "risk": "漏洞",
+    "sessionHistory": "会话历史",
+    "taskList": "任务列表",
+    "timeline": "时间线",
+    "exportLog": "导出日志",
+    "viewLog": "查看日志",
+    "collapse": "折叠",
+    "more": "更多",
+    "duration": "执行时长",
+    "toolCallStats": "工具调用统计",
+    "success": "成功",
+    "failed": "失败",
+    "totalAttempts": "总尝试次数"
+  },
   "AIChatContent": {
     "noActiveChat": "当前没有活跃的会话",
     "fileSystem": "文件系统",

--- a/app/renderer/src/main/src/pages/ai-agent/AIAgentSideList.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/AIAgentSideList.tsx
@@ -13,8 +13,6 @@ import { SplitView } from '../yakRunner/SplitView/SplitView'
 import FileTreeList from './aiChatWelcome/FileTreeList/FileTreeList'
 import type { FileNodeProps } from '@/pages/yakRunner/FileTree/FileTreeType'
 
-const AIChatSetting = React.lazy(() => import('./AIChatSetting/AIChatSetting'))
-const AIModelList = React.lazy(() => import('./aiModelList/AIModelList'))
 const AIMCP = React.lazy(() => import('./aiMCP/AIMCP'))
 const AIScheduledTasks = React.lazy(() => import('./aiScheduledTasks/AIScheduledTasks'))
 
@@ -73,24 +71,10 @@ export const AIAgentSideList: React.FC<AIAgentSideListProps> = (props) => {
           </div>
         )
         break
-      case AIAgentTabListEnum.Setting:
-        content = (
-          <React.Suspense fallback={<div>Loading...</div>}>
-            <AIChatSetting />
-          </React.Suspense>
-        )
-        break
       case AIAgentTabListEnum.Scheduled:
         content = (
           <React.Suspense fallback={<div>Loading...</div>}>
             <AIScheduledTasks visible={show} />
-          </React.Suspense>
-        )
-        break
-      case AIAgentTabListEnum.AI_Model:
-        content = (
-          <React.Suspense fallback={<div>Loading...</div>}>
-            <AIModelList />
           </React.Suspense>
         )
         break

--- a/app/renderer/src/main/src/pages/ai-agent/__test__/AIAgentSideList.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/__test__/AIAgentSideList.test.tsx
@@ -1,0 +1,79 @@
+import type React from 'react'
+import { useState } from 'react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import emiter from '@/utils/eventBus/eventBus'
+import { AIAgentSideList } from '../AIAgentSideList'
+import { SwitchAIAgentTabEventEnum } from '../defaultConstant'
+import type { YakitSideTabProps } from '@/components/yakitSideTab/YakitSideTabType'
+
+vi.mock('@/i18n/useI18nNamespaces', () => ({
+  useI18nNamespaces: () => ({ t: (key: string) => key, i18nRefresh: 0 }),
+}))
+vi.mock('@/components/yakitSideTab/YakitSideTab', () => ({
+  YakitSideTab: ({ yakitTabs, onActiveKey, activeKey, show, children }: React.PropsWithChildren<YakitSideTabProps>) => (
+    <div>
+      <output aria-label="active">{activeKey}</output>
+      <output aria-label="show">{String(show)}</output>
+      {yakitTabs.map((tab) => (
+        <button key={tab.value} onClick={() => onActiveKey?.(tab.value)}>
+          {tab.value}
+        </button>
+      ))}
+      {children}
+    </div>
+  ),
+}))
+vi.mock('../ChatSessionPane/ChatSessionPane', () => ({ default: () => <div>会话列表</div> }))
+vi.mock('../aiChatWelcome/FileTreeList/FileTreeList', () => ({ default: () => <div>文件列表</div> }))
+vi.mock('../aiMCP/AIMCP', () => ({ default: () => <div>MCP 内容</div> }))
+vi.mock('../aiScheduledTasks/AIScheduledTasks', () => ({ default: () => <div>定时任务</div> }))
+vi.mock('../../yakRunner/SplitView/SplitView', () => ({
+  SplitView: ({ elements }: { elements: { element: React.ReactNode }[] }) => (
+    <>
+      {elements.map((item, index) => (
+        <div key={index}>{item.element}</div>
+      ))}
+    </>
+  ),
+}))
+
+const SideList = () => {
+  const [show, setShow] = useState(true)
+  return <AIAgentSideList show={show} setShow={setShow} />
+}
+
+describe('AIAgentSideList', () => {
+  it('仅保留会话、定时任务和 MCP 入口，点击后显示对应内容', async () => {
+    render(<SideList />)
+    expect(screen.getAllByRole('button').map((button) => button.textContent)).toEqual(['session', 'scheduled', 'mcp'])
+    expect(screen.getByText('会话列表')).toBeInTheDocument()
+    expect(screen.getByText('文件列表')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'scheduled' }))
+    expect(await screen.findByText('定时任务')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'mcp' }))
+    expect(await screen.findByText('MCP 内容')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'session' }))
+    expect(screen.getByText('会话列表')).toBeInTheDocument()
+  })
+
+  it('事件切换、旧 history 映射和显隐仍有效，卸载后移除监听', async () => {
+    const off = vi.spyOn(emiter, 'off')
+    const result = render(<SideList />)
+    const emit = (type: SwitchAIAgentTabEventEnum, params: object) =>
+      act(() => {
+        emiter.emit('switchAIAgentTab', JSON.stringify({ type, params }))
+      })
+    emit(SwitchAIAgentTabEventEnum.SET_TAB_ACTIVE, { active: 'mcp' })
+    expect(await screen.findByText('MCP 内容')).toBeInTheDocument()
+    expect(screen.getByLabelText('show')).toHaveTextContent('true')
+    emit(SwitchAIAgentTabEventEnum.SET_TAB_SHOW, { show: false })
+    expect(screen.getByLabelText('show')).toHaveTextContent('false')
+    emit(SwitchAIAgentTabEventEnum.SET_TAB_ACTIVE, { active: 'history' })
+    expect(screen.getByLabelText('active')).toHaveTextContent('session')
+    expect(screen.getByText('会话列表')).toBeInTheDocument()
+    result.unmount()
+    expect(off).toHaveBeenCalledWith('switchAIAgentTab', expect.any(Function))
+    off.mockRestore()
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-agent/aiAgentChat/AIAgentChat.module.scss
+++ b/app/renderer/src/main/src/pages/ai-agent/aiAgentChat/AIAgentChat.module.scss
@@ -1,3 +1,5 @@
+@use '../../ai-re-act/styles/mixin.scss' as mixin;
+
 .ai-agent-chat {
   width: 100%;
   height: 100%;
@@ -14,6 +16,8 @@
   max-height: calc(100% - 120px);
   display: flex;
   justify-content: center;
+  // review 卡片与消息列表共用内容轨道，面板态下对齐消息区中心。
+  @include mixin.ai-right-panel-content-track;
   margin-bottom: 24px;
   z-index: 9;
   left: 0;

--- a/app/renderer/src/main/src/pages/ai-agent/aiAgentChat/useMultiFuncPaneStore.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/aiAgentChat/useMultiFuncPaneStore.ts
@@ -8,7 +8,6 @@ interface MultiFuncPaneStore {
   setVisible: (visible: boolean) => void
   toggleVisible: () => void
   setTab: (tab: MultiFuncPaneTab) => void
-  openWithTab: (tab: MultiFuncPaneTab) => void
 }
 
 export const useMultiFuncPaneStore = create<MultiFuncPaneStore>((set, get) => ({
@@ -23,5 +22,4 @@ export const useMultiFuncPaneStore = create<MultiFuncPaneStore>((set, get) => ({
     if (get().tab === tab) return
     set({ tab })
   },
-  openWithTab: (tab) => set({ visible: true, tab }),
 }))

--- a/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatContent.module.scss
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatContent.module.scss
@@ -21,7 +21,7 @@
     width: 100%;
     overflow: hidden;
     background-color: var(--Colors-Use-Basic-Background);
-    padding: 0 12px 12px 12px;
+    padding: 0 4px 12px 12px;
     justify-content: flex-end;
     display: flex;
 

--- a/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatContent.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatContent.tsx
@@ -66,6 +66,7 @@ export const AIChatContent: React.FC<AIChatContentProps> = React.memo(
                 showFreeChat={showFreeChat}
                 setShowFreeChat={setShowFreeChat}
                 startRequest={startRequest}
+                showAIRightPanel
                 ref={aiReActChatRef}
               />
             </div>

--- a/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatWorkspace/AIChatWorkspace.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatWorkspace/AIChatWorkspace.tsx
@@ -165,9 +165,8 @@ export const AIChatWorkspace: React.FC<AIChatWorkspaceProps> = React.memo((props
     }
 
     if (key === AITabsEnum.Task_Detail) return
-    if (key === AITabsEnum.HTTP && !httpTabShow && relatedRuntimeIDs.length === 0) return
-    if (key === AITabsEnum.Risk && !riskTabShow && relatedRuntimeIDs.length === 0) return
 
+    // 手动切换始终打开 tab，无数据时由内容区域展示空状态。
     openTab({
       key,
       type: key,

--- a/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatWorkspace/__test__/AIChatWorkspace.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatContent/AIChatWorkspace/__test__/AIChatWorkspace.test.tsx
@@ -1,0 +1,126 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStore } from 'zustand/vanilla'
+import { AIRightPanel } from '@/pages/ai-re-act/aiRightPanel/AIRightPanel'
+import emiter from '@/utils/eventBus/eventBus'
+import { AITabs, AITabsEnum } from '../../../defaultConstant'
+import { AIChatWorkspace } from '../AIChatWorkspace'
+
+const store = createStore(() => ({
+  currentChatStatus: { questionID: 'task-1' },
+  execFileRecord: new Map(),
+  httpTabShow: false,
+  httpTabUpdate: 0,
+  riskTabShow: false,
+  riskTabUpdate: 0,
+}))
+const initialState = store.getState()
+const rawData = { httpRunTimeIDs: [] as string[], riskRunTimeIDs: [] as string[] }
+const activeChat = { SessionID: 'session-1', Title: '当前任务', RelatedRuntimeIDs: [] as string[] }
+
+vi.mock('@/pages/ai-re-act/hooks/useCurrentDataBySession', () => ({
+  useCurrentStore: () => store,
+  useCurrentRawData: () => rawData,
+}))
+vi.mock('@/pages/ai-agent/useContext/useStore', () => ({ default: () => ({ activeChat }) }))
+vi.mock('@/pages/ai-agent/useContext/useDispatcher', () => ({
+  default: () => ({ getSetting: () => ({ Source: 'ai' }) }),
+}))
+vi.mock('@/i18n/useI18nNamespaces', () => ({
+  useI18nNamespaces: () => ({ t: (key: string) => key }),
+}))
+
+// 保留真实菜单、任务入口 hook、事件总线和工作区，仅隔离内容页面及 IPC 依赖。
+vi.mock('@/pages/ai-re-act/hooks/useCurrentTaskData/useCurrentTaskExecution', () => ({
+  default: () => undefined,
+}))
+vi.mock('@/pages/ai-agent/chatTemplate/aiTaskExecutionDetails/AITaskExecutionDetails', () => ({
+  AITaskExecutionDetails: ({ taskId }: { taskId: string }) => <div data-testid="task-detail">{taskId}</div>,
+}))
+vi.mock('@/pages/plugins/operator/pluginExecuteResult/PluginExecuteResult', () => ({
+  PluginExecuteHttpFlow: ({ runtimeId }: { runtimeId: string }) => <div data-testid="http-flows">{runtimeId}</div>,
+  VulnerabilitiesRisksTable: ({ runTimeIDs }: { runTimeIDs: string[] }) => (
+    <div data-testid="risks">{runTimeIDs.join(',')}</div>
+  ),
+}))
+vi.mock('@/pages/ai-agent/components/aiFileSystemList/FilePreview/FilePreview', () => ({ default: () => null }))
+vi.mock('@/pages/ai-agent/components/aiFileSystemList/OperationLog/OperationLog', () => ({ default: () => null }))
+vi.mock('@/pages/ai-agent/chatTemplate/historyTaskTree/TaskListPane', () => ({ TaskListPane: () => null }))
+vi.mock('@/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard', () => ({ default: () => null }))
+vi.mock('@/pages/ai-agent/historyChat/HistoryChat', () => ({ default: () => null }))
+vi.mock('@/pages/ai-agent/components/ExportAILogsModal/ExportAILogsModal', () => ({
+  ExportAILogsModal: () => null,
+}))
+vi.mock('@/pages/ai-agent/grpc', () => ({ grpcExportAILogs: vi.fn() }))
+vi.mock('@/hook/useAiChatLog/useAiChatLog.ts', () => ({ default: () => ({ onOpenLogWindow: vi.fn() }) }))
+vi.mock('@/components/yakitUI/YakitEmpty/YakitEmpty', () => ({ YakitEmpty: () => <div>暂无数据</div> }))
+
+beforeEach(() => {
+  store.setState(initialState, true)
+  rawData.httpRunTimeIDs = []
+  rawData.riskRunTimeIDs = []
+})
+
+describe('AIChatWorkspace 菜单切换', () => {
+  it.each([true, false])('small=%s：先打开任务详情，无数据时仍可点击流量、漏洞打开 tab', (small) => {
+    const onTabsChange = vi.fn()
+    render(
+      <>
+        <AIChatWorkspace setFilePreviewData={vi.fn()} onTabsChange={onTabsChange} />
+        <AIRightPanel small={small} />
+      </>,
+    )
+    expect(onTabsChange).toHaveBeenLastCalledWith(0)
+
+    fireEvent.click(screen.getByLabelText('AIRightPanel.taskBoard'))
+    expect(screen.getByTestId('task-detail')).toHaveTextContent('task-1')
+    expect(onTabsChange).toHaveBeenLastCalledWith(1)
+
+    fireEvent.click(screen.getByLabelText('AIRightPanel.traffic'))
+    expect(screen.getByText(AITabs.http.label)).toBeInTheDocument()
+    expect(screen.queryByTestId('task-detail')).not.toBeInTheDocument()
+    expect(screen.getByText('暂无数据')).toBeInTheDocument()
+    expect(onTabsChange).toHaveBeenLastCalledWith(2)
+
+    fireEvent.click(screen.getByLabelText('AIRightPanel.risk'))
+    expect(screen.getByText(AITabs.risk.label)).toBeInTheDocument()
+    expect(screen.getByText('暂无数据')).toBeInTheDocument()
+    expect(onTabsChange).toHaveBeenLastCalledWith(3)
+
+    // 已有 tab 可以重复激活，原来的任务详情也仍可切回。
+    fireEvent.click(screen.getByLabelText('AIRightPanel.traffic'))
+    expect(screen.getAllByText(AITabs.http.label)).toHaveLength(1)
+    expect(onTabsChange).toHaveBeenLastCalledWith(3)
+    fireEvent.click(screen.getByText('当前任务'))
+    expect(screen.getByTestId('task-detail')).toHaveTextContent('task-1')
+  })
+
+  it.each([
+    { key: AITabsEnum.HTTP, testId: 'http-flows' },
+    { key: AITabsEnum.Risk, testId: 'risks' },
+  ])('显式指定 runtimeId 时可直接打开 $key tab', ({ key, testId }) => {
+    render(<AIChatWorkspace setFilePreviewData={vi.fn()} />)
+    act(() => emiter.emit('switchAIActTab', JSON.stringify({ key, value: 'runtime-1' })))
+    expect(screen.getByTestId(testId)).toHaveTextContent('runtime-1')
+  })
+
+  it('无数据时不自动打开，首次流量和漏洞数据到达时仍自动打开对应 tab', () => {
+    const onTabsChange = vi.fn()
+    render(<AIChatWorkspace setFilePreviewData={vi.fn()} onTabsChange={onTabsChange} />)
+    expect(onTabsChange).toHaveBeenLastCalledWith(0)
+
+    act(() => {
+      rawData.httpRunTimeIDs = ['http-runtime']
+      store.setState({ httpTabShow: true, httpTabUpdate: 1 })
+    })
+    expect(screen.getByTestId('http-flows')).toHaveTextContent('http-runtime')
+    expect(onTabsChange).toHaveBeenLastCalledWith(1)
+
+    act(() => {
+      rawData.riskRunTimeIDs = ['risk-runtime']
+      store.setState({ riskTabShow: true, riskTabUpdate: 1 })
+    })
+    expect(screen.getByTestId('risks')).toHaveTextContent('risk-runtime')
+    expect(onTabsChange).toHaveBeenLastCalledWith(2)
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-agent/aiChatContent/aiHorizontalScrollCard/AIHorizontalScrollCard.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatContent/aiHorizontalScrollCard/AIHorizontalScrollCard.tsx
@@ -5,33 +5,15 @@ import { useStore } from 'zustand'
 import classNames from 'classnames'
 import styles from './AIHorizontalScrollCard.module.scss'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
-import { YakitDropdownMenu } from '@/components/yakitUI/YakitDropdownMenu/YakitDropdownMenu'
-import {
-  FigmaIcon2017756Outlined,
-  FlagOutlined,
-  MessageCirclePlusOutlined,
-  NewspaperOutlined,
-  ScrollTextOutlined,
-  Settings2Outlined,
-  TimelineOutlined,
-} from '@yakit-libs/yakit-ui-icons/outline'
+import { MessageCirclePlusOutlined } from '@yakit-libs/yakit-ui-icons/outline'
 import { ChatAlt2Solid } from '@yakit-libs/yakit-ui-icons/solid'
 import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
 import { ExpandAndRetract } from '@/pages/plugins/operator/expandAndRetract/ExpandAndRetract'
 import AIContextToken from '../AIContextToken/AIContextToken'
 import useAIAgentStore from '../../useContext/useStore'
-import useAIAgentDispatcher from '../../useContext/useDispatcher'
-import useAiChatLog from '@/hook/useAiChatLog/useAiChatLog.ts'
-import { ExportAILogsModal } from '../../components/ExportAILogsModal/ExportAILogsModal'
-import { failed, yakitNotify } from '@/utils/notification'
-import { grpcExportAILogs } from '../../grpc'
 import { useMemoizedFn } from 'ahooks'
 import ContextDetailPopover from '../AIContextToken/ContextDetailPopover'
-import { useMultiFuncPaneStore } from '../../aiAgentChat/useMultiFuncPaneStore'
 import { onNewChat } from '../../historyChat/HistoryChat'
-import { AISourceEnum } from '@/pages/ai-re-act/hooks/grpcApi'
-import { useCasualTaskTab } from '../hooks/useCasualTaskTab'
-import { useHasTaskTree } from '../../chatTemplate/historyTaskTree/useHasTaskTree'
 import { Tooltip } from 'antd'
 
 export const AIHorizontalScrollCard = memo(() => {
@@ -39,192 +21,54 @@ export const AIHorizontalScrollCard = memo(() => {
 
   const [isExpand, setIsExpand] = useState<boolean>(true)
 
-  const [exportModalVisible, setExportModalVisible] = useState(false)
-  const [exportLoading, setExportLoading] = useState(false)
-
   const { activeChat } = useAIAgentStore()
-  const { getSetting } = useAIAgentDispatcher()
-  const { onOpenLogWindow } = useAiChatLog()
-  const multiFuncVisible = useMultiFuncPaneStore((state) => state.visible)
-  const openMultiFuncWithTab = useMultiFuncPaneStore((state) => state.openWithTab)
-  const [dropdownVisible, setDropdownVisible] = useState(false)
 
   const store = useCurrentStore()
   const yakExecResultCard = useStore(store, (state) => state.card)
-  const hasTaskTree = useHasTaskTree()
-  const { currentChatStatusQuestionID, syncCasualTaskTab } = useCasualTaskTab()
 
   const onExpand = useMemoizedFn((e) => {
     e.stopPropagation()
     setIsExpand(!isExpand)
   })
 
-  const onDetails = useMemoizedFn((e) => {
-    e.stopPropagation()
-    if (!currentChatStatusQuestionID) {
-      yakitNotify('error', t('AIHorizontalScrollCard.questionIdMissing'))
-      return
-    }
-    if (getSetting().Source !== AISourceEnum.aiAgent) {
-      yakitNotify('info', t('AIHorizontalScrollCard.taskDetailSourceMismatch'))
-      return
-    }
-    syncCasualTaskTab()
-  })
-  const onOpenExportModal = useMemoizedFn((e?: React.MouseEvent) => {
-    e?.stopPropagation()
-    setExportModalVisible(true)
-  })
-  const onMenuClick = useMemoizedFn(({ key }: { key: string }) => {
-    setDropdownVisible(false)
-    switch (key) {
-      case 'task-list':
-        if (!hasTaskTree) return
-        openMultiFuncWithTab(key)
-        break
-      case 'timeline':
-        openMultiFuncWithTab(key)
-        break
-      case 'export-log':
-        onOpenExportModal()
-        break
-      case 'view-log':
-        onOpenLogWindow()
-        break
-      default:
-        break
-    }
-  })
-
-  const onExportCancel = useMemoizedFn(() => {
-    setExportModalVisible(false)
-  })
-
-  const onExportOk = useMemoizedFn(async (data: { types: string[]; outputPath: string }) => {
-    if (!activeChat?.Id) {
-      failed(t('AIChatContent.noActiveChat'))
-      return
-    }
-    setExportLoading(true)
-    //
-    try {
-      await grpcExportAILogs(
-        {
-          SessionID: activeChat.SessionID,
-          ExportDataTypes: data.types,
-          OutputPath: data.outputPath,
-        },
-        true,
-      )
-      yakitNotify('success', t('YakitNotification.exportSuccess'))
-      setExportModalVisible(false)
-    } catch (error) {
-      failed(t('YakitNotification.exportFailed', { error: error + '' }))
-    } finally {
-      setExportLoading(false)
-    }
-  })
   return (
-    <>
-      <ExpandAndRetract
-        isExpand={isExpand}
-        onExpand={onExpand}
-        className={classNames(styles['expand-retract-wrapper'], {
-          [styles['expand-retract-wrapper-collapsed']]: !yakExecResultCard.length,
-        })}
-        animationWrapperClassName={classNames(styles['expand-retract-animation-wrapper'], {
-          [styles['expand-retract-animation-wrapper-hidden']]: !yakExecResultCard.length,
-        })}
-        expandText={t('YakitButton.expand')}
-        retractText={t('YakitButton.collapse')}
-      >
-        <div className={classNames(styles['expand-retract-content'])}>
-          <div className={styles['header']}>
-            <div className={styles['title']}>
-              <ChatAlt2Solid className={styles['chat-alt-icon']} color="currentColor" />
-              <div className={styles['chat-title']}>{activeChat?.Title || t('AIChatContent.newChatTitle')}</div>
-            </div>
-            <div className={styles['extra']}>
-              <AIContextToken />
-              <ContextDetailPopover />
-              <Tooltip title={t('AIChatContent.taskDetail')}>
-                <YakitButton
-                  hidden={!currentChatStatusQuestionID}
-                  type="text2"
-                  icon={<ScrollTextOutlined color="currentColor" />}
-                  onClick={onDetails}
-                />
-              </Tooltip>
-              <Tooltip title={t('AIChatContent.newChat')}>
-                <YakitButton
-                  type="text2"
-                  icon={<MessageCirclePlusOutlined color="currentColor" />}
-                  onClick={onNewChat}
-                />
-              </Tooltip>
-              <YakitDropdownMenu
-                menu={{
-                  data: [
-                    {
-                      key: 'task-list',
-                      label: t('AIAgentChatTemplate.tasklist'),
-                      itemIcon: <FlagOutlined color="currentColor" />,
-                      disabled: !hasTaskTree,
-                    },
-                    {
-                      key: 'timeline',
-                      label: t('AIAgentChatTemplate.timeline'),
-                      itemIcon: <TimelineOutlined color="currentColor" />,
-                    },
-                    {
-                      key: 'export-log',
-                      label: t('AIChatContent.exportLog'),
-                      itemIcon: <FigmaIcon2017756Outlined color="currentColor" />,
-                    },
-                    {
-                      key: 'view-log',
-                      label: t('AIChatContent.log'),
-                      itemIcon: <NewspaperOutlined color="currentColor" />,
-                    },
-                  ],
-                  onClick: onMenuClick,
-                }}
-                dropdown={{
-                  trigger: ['click'],
-                  placement: 'bottomRight',
-                  visible: dropdownVisible,
-                  onVisibleChange: setDropdownVisible,
-                }}
-              >
-                <Tooltip title={t('YakitButton.more')}>
-                  <YakitButton
-                    type="text2"
-                    isActive={multiFuncVisible || dropdownVisible}
-                    icon={<Settings2Outlined color="currentColor" />}
-                    onClick={(e) => e.stopPropagation()}
-                  />
-                </Tooltip>
-              </YakitDropdownMenu>
-            </div>
+    <ExpandAndRetract
+      isExpand={isExpand}
+      onExpand={onExpand}
+      className={classNames(styles['expand-retract-wrapper'], {
+        [styles['expand-retract-wrapper-collapsed']]: !yakExecResultCard.length,
+      })}
+      animationWrapperClassName={classNames(styles['expand-retract-animation-wrapper'], {
+        [styles['expand-retract-animation-wrapper-hidden']]: !yakExecResultCard.length,
+      })}
+      expandText={t('YakitButton.expand')}
+      retractText={t('YakitButton.collapse')}
+    >
+      <div className={classNames(styles['expand-retract-content'])}>
+        <div className={styles['header']}>
+          <div className={styles['title']}>
+            <ChatAlt2Solid className={styles['chat-alt-icon']} color="currentColor" />
+            <div className={styles['chat-title']}>{activeChat?.Title || t('AIChatContent.newChatTitle')}</div>
           </div>
-          {yakExecResultCard.length > 0 ? (
-            <HorizontalScrollCard
-              hiddenHeard={true}
-              data={yakExecResultCard}
-              className={classNames(styles['card-list-wrapper'], {
-                [styles['card-list-wrapper-hidden']]: !isExpand,
-              })}
-              itemProps={{ size: 'small' }}
-            />
-          ) : null}
+          <div className={styles['extra']}>
+            <AIContextToken />
+            <ContextDetailPopover />
+            <Tooltip title={t('AIChatContent.newChat')}>
+              <YakitButton type="text2" icon={<MessageCirclePlusOutlined color="currentColor" />} onClick={onNewChat} />
+            </Tooltip>
+          </div>
         </div>
-      </ExpandAndRetract>
-      <ExportAILogsModal
-        visible={exportModalVisible}
-        onCancel={onExportCancel}
-        onOk={onExportOk}
-        loading={exportLoading}
-      />
-    </>
+        {yakExecResultCard.length > 0 ? (
+          <HorizontalScrollCard
+            hiddenHeard={true}
+            data={yakExecResultCard}
+            className={classNames(styles['card-list-wrapper'], {
+              [styles['card-list-wrapper-hidden']]: !isExpand,
+            })}
+            itemProps={{ size: 'small' }}
+          />
+        ) : null}
+      </div>
+    </ExpandAndRetract>
   )
 })

--- a/app/renderer/src/main/src/pages/ai-agent/aiChatContent/aiHorizontalScrollCard/__test__/AIHorizontalScrollCard.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiChatContent/aiHorizontalScrollCard/__test__/AIHorizontalScrollCard.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStore } from 'zustand/vanilla'
+import { AIHorizontalScrollCard } from '../AIHorizontalScrollCard'
+
+const store = createStore(() => ({ card: [] as { title: string }[] }))
+const { newChat } = vi.hoisted(() => ({ newChat: vi.fn() }))
+vi.mock('@/pages/ai-re-act/hooks/useCurrentDataBySession', () => ({ useCurrentStore: () => store }))
+vi.mock('../../../useContext/useStore', () => ({ default: () => ({ activeChat: { Title: '当前会话' } }) }))
+vi.mock('../../../historyChat/HistoryChat', () => ({ onNewChat: newChat }))
+vi.mock('../../AIContextToken/AIContextToken', () => ({ default: () => <div>Token 统计</div> }))
+vi.mock('../../AIContextToken/ContextDetailPopover', () => ({ default: () => <button>上下文详情</button> }))
+vi.mock('@/pages/plugins/operator/horizontalScrollCard/HorizontalScrollCard', () => ({
+  HorizontalScrollCard: () => <div>执行结果</div>,
+}))
+vi.mock('@/i18n/useI18nNamespaces', () => ({ useI18nNamespaces: () => ({ t: (key: string) => key }) }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  store.setState({ card: [] })
+})
+
+describe('AIHorizontalScrollCard', () => {
+  it('头部保留上下文与新建会话入口，不展示任务详情和更多操作', () => {
+    render(<AIHorizontalScrollCard />)
+    expect(screen.getByText('当前会话')).toBeVisible()
+    expect(screen.getByText('Token 统计')).toBeVisible()
+    expect(screen.getByRole('button', { name: '上下文详情' })).toBeVisible()
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(2)
+    fireEvent.click(buttons[1])
+    expect(newChat).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('执行结果')).not.toBeInTheDocument()
+  })
+
+  it('移除操作按钮后，执行结果仍支持展开和收起', () => {
+    store.setState({ card: [{ title: '结果' }] })
+    render(<AIHorizontalScrollCard />)
+    expect(screen.getByText('执行结果')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('YakitButton.collapse'))
+    expect(screen.getByText('YakitButton.expand')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('YakitButton.expand'))
+    expect(screen.getByText('YakitButton.collapse')).toBeInTheDocument()
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelect.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelect.tsx
@@ -156,6 +156,7 @@ export const AIModelSelect: React.FC<AIModelSelectProps> = React.memo((props) =>
         break
     }
   })
+  const closeOnWidthChange = useMemoizedFn(() => onSetOpen(false))
   const [_, event] = useAIGlobalConfig()
   /**
    * 更新AI配置
@@ -327,6 +328,7 @@ export const AIModelSelect: React.FC<AIModelSelectProps> = React.memo((props) =>
       })
     },
   )
+
   return (
     <div ref={refRef} className={className}>
       {isHaveData ? (
@@ -397,6 +399,7 @@ export const AIModelSelect: React.FC<AIModelSelectProps> = React.memo((props) =>
                       dropdownRef={dropdownRenderRef}
                       triggerRef={refRef}
                       open={open}
+                      onWidthChange={closeOnWidthChange}
                     />
                   )}
                   {/* {!execute && !!lightweightModels.length && (
@@ -452,7 +455,7 @@ export const AIModelSelect: React.FC<AIModelSelectProps> = React.memo((props) =>
 })
 
 const AIModelSelectList: React.FC<AIModelSelectListProps> = React.memo((props) => {
-  const { title, subTitle, list, onSelect, type, onEdit, dropdownRef, triggerRef, open } = props
+  const { title, subTitle, list, onSelect, type, onEdit, dropdownRef, triggerRef, open, onWidthChange } = props
   const [currentSelectIndex, setCurrentSelectIndex] = useState<number>()
   const [currentItem, setCurrentItem] = useState<AIModelConfig>()
   const [loading, setLoading] = useState<boolean>(false)
@@ -491,13 +494,16 @@ const AIModelSelectList: React.FC<AIModelSelectListProps> = React.memo((props) =
 
   useEffect(() => {
     if (!open || !triggerRef.current) return
-    // 输入区域缩放会改变浮层定位；输入内容增高时保留当前编辑状态。
+    // 输入区域宽度变化会同时关闭二级编辑浮层和一级模型选择下拉框；高度变化保留当前状态。
     const input = triggerRef.current
     let previousWidth: number | undefined
     const observer = new ResizeObserver(([entry]) => {
       if (!entry) return
       const width = entry.contentRect.width
-      if (previousWidth !== undefined && width !== previousWidth) closeEditContent()
+      if (previousWidth !== undefined && width !== previousWidth) {
+        closeEditContent()
+        onWidthChange()
+      }
       previousWidth = width
     })
     observer.observe(input)

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelect.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelect.tsx
@@ -102,19 +102,9 @@ export const AIModelSelect: React.FC<AIModelSelectProps> = React.memo((props) =>
 
   const refRef = useRef<HTMLDivElement>(null)
   const dropdownRenderRef = useRef<HTMLDivElement>(null)
-  const dropdownRenderRectRef = useRef<DOMRect>()
 
   const aiGlobalConfigRef = useRef<AIGlobalConfig>()
   const [inViewport = true] = useInViewport(refRef)
-
-  useEffect(() => {
-    if (open) {
-      setTimeout(() => {
-        const rect = dropdownRenderRef.current?.getBoundingClientRect()
-        dropdownRenderRectRef.current = rect
-      }, 200)
-    }
-  }, [open])
 
   useEffect(() => {
     if (!inViewport) return
@@ -404,7 +394,8 @@ export const AIModelSelect: React.FC<AIModelSelectProps> = React.memo((props) =>
                           index,
                         })
                       }
-                      dropdownRenderRectRef={dropdownRenderRectRef.current}
+                      dropdownRef={dropdownRenderRef}
+                      triggerRef={refRef}
                       open={open}
                     />
                   )}
@@ -461,7 +452,7 @@ export const AIModelSelect: React.FC<AIModelSelectProps> = React.memo((props) =>
 })
 
 const AIModelSelectList: React.FC<AIModelSelectListProps> = React.memo((props) => {
-  const { title, subTitle, list, onSelect, type, onEdit, dropdownRenderRectRef, open } = props
+  const { title, subTitle, list, onSelect, type, onEdit, dropdownRef, triggerRef, open } = props
   const [currentSelectIndex, setCurrentSelectIndex] = useState<number>()
   const [currentItem, setCurrentItem] = useState<AIModelConfig>()
   const [loading, setLoading] = useState<boolean>(false)
@@ -471,6 +462,19 @@ const AIModelSelectList: React.FC<AIModelSelectListProps> = React.memo((props) =
   const hideTimerRef = useRef<NodeJS.Timeout | null>(null)
 
   const modelNameListMapRef = useRef<Map<number, ModelNameListRef>>(new Map())
+
+  const clearHideTimer = useMemoizedFn(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current)
+      hideTimerRef.current = null
+    }
+  })
+  const closeEditContent = useMemoizedFn(() => {
+    clearHideTimer()
+    setCurrentItem(undefined)
+    setCurrentSelectIndex(undefined)
+    setEditStyle(undefined)
+  })
 
   // 组件卸载时清理定时器
   useEffect(() => {
@@ -484,6 +488,21 @@ const AIModelSelectList: React.FC<AIModelSelectListProps> = React.memo((props) =
       modelNameListMapRef.current.clear()
     }
   }, [open])
+
+  useEffect(() => {
+    if (!open || !triggerRef.current) return
+    // 输入区域缩放会改变浮层定位；输入内容增高时保留当前编辑状态。
+    const input = triggerRef.current
+    let previousWidth: number | undefined
+    const observer = new ResizeObserver(([entry]) => {
+      if (!entry) return
+      const width = entry.contentRect.width
+      if (previousWidth !== undefined && width !== previousWidth) closeEditContent()
+      previousWidth = width
+    })
+    observer.observe(input)
+    return () => observer.disconnect()
+  }, [open, triggerRef])
   /** 缓存中有就取缓存中的数据，反之调用接口获取数据 */
   const getModelNameList = useMemoizedFn((item: AIModelConfig, index: number) => {
     if (!item?.Provider || isNil(index)) return
@@ -555,19 +574,12 @@ const AIModelSelectList: React.FC<AIModelSelectListProps> = React.memo((props) =
     e.stopPropagation()
     hideEditContent()
   })
-  // 清除延迟隐藏定时器
-  const clearHideTimer = useMemoizedFn(() => {
-    if (hideTimerRef.current) {
-      clearTimeout(hideTimerRef.current)
-      hideTimerRef.current = null
-    }
-  })
-
   const onMouseEnterEdit = useMemoizedFn((e: React.MouseEvent, item: AIModelConfig, index: number) => {
     clearHideTimer()
-    if (!dropdownRenderRectRef) return
+    const dropdownRect = dropdownRef.current?.getBoundingClientRect()
+    if (!dropdownRect) return
 
-    const { left = 0, right = 0, width } = dropdownRenderRectRef || {}
+    const { left, right, width } = dropdownRect
     if (isEqual(currentSelectIndex, index)) return
 
     const rightContextWidth = 200
@@ -577,7 +589,7 @@ const AIModelSelectList: React.FC<AIModelSelectListProps> = React.memo((props) =
      * 链接所在文件内位置 #ai-model-edit-content 处
      */
     const rightContextHeight = 240
-    // 判断右侧屏幕剩余空间是否满足：如果不满足，则在 dropdownRenderRectRef 的左方展示
+    // 判断右侧屏幕剩余空间是否满足：如果不满足，则在下拉框的左方展示
     const spaceOnRight = window.innerWidth - right
     let toLeft = spaceOnRight < rightContextWidth ? left - rightContextWidth - 6 : right + 6
 
@@ -610,11 +622,7 @@ const AIModelSelectList: React.FC<AIModelSelectListProps> = React.memo((props) =
   // 统一的隐藏逻辑：开启定时器，如果 150ms 内没有被再次打断，则关闭弹窗
   const hideEditContent = useMemoizedFn(() => {
     clearHideTimer()
-    hideTimerRef.current = setTimeout(() => {
-      setCurrentItem(undefined)
-      setCurrentSelectIndex(undefined)
-      setEditStyle(undefined)
-    }, 150)
+    hideTimerRef.current = setTimeout(closeEditContent, 150)
   })
   const onEditContentChange = useMemoizedFn((v: AIModelConfig) => {
     if (isNil(currentSelectIndex)) return

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelect.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelect.tsx
@@ -27,20 +27,17 @@ import styles from './AIModelSelect.module.scss'
 import classNames from 'classnames'
 import type { GetAIModelAvailableTotalResponse } from '../../type/aiModel'
 import {
-  AIAgentTabListEnum,
   type AIModelPolicyEnum,
   AIModelTypeEnum,
   AIModelTypeInterFileNameEnum,
   AIOnlineModelIconMap,
   defaultAIGlobalConfig,
-  SwitchAIAgentTabEventEnum,
 } from '../../defaultConstant'
 import { AIModelFreeTag, getTipByType, OutlineAtomIconByStatus, setAIModal } from '../AIModelList'
 import { AIChatSelect } from '@/pages/ai-re-act/aiReviewRuleSelect/AIReviewRuleSelect'
 import {
   BrainOutlined,
   CheckOutlined,
-  CogOutlined,
   InformationCircleOutlined,
   PencilAltOutlined,
   RefreshOutlined,
@@ -51,9 +48,6 @@ import { YakitModalConfirm } from '@/components/yakitUI/YakitModal/YakitModalCon
 import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
 import { Tooltip } from 'antd'
 import { YakitTag } from '@/components/yakitUI/YakitTag/YakitTag'
-import { yakitNotify } from '@/utils/notification'
-import { YakitRoute } from '@/enums/yakitRoute'
-import { getCurrentPageTabRouteKey } from '@/utils/getMainOperatorPageBodyContainer'
 import { type TFunction, useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import useAIGlobalConfig from '@/pages/ai-re-act/hooks/useAIGlobalConfig'
 import { createPortal } from 'react-dom'
@@ -343,35 +337,6 @@ export const AIModelSelect: React.FC<AIModelSelectProps> = React.memo((props) =>
       })
     },
   )
-  const openModelTab = useMemoizedFn(() => {
-    if (getCurrentPageTabRouteKey() !== YakitRoute.AI_Agent) {
-      emiter.emit(
-        'openPage',
-        JSON.stringify({
-          route: YakitRoute.AI_Agent,
-        }),
-      )
-      setTimeout(() => {
-        onSwitchAIAgentTab()
-      }, 100)
-    } else {
-      onSwitchAIAgentTab()
-    }
-
-    yakitNotify('success', t('AIModelSelect.openModelTabSuccess'))
-  })
-  const onSwitchAIAgentTab = useMemoizedFn(() => {
-    emiter.emit(
-      'switchAIAgentTab',
-      JSON.stringify({
-        type: SwitchAIAgentTabEventEnum.SET_TAB_ACTIVE,
-        params: {
-          active: AIAgentTabListEnum.AI_Model,
-          show: true,
-        },
-      }),
-    )
-  })
   return (
     <div ref={refRef} className={className}>
       {isHaveData ? (
@@ -407,14 +372,6 @@ export const AIModelSelect: React.FC<AIModelSelectProps> = React.memo((props) =>
                     </Tooltip>
                   </div>
                   <div className={styles['select-title-right']}>
-                    <Tooltip title={t('AIModelSelect.openConfigTooltip')}>
-                      <YakitButton
-                        size="small"
-                        type="text2"
-                        icon={<CogOutlined color="currentColor" />}
-                        onClick={openModelTab}
-                      />
-                    </Tooltip>
                     {aiType === 'online' && (
                       <Tooltip title={t('YakitButton.refresh')}>
                         <YakitButton

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelectType.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelectType.ts
@@ -30,6 +30,8 @@ export interface AIModelSelectListProps {
   triggerRef: RefObject<HTMLDivElement>
   /** 下拉框是否展开 */
   open?: boolean
+  /** 触发器宽度变化时关闭一级下拉框 */
+  onWidthChange: () => void
 }
 
 export interface AIModelEditContentProps {

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelectType.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelectType.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import type { AIModelConfig } from '../utils'
 import type { AIOnlineModelListProps } from '../AIModelListType'
 import { type AIModelTypeEnum } from '../../defaultConstant'
@@ -26,7 +26,8 @@ export interface AIModelSelectListProps {
   list: AIModelConfig[]
   onSelect: (v: AIModelConfig, i: number) => void
   onEdit: (v: AIModelConfig, i: number) => void
-  dropdownRenderRectRef?: DOMRect
+  dropdownRef: RefObject<HTMLDivElement>
+  triggerRef: RefObject<HTMLDivElement>
   /** 下拉框是否展开 */
   open?: boolean
 }

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/__test__/AIModelSelect.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/__test__/AIModelSelect.test.tsx
@@ -1,0 +1,135 @@
+import type React from 'react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AIModelSelect } from '../AIModelSelect'
+import { defaultAIGlobalConfig } from '../../../defaultConstant'
+
+const mocks = vi.hoisted(() => ({
+  load: vi.fn(),
+  save: vi.fn(() => Promise.resolve()),
+  names: vi.fn(() => Promise.resolve({ ModelName: ['model-edited'] })),
+  configure: vi.fn(),
+}))
+vi.mock('../../utils', () => ({
+  isForcedSetAIModal: mocks.load,
+  grpcListAiModel: mocks.names,
+  getModelName: (name?: string) => name ?? '',
+  isMemfitStart: () => false,
+  isFreeEnd: () => false,
+  sortMemfitNameFirst: (names: string[]) => names,
+}))
+vi.mock('../../AIModelList', () => ({
+  getTipByType: () => 'policy',
+  OutlineAtomIconByStatus: () => null,
+  AIModelFreeTag: () => null,
+  setAIModal: mocks.configure,
+}))
+vi.mock('@/pages/ai-re-act/hooks/useAIGlobalConfig', () => ({
+  default: () => [null, { setAIGlobalConfig: mocks.save }],
+}))
+vi.mock('@/i18n/useI18nNamespaces', () => ({ useI18nNamespaces: () => ({ t: (key: string) => key }) }))
+vi.mock('ahooks', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('ahooks')>()),
+  useInViewport: () => [true],
+}))
+vi.mock('@/pages/ai-re-act/aiReviewRuleSelect/AIReviewRuleSelect', () => ({
+  AIChatSelect: ({
+    open,
+    setOpen,
+    dropdownRender,
+  }: {
+    open: boolean
+    setOpen: (open: boolean) => void
+    dropdownRender: (menu: React.ReactNode) => React.ReactNode
+  }) => (
+    <>
+      <button onClick={() => setOpen(!open)}>{open ? '关闭选择' : '打开选择'}</button>
+      {open && (
+        <div role="region" aria-label="模型列表">
+          {dropdownRender(null)}
+        </div>
+      )}
+    </>
+  ),
+}))
+vi.mock('@/components/yakitUI/YakitSelect/YakitSelect', () => ({ YakitSelect: { Option: () => null } }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.load.mockImplementation(({ haveDataCall }) => {
+    haveDataCall({
+      onlineModelsTotal: 2,
+      localModelsTotal: 0,
+      localModels: [],
+      onlineModels: {
+        ...defaultAIGlobalConfig,
+        IntelligentModels: ['model-a', 'model-b'].map((ModelName) => ({
+          ModelName,
+          ProviderId: ModelName,
+          ExtraParams: [],
+          Provider: { Type: 'test-provider', ReasoningEffort: 'off' },
+        })),
+      },
+    })
+    return Promise.resolve()
+  })
+})
+
+const openModels = async () => {
+  render(<AIModelSelect />)
+  fireEvent.click(await screen.findByRole('button', { name: '打开选择' }))
+  return screen.getByRole('region', { name: '模型列表' })
+}
+
+describe('AIModelSelect', () => {
+  it('移除配置入口后仍可刷新模型列表', async () => {
+    const dropdown = await openModels()
+    expect(within(dropdown).getByText('model-a')).toBeInTheDocument()
+    // 刷新、两条模型的编辑和新增模型按钮；不再包含旧配置入口。
+    const buttons = within(dropdown).getAllByRole('button')
+    expect(buttons).toHaveLength(4)
+    await waitFor(() => expect(buttons[0]).not.toHaveClass('ant-btn-loading'))
+    fireEvent.click(buttons[0])
+    await waitFor(() => expect(mocks.load).toHaveBeenCalledTimes(2))
+    expect(mocks.configure).not.toHaveBeenCalled()
+  })
+
+  it('选择模型后关闭下拉，将选择结果保存为首选模型', async () => {
+    const dropdown = await openModels()
+    fireEvent.click(within(dropdown).getByText('model-b'))
+    fireEvent.click(screen.getByRole('button', { name: '关闭选择' }))
+    await waitFor(() =>
+      expect(mocks.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          IntelligentModels: [
+            expect.objectContaining({ ModelName: 'model-b' }),
+            expect.objectContaining({ ModelName: 'model-a' }),
+          ],
+        }),
+      ),
+    )
+  })
+
+  it('悬停编辑按钮后仍可加载模型名称、编辑并保存', async () => {
+    const dropdown = await openModels()
+    // 组件在打开后延迟测量下拉区域，之后才能定位编辑浮层。
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    })
+    fireEvent.click(within(dropdown).getByText('model-a'))
+    fireEvent.mouseEnter(within(dropdown).getAllByRole('button')[1])
+    fireEvent.click(await screen.findByText('model-edited'))
+    expect(mocks.names).toHaveBeenCalledWith({ Config: JSON.stringify({ Type: 'test-provider' }) })
+    fireEvent.click(screen.getByRole('button', { name: '关闭选择' }))
+    await waitFor(() =>
+      expect(mocks.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          IntelligentModels: [
+            expect.objectContaining({ ModelName: 'model-edited' }),
+            expect.objectContaining({ ModelName: 'model-b' }),
+          ],
+        }),
+      ),
+    )
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/__test__/AIModelSelect.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/__test__/AIModelSelect.test.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AIModelSelect } from '../AIModelSelect'
 import { defaultAIGlobalConfig } from '../../../defaultConstant'
 
@@ -58,6 +58,15 @@ vi.mock('@/components/yakitUI/YakitSelect/YakitSelect', () => ({ YakitSelect: { 
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // jsdom 没有原生 ResizeObserver；尺寸变化在对应交互用例中主动触发。
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    },
+  )
   mocks.load.mockImplementation(({ haveDataCall }) => {
     haveDataCall({
       onlineModelsTotal: 2,
@@ -75,6 +84,12 @@ beforeEach(() => {
     })
     return Promise.resolve()
   })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
 })
 
 const openModels = async () => {
@@ -114,11 +129,6 @@ describe('AIModelSelect', () => {
 
   it('悬停编辑按钮后仍可加载模型名称、编辑并保存', async () => {
     const dropdown = await openModels()
-    // 组件在打开后延迟测量下拉区域，之后才能定位编辑浮层。
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 250))
-    })
-    fireEvent.click(within(dropdown).getByText('model-a'))
     fireEvent.mouseEnter(within(dropdown).getAllByRole('button')[1])
     fireEvent.click(await screen.findByText('model-edited'))
     expect(mocks.names).toHaveBeenCalledWith({ Config: JSON.stringify({ Type: 'test-provider' }) })
@@ -133,5 +143,62 @@ describe('AIModelSelect', () => {
         }),
       ),
     )
+  })
+
+  it('选择器外层宽度变化时关闭二级弹窗，高度变化不关闭，关闭后可重新悬停打开', async () => {
+    let resizeInput: (width: number, height: number) => void = () => {}
+    let observedTarget: Element | undefined
+    const disconnect = vi.fn()
+    // 组件观察的是自身触发器元素（triggerRef），记录 observe 到的目标供用例主动触发尺寸变化。
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(private callback: ResizeObserverCallback) {}
+        observe(target: Element) {
+          observedTarget = target
+          resizeInput = (width, height) =>
+            this.callback(
+              [{ target, contentRect: { width, height } } as ResizeObserverEntry],
+              this as unknown as ResizeObserver,
+            )
+        }
+        disconnect = disconnect
+        unobserve() {}
+      },
+    )
+    try {
+      render(<AIModelSelect className="model-trigger" />)
+      fireEvent.click(await screen.findByRole('button', { name: '打开选择' }))
+      await waitFor(() => expect(observedTarget).toBe(document.querySelector('.model-trigger')))
+      act(() => resizeInput(600, 120))
+      const dropdown = screen.getByRole('region', { name: '模型列表' })
+      const measureDropdown = vi.spyOn(dropdown.firstElementChild!, 'getBoundingClientRect')
+      measureDropdown.mockReturnValue(new DOMRect(100, 0, 200, 300))
+      const editButton = within(dropdown).getAllByRole('button')[1]
+      fireEvent.mouseEnter(editButton)
+      expect(await screen.findByText('model-edited')).toBeVisible()
+      expect(screen.getByText('model-edited').closest('[style*="translate("]')).toHaveStyle({
+        transform: 'translate(306px, 0px)',
+      })
+
+      act(() => resizeInput(600, 240))
+      expect(screen.getByText('model-edited')).toBeVisible()
+      act(() => resizeInput(500, 240))
+      expect(screen.queryByText('model-edited')).not.toBeInTheDocument()
+      expect(dropdown).toBeVisible()
+      expect(mocks.save).not.toHaveBeenCalled()
+
+      measureDropdown.mockReturnValue(new DOMRect(200, 0, 200, 300))
+      fireEvent.mouseEnter(editButton)
+      expect(await screen.findByText('model-edited')).toBeVisible()
+      expect(screen.getByText('model-edited').closest('[style*="translate("]')).toHaveStyle({
+        transform: 'translate(406px, 0px)',
+      })
+      cleanup()
+      expect(disconnect).toHaveBeenCalled()
+    } finally {
+      cleanup()
+      vi.unstubAllGlobals()
+    }
   })
 })

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/__test__/AIModelSelect.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/__test__/AIModelSelect.test.tsx
@@ -145,7 +145,45 @@ describe('AIModelSelect', () => {
     )
   })
 
-  it('选择器外层宽度变化时关闭二级弹窗，高度变化不关闭，关闭后可重新悬停打开', async () => {
+  it.each([500, 700])('宽度变为 %s 时，即使未打开编辑浮层也关闭列表并保存模型选择', async (width) => {
+    let resizeInput: (width: number) => void = () => {}
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(private callback: ResizeObserverCallback) {}
+        observe(target: Element) {
+          resizeInput = (width) =>
+            this.callback(
+              [{ target, contentRect: { width, height: 120 } } as ResizeObserverEntry],
+              this as unknown as ResizeObserver,
+            )
+        }
+        disconnect() {}
+        unobserve() {}
+      },
+    )
+    const dropdown = await openModels()
+    act(() => resizeInput(600))
+    fireEvent.click(within(dropdown).getByText('model-b'))
+    act(() => resizeInput(width))
+    expect(screen.queryByRole('region', { name: '模型列表' })).not.toBeInTheDocument()
+    await waitFor(() => expect(mocks.save).toHaveBeenCalledTimes(1))
+    expect(mocks.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        IntelligentModels: [
+          expect.objectContaining({ ModelName: 'model-b' }),
+          expect.objectContaining({ ModelName: 'model-a' }),
+        ],
+      }),
+    )
+    fireEvent.click(screen.getByRole('button', { name: '打开选择' }))
+    act(() => resizeInput(width))
+    expect(screen.getByRole('region', { name: '模型列表' })).toBeVisible()
+    fireEvent.click(screen.getByRole('button', { name: '关闭选择' }))
+    expect(mocks.save).toHaveBeenCalledTimes(1)
+  })
+
+  it('选择器外层宽度变化时关闭一级和二级弹窗，高度变化不关闭，关闭后可重新打开', async () => {
     let resizeInput: (width: number, height: number) => void = () => {}
     let observedTarget: Element | undefined
     const disconnect = vi.fn()
@@ -172,6 +210,7 @@ describe('AIModelSelect', () => {
       await waitFor(() => expect(observedTarget).toBe(document.querySelector('.model-trigger')))
       act(() => resizeInput(600, 120))
       const dropdown = screen.getByRole('region', { name: '模型列表' })
+      expect(dropdown).toBeVisible()
       const measureDropdown = vi.spyOn(dropdown.firstElementChild!, 'getBoundingClientRect')
       measureDropdown.mockReturnValue(new DOMRect(100, 0, 200, 300))
       const editButton = within(dropdown).getAllByRole('button')[1]
@@ -183,13 +222,19 @@ describe('AIModelSelect', () => {
 
       act(() => resizeInput(600, 240))
       expect(screen.getByText('model-edited')).toBeVisible()
+      expect(dropdown).toBeVisible()
       act(() => resizeInput(500, 240))
       expect(screen.queryByText('model-edited')).not.toBeInTheDocument()
-      expect(dropdown).toBeVisible()
+      expect(screen.queryByRole('region', { name: '模型列表' })).not.toBeInTheDocument()
+      expect(disconnect).toHaveBeenCalled()
       expect(mocks.save).not.toHaveBeenCalled()
 
-      measureDropdown.mockReturnValue(new DOMRect(200, 0, 200, 300))
-      fireEvent.mouseEnter(editButton)
+      fireEvent.click(screen.getByRole('button', { name: '打开选择' }))
+      act(() => resizeInput(500, 240))
+      const reopenedDropdown = screen.getByRole('region', { name: '模型列表' })
+      const reopenedMeasureDropdown = vi.spyOn(reopenedDropdown.firstElementChild!, 'getBoundingClientRect')
+      reopenedMeasureDropdown.mockReturnValue(new DOMRect(200, 0, 200, 300))
+      fireEvent.mouseEnter(within(reopenedDropdown).getAllByRole('button')[1])
       expect(await screen.findByText('model-edited')).toBeVisible()
       expect(screen.getByText('model-edited').closest('[style*="translate("]')).toHaveStyle({
         transform: 'translate(406px, 0px)',

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/__test__/AIModelSelect.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/__test__/AIModelSelect.test.tsx
@@ -29,6 +29,8 @@ vi.mock('@/pages/ai-re-act/hooks/useAIGlobalConfig', () => ({
 }))
 vi.mock('@/i18n/useI18nNamespaces', () => ({ useI18nNamespaces: () => ({ t: (key: string) => key }) }))
 vi.mock('ahooks', async (importOriginal) => ({
+  // ahooks 导出庞大且此处整体 spread，模块类型无法用 import type 描述，显式豁免。
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   ...(await importOriginal<typeof import('ahooks')>()),
   useInViewport: () => [true],
 }))

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard.tsx
@@ -3,7 +3,7 @@ import styles from './TimelineCard.module.scss'
 import { YakitTag } from '@/components/yakitUI/YakitTag/YakitTag'
 import classNames from 'classnames'
 import { formatTime } from '@/utils/timeUtil'
-import { Virtuoso, type Components, type ItemProps, type ListProps } from 'react-virtuoso'
+import { Virtuoso, type Components, type ContextProp, type ItemProps, type ListProps } from 'react-virtuoso'
 import type { AIAgentGrpcApi } from '@/pages/ai-re-act/hooks/grpcApi'
 import useVirtuosoAutoScroll from '@/pages/ai-re-act/hooks/useVirtuosoAutoScroll'
 import { YakitPopover } from '@/components/yakitUI/YakitPopover/YakitPopover'
@@ -16,6 +16,11 @@ import useCurrentSessionId from '@/pages/ai-re-act/hooks/useCurrentSessionId'
 import useLoadHistory from '@/pages/ai-re-act/hooks/useLoadHistory'
 import { globalSessionEngine } from '@/pages/ai-re-act/hooks/ChatMultiSessionController'
 import { useStore } from 'zustand'
+import {
+  useVirtuosoInitialRender,
+  useVirtuosoListReady,
+  type VirtuosoReadyContext,
+} from '@/pages/ai-agent/components/useVirtuosoInitialRender'
 
 const TYPE_COLOR_MAP: Record<string, 'info' | 'white' | 'danger'> = {
   user_input: 'info',
@@ -58,31 +63,35 @@ const TimelineRow = memo(({ item }: { item: AIAgentGrpcApi.TimelineItem }) => {
 
 TimelineRow.displayName = 'TimelineRow'
 
-const VirtuosoItemContainer = forwardRef<HTMLDivElement, ItemProps<AIAgentGrpcApi.TimelineItem>>(
-  ({ children, style, ...props }, ref) => {
+const VirtuosoItemContainer = forwardRef<
+  HTMLDivElement,
+  ItemProps<AIAgentGrpcApi.TimelineItem> & ContextProp<VirtuosoReadyContext>
+>(({ children, style, context, ...props }, ref) => {
+  return (
+    <div {...props} ref={ref} style={style} className={styles['item-wrapper']}>
+      <div className={styles['item-inner']}>{children}</div>
+    </div>
+  )
+})
+
+VirtuosoItemContainer.displayName = 'VirtuosoItemContainer'
+
+const VirtuosoListContainer = forwardRef<HTMLDivElement, ListProps & ContextProp<VirtuosoReadyContext>>(
+  ({ children, style, context, ...props }, ref) => {
+    useVirtuosoListReady({ children, style, context })
+
     return (
-      <div {...props} ref={ref} style={style} className={styles['item-wrapper']}>
-        <div className={styles['item-inner']}>{children}</div>
+      <div {...props} ref={ref} style={style} className={styles['virtuoso-item-list']}>
+        {children}
       </div>
     )
   },
 )
 
-VirtuosoItemContainer.displayName = 'VirtuosoItemContainer'
-
-const VirtuosoListContainer = forwardRef<HTMLDivElement, ListProps>(({ children, style, ...props }, ref) => {
-  return (
-    <div {...props} ref={ref} style={style} className={styles['virtuoso-item-list']}>
-      {children}
-    </div>
-  )
-})
-
 VirtuosoListContainer.displayName = 'VirtuosoListContainer'
 
-const TimelineCard: FC = () => {
+const TimelineList: FC<{ sessionId: string }> = memo(({ sessionId }) => {
   const store = useCurrentStore()
-  const sessionId = useCurrentSessionId()
 
   const reActTimelines = useStore(store, (state) => state.reActTimelines)
   const timelinesLoading = useStore(store, (state) => state.timelinesLoading)
@@ -100,7 +109,14 @@ const TimelineCard: FC = () => {
     isPrependingRef,
   })
 
-  const components = useMemo<Components<AIAgentGrpcApi.TimelineItem>>(
+  const { renderLoading, virtuosoContext, handleListHeightChanged, initialTopMostItemIndex } = useVirtuosoInitialRender(
+    {
+      dataLength: reActTimelines.length,
+      onHeightChanged: handleTotalListHeightChanged,
+    },
+  )
+
+  const components = useMemo<Components<AIAgentGrpcApi.TimelineItem, VirtuosoReadyContext>>(
     () => ({
       Item: VirtuosoItemContainer,
       List: VirtuosoListContainer,
@@ -118,16 +134,17 @@ const TimelineCard: FC = () => {
         [styles['timeline-card-empty']]: reActTimelines.length === 0,
       })}
     >
-      <YakitSpin spinning={timelinesLoading}>
+      <YakitSpin spinning={timelinesLoading || renderLoading}>
         <Virtuoso
           ref={virtuosoRef}
           firstItemIndex={firstItemIndex}
           data={reActTimelines}
+          context={virtuosoContext}
           components={components}
           scrollerRef={setScrollerRef}
-          totalListHeightChanged={handleTotalListHeightChanged}
+          totalListHeightChanged={handleListHeightChanged}
           atBottomStateChange={setIsAtBottomRef}
-          initialTopMostItemIndex={reActTimelines.length > 0 ? reActTimelines.length - 1 : 0}
+          initialTopMostItemIndex={initialTopMostItemIndex}
           style={{ height: '100%', width: '100%' }}
           increaseViewportBy={{ top: 300, bottom: 300 }}
           atBottomThreshold={100}
@@ -138,5 +155,11 @@ const TimelineCard: FC = () => {
       </YakitSpin>
     </div>
   )
-}
+})
+
+const TimelineCard: FC = memo(() => {
+  const sessionId = useCurrentSessionId()
+  return <TimelineList key={sessionId} sessionId={sessionId} />
+})
+
 export default TimelineCard

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard.tsx
@@ -10,6 +10,7 @@ import { YakitPopover } from '@/components/yakitUI/YakitPopover/YakitPopover'
 import { InformationCircleOutlined } from '@yakit-libs/yakit-ui-icons/outline'
 import { useMemoizedFn } from 'ahooks'
 import { YakitSpin } from '@/components/yakitUI/YakitSpin/YakitSpin'
+import { YakitEmpty } from '@/components/yakitUI/YakitEmpty/YakitEmpty'
 import { useCurrentStore } from '@/pages/ai-re-act/hooks/useCurrentDataBySession'
 import useCurrentSessionId from '@/pages/ai-re-act/hooks/useCurrentSessionId'
 import useLoadHistory from '@/pages/ai-re-act/hooks/useLoadHistory'
@@ -103,9 +104,10 @@ const TimelineCard: FC = () => {
     () => ({
       Item: VirtuosoItemContainer,
       List: VirtuosoListContainer,
+      EmptyPlaceholder: () => (timelinesLoading ? null : <YakitEmpty />),
       Footer: () => (reActTimelines.length > 0 ? <div className={styles['arrow']} /> : null),
     }),
-    [reActTimelines.length],
+    [reActTimelines.length, timelinesLoading],
   )
 
   const itemContent = useMemoizedFn((_: number, item: AIAgentGrpcApi.TimelineItem) => <TimelineRow item={item} />)

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/TimelineCard/__test__/TimelineCard.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/TimelineCard/__test__/TimelineCard.test.tsx
@@ -1,37 +1,206 @@
-import type React from 'react'
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { createContext, useContext } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { VirtuosoMockContext } from 'react-virtuoso'
+import { createStore } from 'zustand/vanilla'
+import type { AIAgentGrpcApi } from '@/pages/ai-re-act/hooks/grpcApi'
+import type useAutoScrollFn from '@/pages/ai-re-act/hooks/useVirtuosoAutoScroll'
 import TimelineCard from '../TimelineCard'
 
-const state = vi.hoisted(() => ({ reActTimelines: [] as unknown[], timelinesLoading: false }))
-vi.mock('@/pages/ai-re-act/hooks/useCurrentDataBySession', () => ({ useCurrentStore: () => state }))
-vi.mock('zustand', () => ({ useStore: (_: unknown, selector: (value: typeof state) => unknown) => selector(state) }))
-vi.mock('@/pages/ai-re-act/hooks/useCurrentSessionId', () => ({ default: () => 'session' }))
-vi.mock('@/pages/ai-re-act/hooks/useLoadHistory', () => ({ default: () => ({}) }))
-vi.mock('@/pages/ai-re-act/hooks/useVirtuosoAutoScroll', () => ({ default: () => ({}) }))
-vi.mock('@/pages/ai-re-act/hooks/ChatMultiSessionController', () => ({ globalSessionEngine: {} }))
+const store = createStore(() => ({ reActTimelines: [] as AIAgentGrpcApi.TimelineItem[], timelinesLoading: false }))
+const SessionContext = createContext('session-1')
+const { autoScroll, hasMore, loadMore } = vi.hoisted(() => ({
+  autoScroll: vi.fn(),
+  hasMore: vi.fn(() => false),
+  loadMore: vi.fn(),
+}))
+vi.mock('@/pages/ai-re-act/hooks/useCurrentDataBySession', () => ({ useCurrentStore: () => store }))
+vi.mock('@/pages/ai-re-act/hooks/useCurrentSessionId', () => {
+  // 与真实 hook 一样订阅 Context，使会话切换能够触发 memo 组件更新。
+  const useSessionIdMock = () => useContext(SessionContext)
+  return { default: useSessionIdMock }
+})
+vi.mock('@/pages/ai-re-act/hooks/ChatMultiSessionController', () => ({
+  globalSessionEngine: { hasMoreTimeline: hasMore, loadTimelineHistory: loadMore },
+}))
+// 仅记录自动跟随调用，保留真实 hook 的滚动和向上加载保护。
+vi.mock('@/pages/ai-re-act/hooks/useVirtuosoAutoScroll', async (importOriginal) => {
+  const { default: useAutoScroll } = await importOriginal<{ default: typeof useAutoScrollFn }>()
+  const useAutoScrollMock = (...args: Parameters<typeof useAutoScroll>) => {
+    const result = useAutoScroll(...args)
+    return {
+      ...result,
+      handleTotalListHeightChanged: () => {
+        autoScroll()
+        result.handleTotalListHeightChanged()
+      },
+    }
+  }
+  return { default: useAutoScrollMock }
+})
 vi.mock('@/utils/timeUtil', () => ({ formatTime: () => '' }))
 vi.mock('@/components/yakitUI/YakitEmpty/YakitEmpty', () => ({ YakitEmpty: () => <div>暂无数据</div> }))
-vi.mock('@/components/yakitUI/YakitSpin/YakitSpin', () => ({
-  YakitSpin: ({ children }: React.PropsWithChildren) => children,
-}))
-vi.mock('react-virtuoso', () => ({
-  Virtuoso: ({ data, components }: { data: unknown[]; components: { EmptyPlaceholder: React.FC } }) =>
-    data.length ? <div>时间线数据</div> : <components.EmptyPlaceholder />,
-}))
 
-describe('TimelineCard 空状态', () => {
-  it('无数据时显示 YakitEmpty，加载中隐藏，收到数据后展示列表', () => {
-    const result = render(<TimelineCard />)
-    expect(screen.getByText('暂无数据')).toBeInTheDocument()
-    state.timelinesLoading = true
-    result.rerender(<TimelineCard />)
+const VIEWPORT_HEIGHT = 400
+const ITEM_HEIGHT = 80
+const createItems = (count: number, start = 0): AIAgentGrpcApi.TimelineItem[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: start + index,
+    timestamp: 1,
+    type: 'text',
+    content: `时间线内容 ${start + index}`,
+    deleted: false,
+  }))
+const originalScrollTo = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollTo')
+const originalScrollBy = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollBy')
+const scrollTo = vi.fn(function (this: HTMLElement, options: ScrollToOptions) {
+  this.scrollTop = options.top ?? 0
+  this.dispatchEvent(new Event('scroll'))
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  hasMore.mockReturnValue(false)
+  loadMore.mockReset()
+  store.setState({ reActTimelines: [], timelinesLoading: false })
+  // jsdom 没有布局，使用官方尺寸上下文并补充滚动容器几何信息。
+  vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(VIEWPORT_HEIGHT)
+  vi.spyOn(Element.prototype, 'scrollHeight', 'get').mockImplementation(
+    () => store.getState().reActTimelines.length * ITEM_HEIGHT,
+  )
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    height: VIEWPORT_HEIGHT,
+    width: 300,
+    top: 0,
+    bottom: VIEWPORT_HEIGHT,
+    left: 0,
+    right: 300,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  })
+  Object.defineProperty(HTMLElement.prototype, 'scrollTo', { configurable: true, value: scrollTo })
+  Object.defineProperty(HTMLElement.prototype, 'scrollBy', {
+    configurable: true,
+    value(this: HTMLElement, options: ScrollToOptions) {
+      scrollTo.call(this, { top: this.scrollTop + (options.top ?? 0) })
+    },
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  if (originalScrollTo) Object.defineProperty(HTMLElement.prototype, 'scrollTo', originalScrollTo)
+  else Reflect.deleteProperty(HTMLElement.prototype, 'scrollTo')
+  if (originalScrollBy) Object.defineProperty(HTMLElement.prototype, 'scrollBy', originalScrollBy)
+  else Reflect.deleteProperty(HTMLElement.prototype, 'scrollBy')
+})
+
+const timelineElement = (sessionId = 'session-1') => (
+  <SessionContext.Provider value={sessionId}>
+    <VirtuosoMockContext.Provider value={{ viewportHeight: VIEWPORT_HEIGHT, itemHeight: ITEM_HEIGHT }}>
+      <TimelineCard />
+    </VirtuosoMockContext.Provider>
+  </SessionContext.Provider>
+)
+const renderTimeline = () => render(timelineElement())
+const getScroller = () => document.querySelector<HTMLElement>('[data-virtuoso-scroller]')!
+const isSpinning = () => document.querySelector('.ant-spin-spinning') !== null
+const finishPositioning = async () => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(1000)
+  })
+}
+
+describe('TimelineCard 首次定位', () => {
+  it.each([1, 20])('已有 %s 条数据时覆盖列表隐藏阶段，首次定位到底部后才结束加载', async (count) => {
+    store.setState({ reActTimelines: createItems(count) })
+    renderTimeline()
+    expect(isSpinning()).toBe(true)
+    expect(screen.getByTestId('virtuoso-item-list')).toHaveStyle({ visibility: 'hidden' })
+    expect(autoScroll).not.toHaveBeenCalled()
+
+    await finishPositioning()
+    expect(screen.getByTestId('virtuoso-item-list')).not.toHaveStyle({ visibility: 'hidden' })
+    expect(isSpinning()).toBe(false)
+    expect(screen.getByText(`时间线内容 ${count - 1}`)).toBeVisible()
+    expect(getScroller().scrollTop).toBe(Math.max(0, count * ITEM_HEIGHT - VIEWPORT_HEIGHT))
+    expect(autoScroll).not.toHaveBeenCalled()
+  })
+
+  it('空数据保持空态，首批数据晚到时等待定位完成再停止加载', async () => {
+    renderTimeline()
+    expect(screen.getByText('暂无数据')).toBeVisible()
+    expect(isSpinning()).toBe(false)
+    act(() => store.setState({ timelinesLoading: true }))
     expect(screen.queryByText('暂无数据')).not.toBeInTheDocument()
-    state.timelinesLoading = false
-    state.reActTimelines = [{}]
-    result.rerender(<TimelineCard />)
-    expect(screen.queryByText('暂无数据')).not.toBeInTheDocument()
-    expect(screen.getByText('时间线数据')).toBeInTheDocument()
-    state.reActTimelines = []
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(isSpinning()).toBe(true)
+
+    act(() => store.setState({ reActTimelines: createItems(20), timelinesLoading: false }))
+    expect(isSpinning()).toBe(true)
+    await finishPositioning()
+    expect(isSpinning()).toBe(false)
+    expect(getScroller().scrollTop).toBe(20 * ITEM_HEIGHT - VIEWPORT_HEIGHT)
+    expect(screen.getByText('时间线内容 19')).toBeVisible()
+  })
+
+  it('首次就绪后继续跟随新增数据，用户向上滚动后不强制回到底部', async () => {
+    store.setState({ reActTimelines: createItems(20) })
+    renderTimeline()
+    await finishPositioning()
+    act(() => store.setState({ reActTimelines: createItems(21) }))
+    await finishPositioning()
+    expect(autoScroll).toHaveBeenCalled()
+    expect(getScroller().scrollTop).toBe(21 * ITEM_HEIGHT - VIEWPORT_HEIGHT)
+
+    fireEvent.wheel(getScroller(), { deltaY: -100 })
+    fireEvent.scroll(getScroller(), { target: { scrollTop: 400 } })
+    act(() => store.setState({ reActTimelines: createItems(22) }))
+    await finishPositioning()
+    expect(getScroller().scrollTop).toBe(400)
+    expect(isSpinning()).toBe(false)
+  })
+
+  it('切换会话后重新定位和展示首屏加载状态', async () => {
+    store.setState({ reActTimelines: createItems(20) })
+    const result = renderTimeline()
+    await finishPositioning()
+    result.rerender(timelineElement('session-2'))
+    expect(isSpinning()).toBe(true)
+    await finishPositioning()
+    expect(isSpinning()).toBe(false)
+    expect(getScroller().scrollTop).toBe(20 * ITEM_HEIGHT - VIEWPORT_HEIGHT)
+  })
+
+  it('向上加载历史后保留当前内容位置，完成后清除请求加载提示', async () => {
+    store.setState({ reActTimelines: createItems(20) })
+    renderTimeline()
+    await finishPositioning()
+    hasMore.mockReturnValue(true)
+    loadMore.mockImplementation(() => store.setState({ timelinesLoading: true }))
+    fireEvent.wheel(getScroller(), { deltaY: -100 })
+    fireEvent.scroll(getScroller(), { target: { scrollTop: 0 } })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+    expect(loadMore).toHaveBeenCalledWith('session-1')
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(isSpinning()).toBe(true)
+
+    hasMore.mockReturnValue(false)
+    act(() => store.setState({ reActTimelines: [...createItems(5, -5), ...createItems(20)], timelinesLoading: false }))
+    await finishPositioning()
+    expect(getScroller().scrollTop).toBeLessThan(25 * ITEM_HEIGHT - VIEWPORT_HEIGHT)
+    expect(screen.getByText('时间线内容 0')).toBeVisible()
+    expect(isSpinning()).toBe(false)
   })
 })

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/TimelineCard/__test__/TimelineCard.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/TimelineCard/__test__/TimelineCard.test.tsx
@@ -1,0 +1,37 @@
+import type React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import TimelineCard from '../TimelineCard'
+
+const state = vi.hoisted(() => ({ reActTimelines: [] as unknown[], timelinesLoading: false }))
+vi.mock('@/pages/ai-re-act/hooks/useCurrentDataBySession', () => ({ useCurrentStore: () => state }))
+vi.mock('zustand', () => ({ useStore: (_: unknown, selector: (value: typeof state) => unknown) => selector(state) }))
+vi.mock('@/pages/ai-re-act/hooks/useCurrentSessionId', () => ({ default: () => 'session' }))
+vi.mock('@/pages/ai-re-act/hooks/useLoadHistory', () => ({ default: () => ({}) }))
+vi.mock('@/pages/ai-re-act/hooks/useVirtuosoAutoScroll', () => ({ default: () => ({}) }))
+vi.mock('@/pages/ai-re-act/hooks/ChatMultiSessionController', () => ({ globalSessionEngine: {} }))
+vi.mock('@/utils/timeUtil', () => ({ formatTime: () => '' }))
+vi.mock('@/components/yakitUI/YakitEmpty/YakitEmpty', () => ({ YakitEmpty: () => <div>暂无数据</div> }))
+vi.mock('@/components/yakitUI/YakitSpin/YakitSpin', () => ({
+  YakitSpin: ({ children }: React.PropsWithChildren) => children,
+}))
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: ({ data, components }: { data: unknown[]; components: { EmptyPlaceholder: React.FC } }) =>
+    data.length ? <div>时间线数据</div> : <components.EmptyPlaceholder />,
+}))
+
+describe('TimelineCard 空状态', () => {
+  it('无数据时显示 YakitEmpty，加载中隐藏，收到数据后展示列表', () => {
+    const result = render(<TimelineCard />)
+    expect(screen.getByText('暂无数据')).toBeInTheDocument()
+    state.timelinesLoading = true
+    result.rerender(<TimelineCard />)
+    expect(screen.queryByText('暂无数据')).not.toBeInTheDocument()
+    state.timelinesLoading = false
+    state.reActTimelines = [{}]
+    result.rerender(<TimelineCard />)
+    expect(screen.queryByText('暂无数据')).not.toBeInTheDocument()
+    expect(screen.getByText('时间线数据')).toBeInTheDocument()
+    state.reActTimelines = []
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/aiTaskExecutionDetails/AITaskExecutionDetails.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/aiTaskExecutionDetails/AITaskExecutionDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import classNames from 'classnames'
 import type {
   AIBrowserProcessesProps,
@@ -21,7 +21,7 @@ import { AISkippedNodeIcon } from '@yakit-libs/yakit-ui-icons/oldicon/AISkippedN
 import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
 import { YakitPopconfirm } from '@/components/yakitUI/YakitPopconfirm/YakitPopconfirm'
 import { AIToDoListItem } from '@/pages/ai-re-act/aiReActChat/aiToDoList/AIToDoList'
-import { useCreation, useInterval, useMemoizedFn, useSelections } from 'ahooks'
+import { useCreation, useMemoizedFn, useSelections } from 'ahooks'
 import type {
   ForgesAndSkillsDynamicItem,
   PlanItemDetailsData,
@@ -64,36 +64,19 @@ import { YakitRadioButtons } from '@/components/yakitUI/YakitRadioButtons/YakitR
 import { timeDiffWithMoment } from '@/utils/timeUtil'
 import { AITaskActionItem, AITaskExecutionList } from './aiTaskExecutionList/AITaskExecutionList'
 import { AIToDoListDetail } from '@/pages/ai-re-act/aiReActChat/aiToDoList/AIToDoListDetail'
-import { useCurrentRawData } from '@/pages/ai-re-act/hooks/useCurrentDataBySession'
+import useCurrentTaskData from '@/pages/ai-re-act/hooks/useCurrentTaskData/useCurrentTaskData'
 import useCurrentSessionId from '@/pages/ai-re-act/hooks/useCurrentSessionId'
 import useAIAgentDispatcher from '../../useContext/useDispatcher'
 import { randomString } from '@/utils/randomUtil'
 
 export const AITaskExecutionDetails: React.FC<AITaskExecutionDetailsProps> = React.memo((props) => {
   const { taskId, taskGoal, taskName, onClose } = props
-  const rawData = useCurrentRawData()
-
-  const [planItemDetailsData, setPlanItemDetailsData] = useState<PlanItemDetailsData>()
-  const perPlanItemDetailsDataUUIdRef = useRef<string>('')
-  useEffect(() => {
-    onReset()
-    getData()
-  }, [taskId])
-  useInterval(() => {
-    getData()
-  }, 5 * 1000)
-  const onReset = useMemoizedFn(() => {
-    setPlanItemDetailsData(undefined)
-    perPlanItemDetailsDataUUIdRef.current = ''
-  })
-  const getData = useMemoizedFn(() => {
-    if (!taskId) return
-    const itemData = rawData.taskDetailsMap.get(taskId)
-    if (!itemData) return
-    if (perPlanItemDetailsDataUUIdRef.current === itemData.uuid) return
-    perPlanItemDetailsDataUUIdRef.current = itemData.uuid
-    setPlanItemDetailsData(cloneDeep(itemData))
-  })
+  const taskData = useCurrentTaskData(taskId, 5)
+  // taskDetailsMap 中的数据会原地更新，使用 uuid 作为快照变更信号，避免详情组件持有可变引用。
+  const planItemDetailsData = useCreation<PlanItemDetailsData | undefined>(
+    () => (taskData ? cloneDeep(taskData) : undefined),
+    [taskId, taskData?.uuid],
+  )
   const perception = useCreation(() => {
     if (!planItemDetailsData) return
     return planItemDetailsData.perception

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/aiTaskExecutionDetails/__test__/AITaskExecutionDetails.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/aiTaskExecutionDetails/__test__/AITaskExecutionDetails.test.tsx
@@ -1,0 +1,134 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import cloneDeep from 'lodash/cloneDeep'
+import type { PlanItemDetailsData, TodoListCardData } from '@/pages/ai-re-act/hooks/aiRender'
+import { DefaultPlanItemDetailsData } from '@/pages/ai-re-act/hooks/defaultConstant'
+import { AITaskExecutionDetails } from '../AITaskExecutionDetails'
+
+const taskDetailsMap = new Map<string, PlanItemDetailsData>()
+const todoDetail = vi.fn(({ todoData }: { todoData: TodoListCardData }) => (
+  <div data-testid="todo-detail">{todoData.items.map((item) => item.content).join(',')}</div>
+))
+
+// 保留真实的数据读取、轮询和快照逻辑，只隔离会话来源及无关子组件。
+vi.mock('@/pages/ai-re-act/hooks/useCurrentDataBySession', () => ({
+  useCurrentRawData: () => ({ taskDetailsMap }),
+}))
+vi.mock('@/pages/ai-re-act/hooks/useCurrentSessionId', () => ({ default: () => 'session-1' }))
+vi.mock('../../../useContext/useDispatcher', () => ({ default: () => ({ onSend: vi.fn() }) }))
+vi.mock('@/pages/ai-re-act/aiReActChat/aiToDoList/AIToDoListDetail', () => ({
+  AIToDoListDetail: (props: { todoData: TodoListCardData }) => todoDetail(props),
+}))
+vi.mock('@/pages/ai-re-act/aiReActChat/aiToDoList/AIToDoList', () => ({
+  AIToDoListItem: ({ item }: { item: TodoListCardData['items'][number] }) => <div>{item.content}</div>,
+}))
+vi.mock('@/pages/plugins/operator/horizontalScrollCard/HorizontalScrollCard', () => ({
+  HorizontalScrollCardItemInfoMultiple: () => null,
+  HorizontalScrollCardItemInfoSingle: () => null,
+}))
+vi.mock('@/components/RollingLoadList/RollingLoadList', () => ({ RollingLoadList: () => null }))
+vi.mock('@/components/TableTotalAndSelectNumber/TableTotalAndSelectNumber', () => ({
+  TableTotalAndSelectNumber: () => null,
+}))
+vi.mock('@/components/yakitUI/YakitEmpty/YakitEmpty', () => ({
+  YakitEmpty: ({ title }: { title: string }) => <div>{title}</div>,
+}))
+vi.mock('@/pages/ai-agent/grpc', () => ({ grpcQueryAIForge: vi.fn() }))
+vi.mock('@/pages/ai-agent/aiToolList/utils', () => ({ grpcGetAIToolList: vi.fn() }))
+vi.mock('@/pages/plugins/utils', () => ({ apiQueryYakScript: vi.fn() }))
+vi.mock('@/pages/ai-agent/aiMCP/utils', () => ({ grpcGetAllMCPServers: vi.fn() }))
+
+const createTask = (taskId: string, summary: string) => {
+  const data = cloneDeep(DefaultPlanItemDetailsData)
+  data.taskId = taskId
+  data.uuid = 'uuid-1'
+  data.perception.summary = summary
+  data.todoList.items = [
+    { id: `${taskId}-todo`, content: `${summary}待办`, status: 'PENDING', created_at: 1, updated_at: 1 },
+  ]
+  data.todoList.stats.pending = 1
+  taskDetailsMap.set(taskId, data)
+  return data
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  taskDetailsMap.clear()
+  todoDetail.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+describe('AITaskExecutionDetails 快照刷新', () => {
+  it('taskId 切换立即读取新任务，即使两个任务的 uuid 相同', () => {
+    createTask('task-a', '任务 A 感知')
+    createTask('task-b', '任务 B 感知')
+    const { rerender } = render(<AITaskExecutionDetails taskId="task-a" />)
+    expect(screen.getByText('任务 A 感知')).toBeInTheDocument()
+
+    rerender(<AITaskExecutionDetails taskId="task-b" />)
+
+    expect(screen.queryByText('任务 A 感知')).not.toBeInTheDocument()
+    expect(screen.getByText('任务 B 感知')).toBeInTheDocument()
+    expect(screen.getByTestId('todo-detail')).toHaveTextContent('任务 B 感知待办')
+  })
+
+  it.each(['missing-task', ''])('切换到无数据的 taskId %j 时立即清空旧详情', (taskId) => {
+    createTask('task-a', '旧任务感知')
+    const { rerender } = render(<AITaskExecutionDetails taskId="task-a" />)
+    expect(screen.getByTestId('todo-detail')).toHaveTextContent('旧任务感知待办')
+
+    rerender(<AITaskExecutionDetails taskId={taskId} />)
+
+    expect(screen.queryByText('旧任务感知')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('todo-detail')).not.toBeInTheDocument()
+    expect(screen.getByText('暂无待办任务')).toBeInTheDocument()
+  })
+
+  it('uuid 变化后在 5 秒轮询时生成新快照并刷新详情', () => {
+    const data = createTask('task-a', '刷新前感知')
+    render(<AITaskExecutionDetails taskId="task-a" />)
+    const previousTodo = todoDetail.mock.calls.at(-1)![0].todoData
+
+    data.perception.summary = '刷新后感知'
+    data.todoList.items[0].content = '刷新后待办'
+    data.uuid = 'uuid-2'
+    act(() => vi.advanceTimersByTime(4999))
+    expect(screen.getByText('刷新前感知')).toBeInTheDocument()
+
+    act(() => vi.advanceTimersByTime(1))
+
+    expect(screen.queryByText('刷新前感知')).not.toBeInTheDocument()
+    expect(screen.getByText('刷新后感知')).toBeInTheDocument()
+    expect(screen.getByTestId('todo-detail')).toHaveTextContent('刷新后待办')
+    expect(todoDetail.mock.calls.at(-1)![0].todoData).not.toBe(previousTodo)
+    expect(previousTodo.items[0].content).toBe('刷新前感知待办')
+  })
+
+  it('Map 条目原地修改且 uuid 不变时，轮询和父组件重渲染均不污染已渲染快照', () => {
+    const data = createTask('task-a', '原始感知')
+    const { rerender } = render(<AITaskExecutionDetails taskId="task-a" taskName="原始标题" />)
+    const renderedTodo = todoDetail.mock.calls.at(-1)![0].todoData
+
+    data.perception.summary = '未发布感知'
+    data.todoList.items[0].content = '未发布待办'
+    data.todoList.items[0].status = 'DONE'
+    data.todoList.stats.pending = 0
+    data.todoList.stats.done = 1
+    act(() => vi.advanceTimersByTime(5000))
+    // 改变非数据属性，确保 React.memo 不会跳过本次组件渲染。
+    rerender(<AITaskExecutionDetails taskId="task-a" taskName="新标题" />)
+
+    expect(screen.getByText('新标题')).toBeInTheDocument()
+    expect(screen.getByText('原始感知')).toBeInTheDocument()
+    expect(screen.queryByText('未发布感知')).not.toBeInTheDocument()
+    expect(screen.getByTestId('todo-detail')).toHaveTextContent('原始感知待办')
+    expect(todoDetail.mock.calls.at(-1)![0].todoData).toBe(renderedTodo)
+    expect(renderedTodo.items[0]).toMatchObject({ content: '原始感知待办', status: 'PENDING' })
+    expect(renderedTodo.stats).toMatchObject({ pending: 1, done: 0 })
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/HistoryTaskTree.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/HistoryTaskTree.tsx
@@ -108,7 +108,7 @@ export const HistoryTaskTree: React.FC<HistoryTaskTreeProps> = memo((props) => {
       {expanded && (
         <div className={styles['section-body']}>
           <YakitCollapse
-            destroyInactivePanel
+            destroyOnHidden
             accordion
             bordered={false}
             activeKey={activeKey}

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/SubAgentList.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/SubAgentList.tsx
@@ -1,10 +1,10 @@
 import type React from 'react'
 import { memo, useState } from 'react'
 import styles from './HistoryTaskTree.module.scss'
-import { ChevronDownOutlined } from '@yakit-libs/yakit-ui-icons/outline'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { useCasualConcurrentTaskList } from './useHasTaskTree'
 import { AITree } from '../../aiTree/AITree'
+import { ChevronDownOutlined } from '@yakit-libs/yakit-ui-icons/outline'
 
 export const SubAgentList: React.FC = memo(() => {
   const { t } = useI18nNamespaces(['aiAgent'])

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/TaskListPane.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/TaskListPane.tsx
@@ -1,15 +1,33 @@
 import type React from 'react'
 import { memo } from 'react'
+import { useStore } from 'zustand'
+import { YakitEmpty } from '@/components/yakitUI/YakitEmpty/YakitEmpty'
+import { useCurrentStore } from '@/pages/ai-re-act/hooks/useCurrentDataBySession'
 import styles from './HistoryTaskTree.module.scss'
 import { HistoryTaskTree } from './HistoryTaskTree'
 import { SubAgentList } from './SubAgentList'
+import { useHasTaskTree } from './useHasTaskTree'
 
 /** 任务列表面板：任务列表 + 子 Agent */
 export const TaskListPane: React.FC = memo(() => {
+  const store = useCurrentStore()
+  const hasTaskTree = useHasTaskTree()
+  const hasHistoryTasks = useStore(store, (state) =>
+    (state.planHistoryList?.records ?? []).some(
+      (item) => item.coordinator_id !== (state.currentChatStatus.coordinatorId ?? ''),
+    ),
+  )
+
   return (
     <div className={styles['history-task-tree-container']}>
-      <HistoryTaskTree />
-      <SubAgentList />
+      {hasTaskTree || hasHistoryTasks ? (
+        <>
+          <HistoryTaskTree />
+          <SubAgentList />
+        </>
+      ) : (
+        <YakitEmpty />
+      )}
     </div>
   )
 })

--- a/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/__test__/TaskListPane.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/chatTemplate/historyTaskTree/__test__/TaskListPane.test.tsx
@@ -1,0 +1,60 @@
+import { act, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStore } from 'zustand/vanilla'
+import { AIChatQSDataTypeEnum } from '@/pages/ai-re-act/hooks/aiRender'
+import { TaskListPane } from '../TaskListPane'
+
+const store = createStore(() => ({
+  currentPlan: { task_tree: [] as object[] },
+  currentChatStatus: { coordinatorId: 'current' },
+  planHistoryList: { records: [] as { coordinator_id: string }[] },
+  chatElements: [] as { token: string; chatType: string }[],
+  tasks: {} as Record<string, { renderNum: number }>,
+}))
+const initialState = store.getState()
+const contents = new Map<string, { type: string; data: { taskId: string } }>()
+vi.mock('@/pages/ai-re-act/hooks/useCurrentDataBySession', () => ({
+  useCurrentStore: () => store,
+  useCurrentRawData: () => ({ contents }),
+}))
+vi.mock('@/pages/ai-re-act/hooks/useAIItemKind', () => ({ default: () => () => 'task' }))
+vi.mock('../HistoryTaskTree', () => ({ HistoryTaskTree: () => <div>任务树</div> }))
+vi.mock('../SubAgentList', () => ({ SubAgentList: () => <div>子 Agent</div> }))
+vi.mock('@/components/yakitUI/YakitEmpty/YakitEmpty', () => ({ YakitEmpty: () => <div>暂无数据</div> }))
+
+beforeEach(() => {
+  store.setState(initialState, true)
+  contents.clear()
+})
+
+describe('TaskListPane', () => {
+  it('所有数据为空时显示空状态，数据到达和清空时同步切换', () => {
+    render(<TaskListPane />)
+    expect(screen.getByText('暂无数据')).toBeInTheDocument()
+    expect(screen.queryByText('任务树')).not.toBeInTheDocument()
+    act(() => store.setState({ currentPlan: { task_tree: [{}] } }))
+    expect(screen.queryByText('暂无数据')).not.toBeInTheDocument()
+    expect(screen.getByText('任务树')).toBeInTheDocument()
+    act(() => store.setState({ currentPlan: { task_tree: [] } }))
+    expect(screen.getByText('暂无数据')).toBeInTheDocument()
+  })
+
+  it('仅有历史任务时保留列表，但排除当前协调器的重复历史记录', () => {
+    store.setState({ planHistoryList: { records: [{ coordinator_id: 'history' }] } })
+    render(<TaskListPane />)
+    expect(screen.getByText('任务树')).toBeInTheDocument()
+    expect(screen.queryByText('暂无数据')).not.toBeInTheDocument()
+    act(() => store.setState({ planHistoryList: { records: [{ coordinator_id: 'current' }] } }))
+    expect(screen.getByText('暂无数据')).toBeInTheDocument()
+  })
+
+  it('仅有子 Agent 时保留列表，移除后显示空状态', () => {
+    contents.set('child', { type: AIChatQSDataTypeEnum.TASK_NODE_GROUP, data: { taskId: 'child' } })
+    store.setState({ chatElements: [{ token: 'child', chatType: 'reAct' }], tasks: { child: { renderNum: 1 } } })
+    render(<TaskListPane />)
+    expect(screen.getByText('子 Agent')).toBeInTheDocument()
+    expect(screen.queryByText('暂无数据')).not.toBeInTheDocument()
+    act(() => store.setState({ chatElements: [] }))
+    expect(screen.getByText('暂无数据')).toBeInTheDocument()
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-agent/components/__test__/useVirtuosoInitialRender.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/components/__test__/useVirtuosoInitialRender.test.tsx
@@ -1,0 +1,108 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useVirtuosoInitialRender, useVirtuosoListReady } from '../useVirtuosoInitialRender'
+
+type ListReadyProps = Parameters<typeof useVirtuosoListReady>[0]
+
+describe('useVirtuosoInitialRender', () => {
+  it('空列表不显示 loading，首批数据到达后等待就绪，后续追加不重新加载', () => {
+    const onHeightChanged = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ dataLength }) => useVirtuosoInitialRender({ dataLength, onHeightChanged }),
+      { initialProps: { dataLength: 0 } },
+    )
+    expect(result.current.renderLoading).toBe(false)
+    expect(result.current.initialTopMostItemIndex).toEqual({ index: 'LAST', align: 'end', behavior: 'auto' })
+
+    rerender({ dataLength: 2 })
+    expect(result.current.renderLoading).toBe(true)
+    act(() => result.current.virtuosoContext.onReady())
+    expect(result.current.renderLoading).toBe(false)
+
+    rerender({ dataLength: 3 })
+    expect(result.current.renderLoading).toBe(false)
+  })
+
+  it('首次定位前拦截高度回调，就绪后通过已有引用调用最新回调', () => {
+    const firstCallback = vi.fn()
+    const nextCallback = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ onHeightChanged }) => useVirtuosoInitialRender({ dataLength: 2, onHeightChanged }),
+      { initialProps: { onHeightChanged: firstCallback } },
+    )
+    // Virtuoso 可能保留之前收到的回调引用，该引用仍须读取最新状态。
+    const handleHeightChanged = result.current.handleListHeightChanged
+    act(() => handleHeightChanged())
+    expect(firstCallback).not.toHaveBeenCalled()
+
+    act(() => result.current.virtuosoContext.onReady())
+    act(() => handleHeightChanged())
+    expect(firstCallback).toHaveBeenCalledTimes(1)
+
+    rerender({ onHeightChanged: nextCallback })
+    act(() => handleHeightChanged())
+    expect(firstCallback).toHaveBeenCalledTimes(1)
+    expect(nextCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('不同列表的就绪状态互不影响，重新挂载时重新等待首屏', () => {
+    const timeline = renderHook(() => useVirtuosoInitialRender({ dataLength: 2, onHeightChanged: vi.fn() }))
+    const chat = renderHook(() => useVirtuosoInitialRender({ dataLength: 2, onHeightChanged: vi.fn() }))
+    act(() => timeline.result.current.virtuosoContext.onReady())
+    expect(timeline.result.current.renderLoading).toBe(false)
+    expect(chat.result.current.renderLoading).toBe(true)
+
+    timeline.unmount()
+    const nextSession = renderHook(() => useVirtuosoInitialRender({ dataLength: 2, onHeightChanged: vi.fn() }))
+    expect(nextSession.result.current.renderLoading).toBe(true)
+    expect(chat.result.current.renderLoading).toBe(true)
+  })
+})
+
+describe('useVirtuosoListReady', () => {
+  it('空列表和仅挂载但仍被隐藏的列表不通知就绪，首次定位完成后再通知', () => {
+    const onReady = vi.fn()
+    const context = { onReady }
+    const initialProps: ListReadyProps = { children: null, style: {}, context }
+    const { rerender } = renderHook(useVirtuosoListReady, { initialProps })
+    expect(onReady).not.toHaveBeenCalled()
+
+    rerender({ children: [], style: {}, context })
+    expect(onReady).not.toHaveBeenCalled()
+    rerender({ children: <div>消息</div>, style: { visibility: 'hidden' }, context })
+    expect(onReady).not.toHaveBeenCalled()
+
+    rerender({ children: <div>消息</div>, style: {}, context })
+    expect(onReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('可见的空列表收到首批内容时通知就绪', () => {
+    const onReady = vi.fn()
+    const context = { onReady }
+    const initialProps: ListReadyProps = { children: null, style: {}, context }
+    const { rerender } = renderHook(useVirtuosoListReady, { initialProps })
+    expect(onReady).not.toHaveBeenCalled()
+
+    rerender({ children: <div>消息</div>, style: {}, context })
+    expect(onReady).toHaveBeenCalledTimes(1)
+  })
+
+  it('等待期间 Context 回调变化时，通知最新的接收方', () => {
+    const firstCallback = vi.fn()
+    const nextCallback = vi.fn()
+    const children = <div>消息</div>
+    const initialProps: ListReadyProps = {
+      children,
+      style: { visibility: 'hidden' },
+      context: { onReady: firstCallback },
+    }
+    const { rerender } = renderHook(useVirtuosoListReady, { initialProps })
+    rerender({ children, style: { visibility: 'hidden' }, context: { onReady: nextCallback } })
+    expect(firstCallback).not.toHaveBeenCalled()
+    expect(nextCallback).not.toHaveBeenCalled()
+
+    rerender({ children, style: { visibility: 'visible' }, context: { onReady: nextCallback } })
+    expect(firstCallback).not.toHaveBeenCalled()
+    expect(nextCallback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-agent/components/useVirtuosoInitialRender.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/components/useVirtuosoInitialRender.ts
@@ -1,0 +1,43 @@
+import { Children, useEffect, useMemo, useState } from 'react'
+import { useMemoizedFn } from 'ahooks'
+import type { ContextProp, ListProps } from 'react-virtuoso'
+
+export interface VirtuosoReadyContext {
+  onReady: () => void
+}
+
+interface UseVirtuosoInitialRenderProps {
+  dataLength: number
+  onHeightChanged: () => void
+}
+
+const initialTopMostItemIndex = { index: 'LAST', align: 'end', behavior: 'auto' } as const
+
+/** 管理首屏渲染状态；由调用方的会话 key 在切换会话时重置。 */
+export const useVirtuosoInitialRender = ({ dataLength, onHeightChanged }: UseVirtuosoInitialRenderProps) => {
+  const [listReady, setListReady] = useState(false)
+  const handleListReady = useMemoizedFn(() => setListReady(true))
+  const virtuosoContext = useMemo<VirtuosoReadyContext>(() => ({ onReady: handleListReady }), [handleListReady])
+  const renderLoading = dataLength > 0 && !listReady
+
+  const handleListHeightChanged = useMemoizedFn(() => {
+    // 首次滚动交给 initialTopMostItemIndex，就绪后再跟随内容高度变化。
+    if (!listReady) return
+    onHeightChanged()
+  })
+
+  return { renderLoading, virtuosoContext, handleListHeightChanged, initialTopMostItemIndex }
+}
+
+/** 在自定义 List 中使用：列表项已挂载，且 Virtuoso 已完成首次定位时通知就绪。 */
+export const useVirtuosoListReady = ({
+  children,
+  style,
+  context,
+}: Pick<ListProps, 'children' | 'style'> & ContextProp<VirtuosoReadyContext>) => {
+  const hasItems = Children.count(children) > 0
+  useEffect(() => {
+    // Virtuoso 首次定位期间会隐藏 List，仅挂载列表项还不能结束 loading。
+    if (hasItems && style?.visibility !== 'hidden') context.onReady()
+  }, [hasItems, style?.visibility, context.onReady])
+}

--- a/app/renderer/src/main/src/pages/ai-agent/defaultConstant.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/defaultConstant.tsx
@@ -5,8 +5,6 @@ import {
   BookOpenTextOutlined,
   BotOutlined,
   CalendarOutlined,
-  ChipOutlined,
-  CogOutlined,
   DocumentTextOutlined,
   EarOffOutlined,
   FolderOpenOutlined,
@@ -64,15 +62,11 @@ export const AiAgentTabList: YakitTabsProps[] = [
     label: 'AIAgentTabs.session',
     icon: <ColorsChatIcon className="ai-agent-session-tab-icon" />,
   },
-  { value: AIAgentTabListEnum.Setting, label: 'AIAgentTabs.config', icon: <CogOutlined color="currentColor" /> },
   {
     value: AIAgentTabListEnum.Scheduled,
     label: 'AIAgentTabs.scheduled',
     icon: <CalendarOutlined color="currentColor" />,
   },
-  // {value: AIAgentTabListEnum.Forge_Name, label: "AIAgentTabs.skill", icon: <OutlineTemplateIcon />},
-  // {value: AIAgentTabListEnum.Tool, label: "AIAgentTabs.tool", icon: <OutlineWrenchIcon />},
-  { value: AIAgentTabListEnum.AI_Model, label: 'AiAgengt.aiModel', icon: <ChipOutlined color="currentColor" /> },
   { value: AIAgentTabListEnum.MCP, label: 'MCP', icon: <MCPOutlined color="currentColor" /> },
 ]
 export enum AIMentionTabsEnum {

--- a/app/renderer/src/main/src/pages/ai-agent/defaultConstant.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/defaultConstant.tsx
@@ -48,10 +48,8 @@ export const YakitAIAgentPageID = 'yakit-ai-agent'
 
 export enum AIAgentTabListEnum {
   Session = 'session',
-  Setting = 'setting',
   Forge_Name = 'forgeName',
   Tool = 'tool',
-  AI_Model = 'AIModel',
   MCP = 'mcp',
   KnowledgeBase = 'knowledgeBase',
   Scheduled = 'scheduled',

--- a/app/renderer/src/main/src/pages/ai-agent/historyChat/HistoryChat.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/historyChat/HistoryChat.tsx
@@ -114,6 +114,8 @@ interface HistoryChatProps {
   title?: ReactNode
   /** 隐藏底部搜索输入，改由 headerActionsExtra / renderExtra 自定义搜索 */
   hideInlineSearch?: boolean
+  /** 隐藏固定按钮，保留新建与其他头部操作 */
+  hidePinButton?: boolean
   /** 顶栏操作区额外按钮（新建与钉住之间） */
   headerActionsExtra?: ReactNode
   renderExtra?: (sessions: AISession[]) => ReactNode
@@ -121,7 +123,16 @@ interface HistoryChatProps {
 }
 
 const HistoryChat = memo(
-  ({ aiSource, embedded, title, hideInlineSearch, headerActionsExtra, renderExtra, className }: HistoryChatProps) => {
+  ({
+    aiSource,
+    embedded,
+    title,
+    hideInlineSearch,
+    hidePinButton = false,
+    headerActionsExtra,
+    renderExtra,
+    className,
+  }: HistoryChatProps) => {
     const { setActiveChat, getSetting } = useAIAgentDispatcher()
     const { t } = useI18nNamespaces(['aiAgent', 'yakitUi'])
     const [historySourceFilter, setHistorySourceFilter] = useState<HistorySourceFilter>('local')
@@ -510,7 +521,7 @@ const HistoryChat = memo(
                     />
                   </Tooltip>
                   {headerActionsExtra}
-                  <SideSettingButton />
+                  {!hidePinButton && <SideSettingButton />}
                 </>
               )}
             </div>

--- a/app/renderer/src/main/src/pages/ai-agent/historyChat/__test__/HistoryChat.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/historyChat/__test__/HistoryChat.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import HistoryChat from '../HistoryChat'
+import emiter from '@/utils/eventBus/eventBus'
+import { ReActChatEventEnum } from '../../defaultConstant'
+
+const mocks = vi.hoisted(() => ({
+  dispatcher: {
+    setSessions: vi.fn(),
+    resetPagination: vi.fn(),
+    loadHistoryData: vi.fn().mockResolvedValue(0),
+  },
+}))
+
+vi.mock('../../useContext/useStore', () => ({ default: () => ({ activeChat: undefined }) }))
+vi.mock('../../useContext/useDispatcher', () => ({ default: () => ({ getSetting: () => ({ Source: 'ai' }) }) }))
+vi.mock('@/i18n/useI18nNamespaces', () => ({ useI18nNamespaces: () => ({ t: (key: string) => key }) }))
+vi.mock('../HistoryChatList/hook/useSessionList', () => ({
+  default: () => [{ sessions: [] }, mocks.dispatcher],
+}))
+vi.mock('../HistoryChatList/HistoryChatList', () => ({
+  default: () => <div>历史会话内容</div>,
+  DAY_MS: 86400000,
+  getChatTimestamp: () => 0,
+}))
+vi.mock('../../aiChatWelcome/AIChatWelcomeSideSetting', () => ({
+  SideSettingButton: () => <button>固定</button>,
+}))
+vi.mock('../../grpc', () => ({ grpcDeleteAISession: vi.fn() }))
+vi.mock('../utils', async () => ({
+  ...(await import('../deleteSource')),
+  AISessionDeleteCancelledError: class extends Error {},
+  handAIHistoryChatRemove: vi.fn(),
+}))
+vi.mock('@/pages/ai-re-act/hooks/useGetChatDataStoreKey', () => ({
+  default: () => 'ai',
+  getImageStoreKeyByAISource: () => 'ai',
+}))
+vi.mock('@/store/pageInfo', () => ({ usePageInfo: () => 'ai-agent' }))
+vi.mock('@/pages/ai-re-act/hooks/ChatMultiSessionController', () => ({
+  globalSessionEngine: { getSessionIdsBySourceAndRoute: () => [] },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('HistoryChat 头部操作', () => {
+  it('默认保留新建与固定按钮', async () => {
+    render(<HistoryChat aiSource={['ai']} />)
+
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(3)
+    fireEvent.mouseEnter(buttons[1])
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('HistoryChat.newChat')
+    expect(screen.getByRole('button', { name: '固定' })).toBeInTheDocument()
+    expect(screen.getByText('历史会话内容')).toBeInTheDocument()
+  })
+
+  it('隐藏固定按钮时保留新建行为，额外操作位于同一行最右侧', () => {
+    const onClose = vi.fn()
+    const onChatEvent = vi.fn()
+    emiter.on('onReActChatEvent', onChatEvent)
+    try {
+      render(
+        <HistoryChat
+          aiSource={['ai']}
+          hidePinButton
+          headerActionsExtra={<button onClick={onClose}>关闭会话列表</button>}
+        />,
+      )
+
+      // 头部按钮依次为清空、新建和传入的关闭操作。
+      const buttons = screen.getAllByRole('button')
+      expect(buttons).toHaveLength(3)
+      const newChatButton = buttons[1]
+      const closeButton = screen.getByRole('button', { name: '关闭会话列表' })
+      expect(screen.queryByRole('button', { name: '固定' })).not.toBeInTheDocument()
+      expect(closeButton.parentElement).toBe(newChatButton.parentElement)
+      expect(closeButton.parentElement?.lastElementChild).toBe(closeButton)
+
+      fireEvent.click(newChatButton)
+      expect(onChatEvent).toHaveBeenCalledWith(JSON.stringify({ type: ReActChatEventEnum.NEW_CHAT }))
+      fireEvent.click(closeButton)
+      expect(onClose).toHaveBeenCalledTimes(1)
+    } finally {
+      emiter.off('onReActChatEvent', onChatEvent)
+    }
+  })
+
+  it('embedded 仍隐藏新建和固定按钮，并在挂载时刷新会话', () => {
+    render(<HistoryChat aiSource={['ai']} embedded hidePinButton={false} />)
+
+    expect(screen.getAllByRole('button')).toHaveLength(1)
+    expect(screen.queryByRole('button', { name: '固定' })).not.toBeInTheDocument()
+    expect(screen.getByText('历史会话内容')).toBeInTheDocument()
+    expect(mocks.dispatcher.loadHistoryData).toHaveBeenCalledWith(true)
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/AIReActChat.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/AIReActChat.module.scss
@@ -1,4 +1,4 @@
-@use '../../../styles/mixin.scss' as mixin;
+@use '../styles/mixin.scss' as mixin;
 
 @mixin content-side($type) {
   .content-#{$type}-side {
@@ -65,10 +65,12 @@
   align-items: flex-start;
   height: 100%;
   width: 100%;
-  // 面板存在/小屏两态由下方 :has(data-ai-right-panel*) 联动，列表和输入框共同使用 chat-layout-wrapper
+  // 面板存在/小屏两态由下方 :has(data-ai-right-panel*) 联动。
+  // 滚动容器保持全宽，消息内容与输入框分别套用同一条内容轨道。
   --ai-right-panel-slot-width: 0px;
   --ai-right-panel-content-shift: 0px;
-  --ai-right-panel-list-content-shift: 0px;
+  // 内容轨道只在根容器计算一次，列表、输入框和状态提示共同复用。
+  --ai-right-panel-content-track-width: min(784px, calc(100% - var(--ai-right-panel-slot-width)));
   position: relative;
   overflow: hidden;
 
@@ -78,8 +80,6 @@
     --ai-right-panel-slot-width: 325px;
     // 内容中心偏移 = -(325px / 2) = -162.5px
     --ai-right-panel-content-shift: -162.5px;
-    // 列表和输入框已经共用同一轨道，不再追加单独的列表偏移
-    --ai-right-panel-list-content-shift: var(--ai-right-panel-content-shift);
   }
 
   // 小屏面板槽位 = 41px 面板 + 12px 右侧留白 + 8px 内容间距 = 61px
@@ -87,12 +87,11 @@
     --ai-right-panel-slot-width: 61px;
     // 内容中心偏移 = -(61px / 2) = -30.5px
     --ai-right-panel-content-shift: -30.5px;
-    // 列表和输入框已经共用同一轨道，不再追加单独的列表偏移
-    --ai-right-panel-list-content-shift: var(--ai-right-panel-content-shift);
   }
 
-  // 面板态下 footer 与列表都以 ai-re-act 根容器为坐标基准，避免原有 4px/12px padding 造成左右边界错位
+  // 面板态下 footer 以 ai-re-act 根容器为坐标基准，与消息项使用相同的内容轨道。
   &:has([data-ai-right-panel]) .chat-footer {
+    @include mixin.ai-right-panel-content-track;
     padding: 0;
   }
 
@@ -131,7 +130,7 @@
 }
 
 .chat-layout-wrapper {
-  // 列表与输入框的共同内容轨道：面板态统一计算宽度和横向偏移，子元素只填满轨道
+  // 保持滚动容器的父级全宽，避免 Virtuoso 滚动条停在内容轨道右侧。
   width: 100%;
   min-width: 0;
   min-height: 0;
@@ -141,11 +140,6 @@
   flex-direction: column;
   gap: 8px;
   transform: none;
-}
-
-.ai-re-act:has([data-ai-right-panel]) .chat-layout-wrapper {
-  width: min(784px, calc(100% - var(--ai-right-panel-slot-width)));
-  transform: translateX(var(--ai-right-panel-list-content-shift));
 }
 
 .chat-footer {

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/AIReActChat.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/AIReActChat.module.scss
@@ -65,7 +65,37 @@
   align-items: flex-start;
   height: 100%;
   width: 100%;
+  // 面板存在/小屏两态由下方 :has(data-ai-right-panel*) 联动，列表和输入框共同使用 chat-layout-wrapper
+  --ai-right-panel-slot-width: 0px;
+  --ai-right-panel-content-shift: 0px;
+  --ai-right-panel-list-content-shift: 0px;
+  position: relative;
   overflow: hidden;
+
+  // 正常面板槽位 = 301px 面板 + 12px 右侧留白 + 12px 内容间距 = 325px；
+  // 共同轨道需要向左移动半个槽位，才能以扣除槽位后的可用区域为中心。
+  &:has([data-ai-right-panel]) {
+    --ai-right-panel-slot-width: 325px;
+    // 内容中心偏移 = -(325px / 2) = -162.5px
+    --ai-right-panel-content-shift: -162.5px;
+    // 列表和输入框已经共用同一轨道，不再追加单独的列表偏移
+    --ai-right-panel-list-content-shift: var(--ai-right-panel-content-shift);
+  }
+
+  // 小屏面板槽位 = 41px 面板 + 12px 右侧留白 + 8px 内容间距 = 61px
+  &:has([data-ai-right-panel-small='true']) {
+    --ai-right-panel-slot-width: 61px;
+    // 内容中心偏移 = -(61px / 2) = -30.5px
+    --ai-right-panel-content-shift: -30.5px;
+    // 列表和输入框已经共用同一轨道，不再追加单独的列表偏移
+    --ai-right-panel-list-content-shift: var(--ai-right-panel-content-shift);
+  }
+
+  // 面板态下 footer 与列表都以 ai-re-act 根容器为坐标基准，避免原有 4px/12px padding 造成左右边界错位
+  &:has([data-ai-right-panel]) .chat-footer {
+    padding: 0;
+  }
+
   // transition: width 0.3s ease-in-out;
   .open-wrapper {
     width: 0;
@@ -85,10 +115,7 @@
   padding-bottom: 12px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
   background: var(--Colors-Use-Basic-Background);
-  .chat-container {
-  }
 }
 .ai-re-act-chat-hidden {
   width: 0;
@@ -96,20 +123,41 @@
 }
 .chat-container {
   flex: 1;
+  width: 100%;
+  min-height: 0;
   overflow: hidden;
   height: 100%;
   @extend %display-column-center;
 }
 
+.chat-layout-wrapper {
+  // 列表与输入框的共同内容轨道：面板态统一计算宽度和横向偏移，子元素只填满轨道
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transform: none;
+}
+
+.ai-re-act:has([data-ai-right-panel]) .chat-layout-wrapper {
+  width: min(784px, calc(100% - var(--ai-right-panel-slot-width)));
+  transform: translateX(var(--ai-right-panel-list-content-shift));
+}
+
 .chat-footer {
+  width: 100%;
   min-height: 96px;
   padding: 0px 12px 0 4px;
   display: flex;
   justify-content: center;
   .footer-body {
     height: 100%;
-    max-width: 784px;
     width: 100%;
+    max-width: 784px;
     flex: 1;
     position: relative;
   }

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/AIReActChat.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/AIReActChat.tsx
@@ -28,12 +28,14 @@ import { AIReActChatHeader } from './aiReActChatHeader/AIReActChatHeader'
 import { AIToDoListWrapper } from './aiToDoListWrapper/AIToDoListWrapper'
 import { AIReActTaskChatReview } from '@/pages/ai-agent/aiAgentChat/AIAgentChat'
 import { globalSessionEngine } from '../hooks/ChatMultiSessionController'
+import { AIRightPanel } from '../aiRightPanel/AIRightPanel'
 
 export const AIReActChat: React.FC<AIReActChatProps> = React.memo(
   forwardRef((props, ref) => {
     const {
       chatContainerClassName,
       chatContainerHeaderClassName,
+      showAIRightPanel,
       title,
       sendRequest,
       startRequest,
@@ -306,37 +308,40 @@ export const AIReActChat: React.FC<AIReActChatProps> = React.memo(
               [styles['ai-re-act-chat-hidden']]: !showFreeChat,
             })}
           >
-            <div className={classNames(styles['chat-container'], chatContainerClassName)}>
-              {title && (
-                <AIReActChatHeader
-                  title={title}
-                  chatContainerHeaderClassName={chatContainerHeaderClassName}
-                  isShowRetract={isShowRetract}
-                  externalParameters={externalParameters}
-                  scrollToItemIndex={aiReActChatContentsRef.current?.scrollToItemIndex}
-                />
-              )}
-              <AIToDoListWrapper />
-              <AIReActChatContents ref={aiReActChatContentsRef} />
-              <AIReActTaskChatReview />
-            </div>
-            <div className={classNames(styles['chat-footer'])}>
-              <div className={styles['footer-body']}>
-                <div className={styles['footer-inputs']}>
-                  <AITaskQuery />
-                  <AINotifyMessage />
-                  <div className={classNames(styles['footer-inputs-file-list'])}>
-                    <AIReactChatTextarea
-                      ref={aiChatTextareaRef}
-                      handleSubmit={handleSubmit}
-                      externalParameters={externalParameters}
-                      handleStopCasualTask={handleStopCasualTask}
-                    />
+            <div className={styles['chat-layout-wrapper']}>
+              <div className={classNames(styles['chat-container'], chatContainerClassName)}>
+                {title && (
+                  <AIReActChatHeader
+                    title={title}
+                    chatContainerHeaderClassName={chatContainerHeaderClassName}
+                    isShowRetract={isShowRetract}
+                    externalParameters={externalParameters}
+                    scrollToItemIndex={aiReActChatContentsRef.current?.scrollToItemIndex}
+                  />
+                )}
+                <AIToDoListWrapper />
+                <AIReActChatContents ref={aiReActChatContentsRef} />
+                <AIReActTaskChatReview />
+              </div>
+              <div className={classNames(styles['chat-footer'])}>
+                <div className={styles['footer-body']}>
+                  <div className={styles['footer-inputs']}>
+                    <AITaskQuery />
+                    <AINotifyMessage />
+                    <div className={classNames(styles['footer-inputs-file-list'])}>
+                      <AIReactChatTextarea
+                        ref={aiChatTextareaRef}
+                        handleSubmit={handleSubmit}
+                        externalParameters={externalParameters}
+                        handleStopCasualTask={handleStopCasualTask}
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
+          {showAIRightPanel && showFreeChat && <AIRightPanel layoutRef={wrapperRef} />}
           <div className={styles['open-wrapper']} onClick={(e) => setShowFreeChat(true)}>
             <ChevrondownButton />
             <div className={styles['text']}>自由对话</div>

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/AIReActChatType.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/AIReActChatType.ts
@@ -46,6 +46,8 @@ type ExternalParametersRightIcon = Partial<{
 export interface AIReActChatProps {
   chatContainerClassName?: string
   chatContainerHeaderClassName?: string
+  /** 是否渲染右侧功能面板（AIRightPanel）：仅 ai-agent 主页面开启，侧边栏等复用方不展示 */
+  showAIRightPanel?: boolean
   showFreeChat: boolean
   setShowFreeChat: (show: boolean) => void
   title?: React.ReactNode

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/__test__/AIReActChat.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/__test__/AIReActChat.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('ahooks', async () => {
+  const actual = await vi.importActual('ahooks')
+  return {
+    ...actual,
+    useInViewport: () => [true],
+  }
+})
+
+vi.mock('@/pages/ai-agent/useContext/useStore', () => ({
+  default: () => ({ activeChat: undefined, setting: undefined }),
+}))
+
+vi.mock('@/pages/ai-agent/useContext/useDispatcher', () => ({
+  default: () => ({
+    setActiveChat: vi.fn(),
+    getSetting: () => ({}),
+    onStart: vi.fn(),
+    onSend: vi.fn(),
+  }),
+}))
+
+vi.mock('@/pages/ai-agent/utils', () => ({
+  formatAIAgentSetting: () => ({}),
+  getAIReActRequestParams: () => ({ attachedResourceInfo: undefined }),
+}))
+
+vi.mock('@/utils/notification', () => ({ yakitNotify: vi.fn() }))
+vi.mock('@/utils/randomUtil', () => ({ randomString: () => 'test-id' }))
+vi.mock('@/utils/eventBus/eventBus', () => ({ default: { emit: vi.fn() } }))
+
+vi.mock('../../hooks/useCurrentDataBySession', () => ({
+  useCurrentStore: () => ({
+    getState: () => ({ execute: false, currentChatStatus: { questionID: '' }, notifyMessage: undefined }),
+  }),
+}))
+vi.mock('../../hooks/useCurrentSessionId', () => ({ default: () => 'test-session' }))
+vi.mock('../../hooks/useSessionId', () => ({ default: () => ({ getSession: () => 'test-session' }) }))
+vi.mock('../../hooks/useAINodeLabel', () => ({ default: () => ({ nodeLabel: '' }) }))
+vi.mock('../../hooks/ChatMultiSessionController', () => ({
+  globalSessionEngine: {
+    ensureSession: () => ({ store: {} }),
+    setActiveShowSession: vi.fn(),
+  },
+}))
+vi.mock('zustand', async () => {
+  const actual = await vi.importActual('zustand')
+  return { ...actual, useStore: () => false }
+})
+
+vi.mock('../../aiReActChatContents/AIReActChatContents', () => ({
+  AIReActChatContents: React.forwardRef(() => <div data-testid="chat-contents" />),
+}))
+vi.mock('../aiReActChatHeader/AIReActChatHeader', () => ({
+  AIReActChatHeader: () => <div data-testid="chat-header" />,
+}))
+vi.mock('../aiReactChatTextarea/AIReactChatTextarea', () => ({
+  AIReactChatTextarea: React.forwardRef(() => <div data-testid="chat-textarea" />),
+}))
+vi.mock('../aiToDoListWrapper/AIToDoListWrapper', () => ({
+  AIToDoListWrapper: () => <div data-testid="todo-list" />,
+}))
+vi.mock('@/pages/ai-agent/components/aiTaskQuery/AITaskQuery', () => ({
+  AITaskQuery: () => null,
+}))
+vi.mock('@/pages/ai-agent/aiAgentChat/AIAgentChat', () => ({
+  AIReActTaskChatReview: () => null,
+}))
+vi.mock('../AIReActComponent', () => ({
+  ChevrondownButton: () => <span data-testid="expand-button" />,
+}))
+vi.mock('../../aiRightPanel/AIRightPanel', () => ({
+  AIRightPanel: () => <div data-testid="right-panel" />,
+}))
+
+import { AIReActChat } from '../AIReActChat'
+
+const baseProps = {
+  showFreeChat: true,
+  showAIRightPanel: true,
+  setShowFreeChat: vi.fn(),
+  startRequest: vi.fn(),
+}
+
+describe('AIReActChat', () => {
+  it('自由对话收起时不渲染右侧面板', () => {
+    render(<AIReActChat {...baseProps} showFreeChat={false} />)
+
+    expect(screen.queryByTestId('right-panel')).not.toBeInTheDocument()
+  })
+
+  it('未开启右侧面板开关时不渲染右侧面板', () => {
+    render(<AIReActChat {...baseProps} showAIRightPanel={false} />)
+
+    expect(screen.queryByTestId('right-panel')).not.toBeInTheDocument()
+  })
+
+  it('自由对话展开时渲染右侧面板', () => {
+    render(<AIReActChat {...baseProps} />)
+
+    expect(screen.getByTestId('right-panel')).toBeInTheDocument()
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/aiToDoListWrapper/AIToDoListWrapper.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChat/aiToDoListWrapper/AIToDoListWrapper.module.scss
@@ -1,3 +1,5 @@
+@use '../../styles/mixin.scss' as mixin;
+
 .todoList-wrapper {
   height: 33px;
   width: 100%;
@@ -11,8 +13,8 @@
   z-index: 10;
   flex-shrink: 0;
   .to-do-list {
-    width: 100%;
-    max-width: 784px;
+    // 待办卡片与消息列表共用同一条内容轨道。
+    @include mixin.ai-right-panel-content-track;
     margin: 8px 0 0;
   }
 }

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.module.scss
@@ -1,3 +1,5 @@
+@use '../styles/mixin.scss' as mixin;
+
 .ai-re-act-chat-contents {
   width: 100%;
   overflow: hidden auto;
@@ -7,18 +9,22 @@
   position: relative;
   margin-top: 8px;
   .re-act-contents-list {
+    // Virtuoso Scroller 负责滚动并保持全宽，避免滚动条随内容轨道移动。
     display: flex;
     flex-direction: column;
     gap: 8px;
     width: 100%;
+    max-width: none;
     height: 100%;
+  }
+  // Virtuoso 的内部 List 承担内容轨道，外层 re-act-contents-list 只负责滚动。
+  .re-act-contents-track {
+    @include mixin.ai-right-panel-content-track;
   }
   .item-wrapper {
     width: 100%;
     box-sizing: border-box;
     min-width: 0;
-    max-width: 784px;
-    margin: 0 auto;
     .item-inner {
       padding-top: 4px;
     }
@@ -46,18 +52,16 @@
       font-size: 12px;
     }
   }
+  // Virtuoso 的 Footer 与内部 List 是兄弟节点，父级是全宽 viewport；
+  // 需要单独套用内容轨道，面板态下才能与消息列表对齐。
   .end {
     font-size: 12px;
     font-weight: bold;
     color: var(--Colors-Use-Neutral-Text-3-Secondary);
-    width: 100%;
-    max-width: 784px;
-    margin: 0 auto;
+    @include mixin.ai-right-panel-content-track;
   }
   .footer-loading {
-    width: 100%;
-    max-width: 784px;
-    margin: 0 auto;
+    @include mixin.ai-right-panel-content-track;
     padding-bottom: 24px;
     .footer-loading-title {
       width: 100%;
@@ -76,7 +80,8 @@
   .scroll-to-bottom-wrapper {
     position: absolute;
     bottom: 8px;
-    width: 100%;
+    // 置底按钮也沿用消息内容轨道，避免面板态下回到窗口中心。
+    @include mixin.ai-right-panel-content-track;
     display: flex;
     justify-content: center;
     pointer-events: none;

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.module.scss
@@ -21,6 +21,12 @@
   .re-act-contents-track {
     @include mixin.ai-right-panel-content-track;
   }
+  // 首屏 loading 遮罩层默认全宽居中，接入内容轨道后圆点才会落在消息列表中心。
+  // 直接子级限定只命中包住列表的这层 Spin，不影响后续嵌入消息内容的 Spin。
+  > :global(.ant-spin-nested-loading) > :global(div) > :global(.ant-spin) {
+    inset-inline: 0;
+    @include mixin.ai-right-panel-content-track;
+  }
   .item-wrapper {
     width: 100%;
     box-sizing: border-box;

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.module.scss
@@ -16,8 +16,7 @@
   .item-wrapper {
     width: 100%;
     box-sizing: border-box;
-    padding-left: 8px;
-    padding-right: 8px;
+    min-width: 0;
     max-width: 784px;
     margin: 0 auto;
     .item-inner {
@@ -51,10 +50,12 @@
     font-size: 12px;
     font-weight: bold;
     color: var(--Colors-Use-Neutral-Text-3-Secondary);
+    width: 100%;
     max-width: 784px;
     margin: 0 auto;
   }
   .footer-loading {
+    width: 100%;
     max-width: 784px;
     margin: 0 auto;
     padding-bottom: 24px;

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
@@ -119,8 +119,8 @@ export const AIStreamNode: React.FC<AIStreamNodeProps> = React.memo((props) => {
 const TYPE = 'reAct'
 
 export const AIReActChatContents: React.FC<AIReActChatContentsPProps> = React.memo(
-  forwardRef((props, ref) => {
-    const listRootRef = useRef<HTMLDivElement>(null)
+  forwardRef((_props, ref) => {
+    const listRootRef = useRef<HTMLDivElement | null>(null)
     const { activeChat } = useAIAgentStore()
 
     const store = useCurrentStore()

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
@@ -10,7 +10,7 @@ import { AIChatListItem } from '@/pages/ai-agent/components/aiChatListItem/AICha
 import { AIYaklangCode } from '@/pages/ai-agent/components/aiYaklangCode/AIYaklangCode'
 import type { ModalInfoProps } from '@/pages/ai-agent/components/ModelInfo'
 import { AIStreamContentType } from '../hooks/defaultConstant'
-import { Virtuoso } from 'react-virtuoso'
+import { Virtuoso, type ListProps } from 'react-virtuoso'
 import useVirtuosoAutoScroll from '../hooks/useVirtuosoAutoScroll'
 import useChatStreamLocateHighlight from '../hooks/useChatStreamLocateHighlight'
 import type { ReActChatRenderElement, ChatReferenceMaterialPayload } from '../hooks/aiRender'
@@ -117,6 +117,15 @@ export const AIStreamNode: React.FC<AIStreamNodeProps> = React.memo((props) => {
   }
 })
 const TYPE = 'reAct'
+
+// Virtuoso 的滚动容器需要保持全宽，内容轨道放到内部 List，避免滚动条跟随轨道移动。
+const VirtuosoListContainer = forwardRef<HTMLDivElement, ListProps>(({ children, style, ...props }, ref) => (
+  <div {...props} ref={ref} style={style} className={styles['re-act-contents-track']}>
+    {children}
+  </div>
+))
+
+VirtuosoListContainer.displayName = 'VirtuosoListContainer'
 
 export const AIReActChatContents: React.FC<AIReActChatContentsPProps> = React.memo(
   forwardRef((_props, ref) => {
@@ -240,6 +249,7 @@ export const AIReActChatContents: React.FC<AIReActChatContentsPProps> = React.me
     const components = useMemo(
       () => ({
         Item,
+        List: VirtuosoListContainer,
         Footer,
         Header,
       }),

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/AIReActChatContents.tsx
@@ -1,5 +1,10 @@
 import React, { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState, useEffect } from 'react'
-import type { AIReActChatContentsPProps, AIReferenceNodeProps, AIStreamNodeProps } from './AIReActChatContentsType'
+import type {
+  AIReActChatContentsPProps,
+  AIReActChatContentsRef,
+  AIReferenceNodeProps,
+  AIStreamNodeProps,
+} from './AIReActChatContentsType'
 import styles from './AIReActChatContents.module.scss'
 import { AIMarkdown } from '@/pages/ai-agent/components/aiMarkdown/AIMarkdown'
 import { AIStreamChatContent } from '@/pages/ai-agent/components/aiStreamChatContent/AIStreamChatContent'
@@ -10,14 +15,14 @@ import { AIChatListItem } from '@/pages/ai-agent/components/aiChatListItem/AICha
 import { AIYaklangCode } from '@/pages/ai-agent/components/aiYaklangCode/AIYaklangCode'
 import type { ModalInfoProps } from '@/pages/ai-agent/components/ModelInfo'
 import { AIStreamContentType } from '../hooks/defaultConstant'
-import { Virtuoso, type ListProps } from 'react-virtuoso'
+import { Virtuoso, type Components, type ContextProp, type ListProps } from 'react-virtuoso'
 import useVirtuosoAutoScroll from '../hooks/useVirtuosoAutoScroll'
 import useChatStreamLocateHighlight from '../hooks/useChatStreamLocateHighlight'
 import type { ReActChatRenderElement, ChatReferenceMaterialPayload } from '../hooks/aiRender'
 import Loading from '@/components/Loading/Loading'
 import { ScrollText } from '@/pages/ai-agent/chatTemplate/TaskLoading/TaskLoading'
 import { YakitModal } from '@/components/yakitUI/YakitModal/YakitModal'
-import useAIAgentStore from '@/pages/ai-agent/useContext/useStore'
+import useCurrentSessionId from '../hooks/useCurrentSessionId'
 import { YakitSpin } from '@/components/yakitUI/YakitSpin/YakitSpin'
 import AITextSyntaxFlow from '@/pages/ai-agent/components/aiTextSyntaxFlow/AITextSyntaxFlow'
 import { useCurrentStore, useCurrentRawData } from '../hooks/useCurrentDataBySession'
@@ -31,7 +36,12 @@ import { AITaskStatus } from '../hooks/grpcApi'
 import { AIChatQSDataTypeEnum } from '../hooks/aiRender'
 import emiter from '@/utils/eventBus/eventBus'
 import { PositionOutlined } from '@yakit-libs/yakit-ui-icons/outline'
-import { useDebounceFn, useMount, useCreation, useMemoizedFn } from 'ahooks'
+import { useDebounceFn, useCreation, useMemoizedFn } from 'ahooks'
+import {
+  useVirtuosoInitialRender,
+  useVirtuosoListReady,
+  type VirtuosoReadyContext,
+} from '@/pages/ai-agent/components/useVirtuosoInitialRender'
 
 export const AIStreamNode: React.FC<AIStreamNodeProps> = React.memo((props) => {
   const { stream, aiMarkdownProps, listItemIndex, sessionId } = props
@@ -119,20 +129,43 @@ export const AIStreamNode: React.FC<AIStreamNodeProps> = React.memo((props) => {
 const TYPE = 'reAct'
 
 // Virtuoso 的滚动容器需要保持全宽，内容轨道放到内部 List，避免滚动条跟随轨道移动。
-const VirtuosoListContainer = forwardRef<HTMLDivElement, ListProps>(({ children, style, ...props }, ref) => (
-  <div {...props} ref={ref} style={style} className={styles['re-act-contents-track']}>
-    {children}
-  </div>
-))
+const VirtuosoListContainer = forwardRef<HTMLDivElement, ListProps & ContextProp<VirtuosoReadyContext>>(
+  ({ children, style, context, ...props }, ref) => {
+    useVirtuosoListReady({ children, style, context })
+
+    return (
+      <div {...props} ref={ref} style={style} className={styles['re-act-contents-track']}>
+        {children}
+      </div>
+    )
+  },
+)
 
 VirtuosoListContainer.displayName = 'VirtuosoListContainer'
 
 export const AIReActChatContents: React.FC<AIReActChatContentsPProps> = React.memo(
+  forwardRef((props, ref) => {
+    const sessionId = useCurrentSessionId()
+    const contentsRef = useRef<AIReActChatContentsRef>(null)
+    // 头部会保存定位方法的引用，切换会话后仍需转发到当前列表。
+    useImperativeHandle(
+      ref,
+      () => ({
+        scrollToItemIndex: (index, behavior) => contentsRef.current?.scrollToItemIndex(index, behavior),
+      }),
+      [],
+    )
+    return <AIReActChatContentsList {...props} key={sessionId} ref={contentsRef} />
+  }),
+)
+
+const AIReActChatContentsList: React.FC<AIReActChatContentsPProps> = React.memo(
   forwardRef((_props, ref) => {
+    const { t } = useI18nNamespaces(['aiAgent'])
     const listRootRef = useRef<HTMLDivElement | null>(null)
-    const { activeChat } = useAIAgentStore()
 
     const store = useCurrentStore()
+    const initLoading = useStore(store, (state) => state.initLoading)
     const casualChatElements = useStore(store, (state) => state.chatElements)
     const chatLength = useStore(store, (state) => state.chatElements.length)
     const casualTitle = useStore(store, (state) => state.currentLoadingTitle.casualTitle)
@@ -158,6 +191,12 @@ export const AIReActChatContents: React.FC<AIReActChatContentsPProps> = React.me
       total: chatLength,
       isPrependingRef,
     })
+    const { renderLoading, virtuosoContext, handleListHeightChanged, initialTopMostItemIndex } =
+      useVirtuosoInitialRender({
+        dataLength: chatLength,
+        onHeightChanged: handleTotalListHeightChanged,
+      })
+    const initialLoading = !initLoading && renderLoading
 
     // 是否已滚动到底部：ref 供 hook 内部判断，state 触发重渲染控制置底按钮显隐
     const [isAtBottom, setIsAtBottom] = useState(true)
@@ -199,12 +238,12 @@ export const AIReActChatContents: React.FC<AIReActChatContentsPProps> = React.me
       })
       if (index !== -1) locateToIndex(index, 'auto')
     })
-    useMount(() => {
+    useEffect(() => {
       emiter.on('onAITreeLocatePlanningList', onTreeLocate)
       return () => {
         emiter.off('onAITreeLocatePlanningList', onTreeLocate)
       }
-    })
+    }, [onTreeLocate])
 
     const renderItem = useCallback((_, item?: ReActChatRenderElement) => {
       if (!item?.token) return null
@@ -246,7 +285,7 @@ export const AIReActChatContents: React.FC<AIReActChatContentsPProps> = React.me
         ) : null,
       [grpcLoadMoreLoading],
     )
-    const components = useMemo(
+    const components = useMemo<Components<ReActChatRenderElement, VirtuosoReadyContext>>(
       () => ({
         Item,
         List: VirtuosoListContainer,
@@ -258,26 +297,29 @@ export const AIReActChatContents: React.FC<AIReActChatContentsPProps> = React.me
     // console.log('chatElements', casualChatElements, store.getState().items)
     return (
       <div ref={listRootRef} className={styles['ai-re-act-chat-contents']}>
-        <Virtuoso
-          key={activeChat?.SessionID}
-          ref={virtuosoRef}
-          scrollerRef={setScrollerRef}
-          defaultItemHeight={80}
-          atBottomStateChange={handleAtBottomStateChange}
-          data={casualChatElements}
-          totalListHeightChanged={handleTotalListHeightChanged}
-          itemContent={renderItem}
-          firstItemIndex={firstItemIndex}
-          initialTopMostItemIndex={chatLength > 1 ? { index: 'LAST' } : 0}
-          components={components}
-          increaseViewportBy={{ top: 600, bottom: 200 }}
-          atBottomThreshold={50}
-          skipAnimationFrameInResizeObserver
-          startReached={handleLoadMore}
-          rangeChanged={onRangeChange}
-          className={styles['re-act-contents-list']}
-        />
-        {chatLength > 0 && !isAtBottom && (
+        <YakitSpin spinning={initialLoading} tip={t('AIReActChatContents.uiRendering')}>
+          <Virtuoso
+            ref={virtuosoRef}
+            scrollerRef={setScrollerRef}
+            defaultItemHeight={80}
+            atBottomStateChange={handleAtBottomStateChange}
+            data={casualChatElements}
+            context={virtuosoContext}
+            totalListHeightChanged={handleListHeightChanged}
+            itemContent={renderItem}
+            firstItemIndex={firstItemIndex}
+            initialTopMostItemIndex={initialTopMostItemIndex}
+            components={components}
+            increaseViewportBy={{ top: 600, bottom: 200 }}
+            atBottomThreshold={50}
+            skipAnimationFrameInResizeObserver
+            startReached={handleLoadMore}
+            rangeChanged={onRangeChange}
+            className={styles['re-act-contents-list']}
+            style={{ visibility: initialLoading ? 'hidden' : undefined }}
+          />
+        </YakitSpin>
+        {chatLength > 0 && !initialLoading && !isAtBottom && (
           <div className={styles['scroll-to-bottom-wrapper']}>
             <YakitButton
               type="outline2"

--- a/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/__test__/AIReActChatContents.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiReActChatContents/__test__/AIReActChatContents.test.tsx
@@ -1,0 +1,266 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { createContext, createRef, useContext } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { VirtuosoMockContext } from 'react-virtuoso'
+import { createStore } from 'zustand/vanilla'
+import type { ReActChatRenderElement } from '../../hooks/aiRender'
+import { AIChatQSDataTypeEnum } from '../../hooks/aiRender'
+import type useAutoScrollFn from '../../hooks/useVirtuosoAutoScroll'
+import emiter from '@/utils/eventBus/eventBus'
+import { AIReActChatContents } from '../AIReActChatContents'
+import type { AIReActChatContentsRef } from '../AIReActChatContentsType'
+
+const SessionContext = createContext('session-1')
+const store = createStore(() => ({
+  chatElements: [] as ReActChatRenderElement[],
+  initLoading: false,
+  grpcLoadMoreLoading: false,
+  currentLoadingTitle: { casualTitle: '', planTitle: '' },
+  currentChatStatus: { coordinatorId: '', status: '' },
+  currentReviewDetail: { token: '' },
+  execute: false,
+  items: {},
+  groups: {},
+  tasks: {},
+}))
+const initialState = store.getState()
+const rawData = { contents: new Map(), grpcOffset: 0 }
+const { autoScroll, recovery, locate } = vi.hoisted(() => ({
+  autoScroll: vi.fn(),
+  recovery: vi.fn(),
+  locate: vi.fn(),
+}))
+
+vi.mock('../../hooks/useCurrentSessionId', () => {
+  const useSessionIdMock = () => useContext(SessionContext)
+  return { default: useSessionIdMock }
+})
+vi.mock('../../hooks/useCurrentDataBySession', () => ({
+  useCurrentStore: () => store,
+  useCurrentRawData: () => rawData,
+}))
+vi.mock('../../hooks/ChatMultiSessionController', () => ({
+  globalSessionEngine: {
+    requestRecoveryHistory: recovery,
+    getSessionExecute: () => true,
+    removeContentsFromMemory: vi.fn(),
+    persistGetSessionContents: vi.fn().mockResolvedValue([]),
+  },
+}))
+// 保留真实滚动与前插保护，仅记录调用，避免首次定位被重复自动滚动干扰。
+vi.mock('../../hooks/useVirtuosoAutoScroll', async (importOriginal) => {
+  const { default: useAutoScroll } = await importOriginal<{ default: typeof useAutoScrollFn }>()
+  const useAutoScrollMock = (...args: Parameters<typeof useAutoScroll>) => {
+    const result = useAutoScroll(...args)
+    return {
+      ...result,
+      handleTotalListHeightChanged: () => {
+        autoScroll()
+        result.handleTotalListHeightChanged()
+      },
+      scrollToItemIndex: (...scrollArgs: Parameters<typeof result.scrollToItemIndex>) => {
+        locate(...scrollArgs)
+        result.scrollToItemIndex(...scrollArgs)
+      },
+    }
+  }
+  return { default: useAutoScrollMock }
+})
+// 消息内容用固定尺寸文本代替，Virtuoso、加载组件及滚动 hooks 均使用真实实现。
+vi.mock('@/pages/ai-agent/components/aiChatListItem/AIChatListItem', () => ({
+  AIChatListItem: ({ item }: { item: ReActChatRenderElement }) => <div>消息 {item.token}</div>,
+}))
+vi.mock('@/pages/ai-agent/components/aiMarkdown/AIMarkdown', () => ({ AIMarkdown: () => null }))
+vi.mock('@/pages/ai-agent/components/aiStreamChatContent/AIStreamChatContent', () => ({
+  AIStreamChatContent: () => null,
+}))
+vi.mock('@/pages/ai-agent/components/StreamCard', () => ({ default: () => null }))
+vi.mock('@/pages/ai-agent/components/aiYaklangCode/AIYaklangCode', () => ({ AIYaklangCode: () => null }))
+vi.mock('@/pages/ai-agent/components/aiTextSyntaxFlow/AITextSyntaxFlow', () => ({ default: () => null }))
+vi.mock('@/pages/ai-agent/components/aiGroupStreamCard/AIGroupStreamCard', () => ({ Code: () => null }))
+vi.mock('@/pages/ai-agent/chatTemplate/TaskLoading/TaskLoading', () => ({ ScrollText: () => null }))
+
+const VIEWPORT_HEIGHT = 400
+const ITEM_HEIGHT = 80
+const createItems = (count: number, start = 0): ReActChatRenderElement[] =>
+  Array.from({ length: count }, (_, index) => {
+    const token = `${start + index}`
+    rawData.contents.set(token, { stageSettled: true })
+    return { token, kind: 'item', chatType: 'reAct', isHistory: true }
+  })
+const originalScrollTo = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollTo')
+const originalScrollBy = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollBy')
+const scrollTo = vi.fn(function (this: HTMLElement, options: ScrollToOptions) {
+  this.scrollTop = options.top ?? 0
+  this.dispatchEvent(new Event('scroll'))
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  store.setState(initialState, true)
+  rawData.contents.clear()
+  rawData.grpcOffset = 0
+  recovery.mockImplementation(() => store.setState({ grpcLoadMoreLoading: true }))
+  // jsdom 无布局，使用 Virtuoso 官方尺寸上下文并模拟滚动容器几何信息。
+  vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(VIEWPORT_HEIGHT)
+  vi.spyOn(Element.prototype, 'scrollHeight', 'get').mockImplementation(
+    () => store.getState().chatElements.length * ITEM_HEIGHT,
+  )
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    height: VIEWPORT_HEIGHT,
+    width: 800,
+    top: 0,
+    bottom: VIEWPORT_HEIGHT,
+    left: 0,
+    right: 800,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  })
+  Object.defineProperty(HTMLElement.prototype, 'scrollTo', { configurable: true, value: scrollTo })
+  Object.defineProperty(HTMLElement.prototype, 'scrollBy', {
+    configurable: true,
+    value(this: HTMLElement, options: ScrollToOptions) {
+      scrollTo.call(this, { top: this.scrollTop + (options.top ?? 0) })
+    },
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  if (originalScrollTo) Object.defineProperty(HTMLElement.prototype, 'scrollTo', originalScrollTo)
+  else Reflect.deleteProperty(HTMLElement.prototype, 'scrollTo')
+  if (originalScrollBy) Object.defineProperty(HTMLElement.prototype, 'scrollBy', originalScrollBy)
+  else Reflect.deleteProperty(HTMLElement.prototype, 'scrollBy')
+})
+
+const chatElement = (sessionId = 'session-1', ref = createRef<AIReActChatContentsRef>()) => (
+  <SessionContext.Provider value={sessionId}>
+    <VirtuosoMockContext.Provider value={{ viewportHeight: VIEWPORT_HEIGHT, itemHeight: ITEM_HEIGHT }}>
+      <AIReActChatContents ref={ref} />
+    </VirtuosoMockContext.Provider>
+  </SessionContext.Provider>
+)
+const getScroller = () => document.querySelector<HTMLElement>('[data-virtuoso-scroller]')!
+const isSpinning = () => document.querySelector('.ant-spin-spinning') !== null
+const finishPositioning = async () => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(1000)
+  })
+}
+
+describe('AIReActChatContents 首屏加载', () => {
+  it.each([1, 20])('已有 %s 条消息时先显示 loading，定位完成后显示消息', async (count) => {
+    store.setState({ chatElements: createItems(count) })
+    render(chatElement())
+    expect(isSpinning()).toBe(true)
+    expect(getScroller()).toHaveStyle({ visibility: 'hidden' })
+    expect(screen.getByText('当前会话已停止')).not.toBeVisible()
+    expect(autoScroll).not.toHaveBeenCalled()
+
+    await finishPositioning()
+    expect(isSpinning()).toBe(false)
+    expect(screen.getByText(`消息 ${count - 1}`)).toBeVisible()
+    expect(getScroller().scrollTop).toBe(Math.max(0, count * ITEM_HEIGHT - VIEWPORT_HEIGHT))
+    expect(autoScroll).not.toHaveBeenCalled()
+  })
+
+  it('空会话不空转，首批消息晚到时等待列表定位完成', async () => {
+    render(chatElement())
+    expect(isSpinning()).toBe(false)
+    act(() => store.setState({ initLoading: true }))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(isSpinning()).toBe(false)
+    act(() => store.setState({ chatElements: createItems(20), initLoading: false }))
+    expect(getScroller()).toHaveStyle({ visibility: 'hidden' })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(isSpinning()).toBe(true)
+    await finishPositioning()
+    expect(isSpinning()).toBe(false)
+    expect(screen.getByText('消息 19')).toBeVisible()
+  })
+
+  it.each([0, 20])('会话恢复期间由外层显示 loading，列表不重复转圈（消息数：%s）', async (count) => {
+    store.setState({ initLoading: true, chatElements: createItems(count) })
+    render(chatElement())
+    expect(isSpinning()).toBe(false)
+    await finishPositioning()
+    expect(isSpinning()).toBe(false)
+    act(() => store.setState({ initLoading: false }))
+    expect(isSpinning()).toBe(false)
+    expect(getScroller()).not.toHaveStyle({ visibility: 'hidden' })
+  })
+
+  it('就绪后新增消息继续自动跟随，用户上滑时不抢滚动位置', async () => {
+    store.setState({ chatElements: createItems(20) })
+    render(chatElement())
+    await finishPositioning()
+    act(() => store.setState({ chatElements: createItems(21) }))
+    expect(isSpinning()).toBe(false)
+    await finishPositioning()
+    expect(autoScroll).toHaveBeenCalled()
+    expect(getScroller().scrollTop).toBe(21 * ITEM_HEIGHT - VIEWPORT_HEIGHT)
+
+    fireEvent.wheel(getScroller(), { deltaY: -100 })
+    fireEvent.scroll(getScroller(), { target: { scrollTop: 400 } })
+    act(() => store.setState({ chatElements: createItems(22) }))
+    await finishPositioning()
+    expect(getScroller().scrollTop).toBe(400)
+    expect(isSpinning()).toBe(false)
+  })
+
+  it('切换会话重新等待首屏，清理旧定位监听，并保持 ref 定位可用', async () => {
+    store.setState({ chatElements: createItems(20) })
+    const ref = createRef<AIReActChatContentsRef>()
+    const result = render(chatElement('session-1', ref))
+    const scrollToItemIndex = ref.current?.scrollToItemIndex
+    await finishPositioning()
+    result.rerender(chatElement('session-2', ref))
+    expect(isSpinning()).toBe(true)
+    expect(getScroller()).toHaveStyle({ visibility: 'hidden' })
+    await finishPositioning()
+    expect(isSpinning()).toBe(false)
+    expect(emiter.all.get('onAITreeLocatePlanningList')).toHaveLength(1)
+
+    expect(ref.current?.scrollToItemIndex).toBe(scrollToItemIndex)
+    act(() => scrollToItemIndex?.(3, 'auto'))
+    expect(locate).toHaveBeenLastCalledWith(3, 'auto')
+    rawData.contents.set('2', { type: AIChatQSDataTypeEnum.TASK_NODE_GROUP, data: { taskId: 'task-2' } })
+    act(() => emiter.emit('onAITreeLocatePlanningList', 'task-2'))
+    expect(locate).toHaveBeenLastCalledWith(2, 'auto')
+    expect(locate).toHaveBeenCalledTimes(2)
+    result.unmount()
+    expect(emiter.all.get('onAITreeLocatePlanningList') ?? []).toHaveLength(0)
+  })
+
+  it('向上加载历史时只使用顶部 loading，前插后保留阅读位置', async () => {
+    store.setState({ chatElements: createItems(20) })
+    render(chatElement())
+    await finishPositioning()
+    rawData.grpcOffset = 1
+    fireEvent.wheel(getScroller(), { deltaY: -100 })
+    fireEvent.scroll(getScroller(), { target: { scrollTop: 0 } })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+    expect(recovery).toHaveBeenCalledWith('session-1')
+    expect(getScroller()).not.toHaveStyle({ visibility: 'hidden' })
+    expect(screen.getByText('消息 0')).toBeVisible()
+    expect(isSpinning()).toBe(true)
+
+    rawData.grpcOffset = 0
+    act(() => store.setState({ chatElements: [...createItems(5, -5), ...createItems(20)], grpcLoadMoreLoading: false }))
+    await finishPositioning()
+    expect(isSpinning()).toBe(false)
+    expect(screen.getByText('消息 0')).toBeVisible()
+    expect(getScroller().scrollTop).toBeLessThan(25 * ITEM_HEIGHT - VIEWPORT_HEIGHT)
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.module.scss
@@ -83,8 +83,7 @@
   user-select: none;
   box-sizing: border-box;
 
-  &:hover,
-  &.menu-item-active {
+  &:hover {
     background: var(--Colors-Use-Neutral-Bg-Hover);
   }
 }
@@ -144,10 +143,35 @@
 }
 
 .menu-item-icon-small {
+  position: relative;
   width: 16px;
   height: 16px;
   font-size: 16px;
   line-height: 16px;
+}
+
+// 小屏漏洞总数角标：16px × 14px（含左右各 2px 内边距），向右下偏移 8px/6px，与 16px 图标重叠 8px × 8px（面积约四分之一）
+.risk-count-badge {
+  position: absolute;
+  right: -8px;
+  bottom: -6px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  min-width: 16px;
+  height: 14px;
+  padding: 0 2px;
+  box-sizing: border-box;
+  color: var(--Colors-Use-Basic-White);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 14px;
+  white-space: nowrap;
+  background: var(--Colors-Use-Status-High);
+  @include themeify.color-mix-border(1px, solid, var(--Colors-Use-Neutral-Bg), 50%);
+  border-radius: 4px;
 }
 
 // 「更多/折叠」图标使用帮助文本颜色
@@ -200,8 +224,8 @@
     color: var(--Colors-Use-Status-Low);
   }
 
-  // 当前设计将 unknown 档映射为 Status-Safe 颜色
-  &-unknown {
+  // 当前设计将 info 档映射为 Status-Safe 颜色
+  &-info {
     color: var(--Colors-Use-Status-Safe);
   }
 }

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.module.scss
@@ -40,6 +40,27 @@
   padding: 4px;
 }
 
+.right-panel-hidden {
+  display: none;
+}
+
+.pane-slot {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 2;
+  width: 301px;
+  pointer-events: auto;
+}
+
+.pane-slot-small {
+  right: 53px;
+  width: min(309px, calc(100vw - 65px));
+  padding-right: 8px;
+  box-sizing: border-box;
+}
+
 .panel-top {
   display: flex;
   flex-direction: column;
@@ -109,9 +130,6 @@
   svg {
     width: 100%;
     height: 100%;
-  }
-  path {
-    stroke-width: 1px;
   }
 }
 

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.module.scss
@@ -1,0 +1,309 @@
+@use '../../../theme/themeify.scss' as themeify;
+// 外层相对聊天容器定位在右侧，卡片通过 12px 的右侧 padding 与容器边缘保持距离
+.right-panel-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  height: 100%;
+  padding: 12px 12px 12px 0;
+  box-sizing: border-box;
+  // wrapper 的透明留白不接收指针事件，只有面板卡片接收交互
+  pointer-events: none;
+}
+
+// 面板卡片：正常态宽 301px，小屏态宽 41px
+// 背景、边框和阴影使用主题变量，随主题切换
+.right-panel {
+  display: flex;
+  flex-direction: column;
+  width: 301px;
+  min-height: 0;
+  max-height: 100%;
+  padding: 8px 12px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--Colors-Use-Neutral-Bg);
+  @include themeify.color-mix-border(1px, solid, var(--Colors-Use-Neutral-Disable), 50%);
+  border-radius: 12px;
+  box-shadow: 0 4px 4px 0 var(--Colors-Use-Basic-Shadow);
+  box-sizing: border-box;
+  pointer-events: auto;
+}
+
+.right-panel-small {
+  // 小屏态只保留图标栏所需的紧凑内边距
+  width: 41px;
+  padding: 4px;
+}
+
+.panel-top {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0 0 8px;
+}
+
+.panel-top-small {
+  padding: 0;
+}
+
+.menu-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.divider {
+  flex: none;
+  width: 100%;
+  height: 1px;
+  background: var(--Colors-Use-Neutral-Bg-Hover);
+}
+
+.bottom-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 0 0;
+}
+
+// 常规菜单项：32px 高，图标与文案间距 12px，右侧角标间距 4px
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 32px;
+  padding: 0 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  user-select: none;
+  box-sizing: border-box;
+
+  &:hover,
+  &.menu-item-active {
+    background: var(--Colors-Use-Neutral-Bg-Hover);
+  }
+}
+
+.menu-item-base {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+// 图标容器固定为 20px，svg 填满容器；图标颜色通过 currentColor 继承
+.menu-item-icon {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--Colors-Use-Neutral-Text-1-Title);
+
+  svg {
+    width: 100%;
+    height: 100%;
+  }
+  path {
+    stroke-width: 1px;
+  }
+}
+
+.menu-item-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--Colors-Use-Neutral-Text-1-Title);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+// 「更多/折叠」为次要操作，使用帮助文本颜色
+.menu-item-label-secondary {
+  color: var(--Colors-Use-Neutral-Text-4-Help-text);
+}
+
+// 小屏图标栏：仅图标居中展示
+.menu-item-small {
+  justify-content: center;
+  gap: 0;
+}
+
+.menu-item-small .menu-item-base {
+  justify-content: center;
+  gap: 0;
+}
+
+.menu-item-icon-small {
+  width: 16px;
+  height: 16px;
+  font-size: 16px;
+  line-height: 16px;
+}
+
+// 「更多/折叠」图标使用帮助文本颜色
+.menu-item-icon-secondary {
+  color: var(--Colors-Use-Neutral-Text-4-Help-text);
+}
+
+// 计数角标
+.count-tag {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--Colors-Use-Neutral-Text-1-Title);
+  background: var(--Colors-Use-Neutral-Border);
+  border-radius: 4px;
+}
+
+.risk-tag {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  border-radius: 4px;
+}
+
+.risk-tag-separator {
+  color: var(--Colors-Use-Neutral-Border);
+}
+
+// 各等级计数使用主题状态色
+.risk-tag-value {
+  &-serious {
+    color: var(--Colors-Use-Status-Serious);
+  }
+
+  &-high {
+    color: var(--Colors-Use-Status-High);
+  }
+
+  &-medium {
+    color: var(--Colors-Use-Status-Medium);
+  }
+
+  &-low {
+    color: var(--Colors-Use-Status-Low);
+  }
+
+  // 当前设计将 unknown 档映射为 Status-Safe 颜色
+  &-unknown {
+    color: var(--Colors-Use-Status-Safe);
+  }
+}
+
+// 数据卡片区
+.data-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px 0 8px;
+}
+
+.data-card {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  background: var(--Colors-Use-Basic-Background);
+  // 左缘由 2px 色条充当，因此移除左侧边框
+  border: 1px solid var(--Colors-Use-Neutral-Bg-Hover);
+  border-left: none;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+.data-card-stats {
+  border-radius: 6px;
+}
+
+.data-card-accent {
+  flex: none;
+  width: 2px;
+  background: var(--yakit-colors-Lake-blue-50);
+}
+
+.data-card-accent-blue {
+  background: var(--yakit-colors-Blue-50);
+}
+
+.data-card-row {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+}
+
+.data-card-label {
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--Colors-Use-Neutral-Text-3-Secondary);
+}
+
+.data-card-value {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  color: var(--Colors-Use-Neutral-Text-1-Title);
+}
+
+.data-card-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+}
+
+.stats-title {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+  color: var(--Colors-Use-Neutral-Text-1-Title);
+}
+
+.stats-row {
+  display: flex;
+  gap: 20px;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.stat-value {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 24px;
+  color: var(--Colors-Use-Neutral-Text-1-Title);
+}
+
+.stat-value-success {
+  color: var(--Colors-Use-Success-Primary);
+}
+
+.stat-value-failed {
+  color: var(--Colors-Use-Error-Primary);
+}
+
+.stat-label {
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--Colors-Use-Neutral-Text-3-Secondary);
+}

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.module.scss
@@ -13,6 +13,11 @@
   box-sizing: border-box;
   // wrapper 的透明留白不接收指针事件，只有面板卡片接收交互
   pointer-events: none;
+
+  // 小屏浮层需越过 TodoList 所在的 z-index: 10 层叠上下文。
+  &[data-ai-right-panel-small='true'] {
+    z-index: 11;
+  }
 }
 
 // 面板卡片：正常态宽 301px，小屏态宽 41px

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
@@ -1,4 +1,7 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
+import { TaskListPane } from '@/pages/ai-agent/chatTemplate/historyTaskTree/TaskListPane'
+import { AIRightPanelPane } from './AIRightPanelPane'
+import TimelineCard from '@/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard'
 import { useCreation, useMemoizedFn } from 'ahooks'
 import classNames from 'classnames'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
@@ -146,11 +149,22 @@ interface MenuItemProps {
   suffix?: React.ReactNode
   smallBadge?: React.ReactNode
   onClick?: () => void
+  onMouseEnter?: () => boolean
+  onMouseLeave?: () => void
 }
 
 const MenuItem: React.FC<MenuItemProps> = React.memo(
-  ({ icon, label, small, secondary, suffix, smallBadge, onClick }) => {
+  ({ icon, label, small, secondary, suffix, smallBadge, onClick, onMouseEnter, onMouseLeave }) => {
     const [tooltipOpen, setTooltipOpen] = useState(false)
+
+    const handleMouseEnter = useMemoizedFn(() => {
+      const paneOpened = onMouseEnter?.() ?? false
+      setTooltipOpen(!paneOpened)
+    })
+    const handleMouseLeave = useMemoizedFn(() => {
+      setTooltipOpen(false)
+      onMouseLeave?.()
+    })
 
     const onItemClick = useMemoizedFn(() => {
       if (onClick) {
@@ -165,8 +179,8 @@ const MenuItem: React.FC<MenuItemProps> = React.memo(
         className={classNames(styles['menu-item'], className)}
         aria-label={label}
         onClick={onItemClick}
-        onMouseEnter={() => setTooltipOpen(true)}
-        onMouseLeave={() => setTooltipOpen(false)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
         {children}
       </div>
@@ -266,6 +280,51 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
   }, [layoutRef, small])
 
   const isSmall = small ?? chatSmall
+  const [activePane, setActivePane] = useState<'task-list' | 'timeline'>()
+  const closeTimer = useRef<ReturnType<typeof setTimeout>>()
+  const cancelPaneClose = useMemoizedFn(() => clearTimeout(closeTimer.current))
+  const closePane = useMemoizedFn(() => {
+    cancelPaneClose()
+    setActivePane(undefined)
+  })
+  const openPane = useMemoizedFn((key: 'task-list' | 'timeline') => {
+    cancelPaneClose()
+    setActivePane(key)
+  })
+  const schedulePaneClose = useMemoizedFn(() => {
+    cancelPaneClose()
+    // 留出从入口穿过间距移入浮层的时间。
+    closeTimer.current = setTimeout(closePane, 150)
+  })
+
+  const handleMenuMouseEnter = useMemoizedFn((key: AIRightPanelMenuKey) => {
+    if (!isSmall) return false
+    switch (key) {
+      case 'task-list':
+      case 'timeline':
+        openPane(key)
+        return true
+      default:
+        return false
+    }
+  })
+
+  const handleMenuMouseLeave = useMemoizedFn((key: AIRightPanelMenuKey) => {
+    if (!isSmall) return
+    switch (key) {
+      case 'task-list':
+      case 'timeline':
+        schedulePaneClose()
+        break
+      default:
+        break
+    }
+  })
+
+  useEffect(() => {
+    closePane()
+    return cancelPaneClose
+  }, [isSmall, activeChat?.Id, closePane, cancelPaneClose])
 
   const mainMenus = useCreation(() => {
     // 无 questionID 或非 ai-agent 来源时不展示「任务详情」入口
@@ -279,6 +338,10 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
   // 任务详情/文件系统/流量/漏洞打开工作区对应 tab；导出/查看日志行为与 AIHorizontalScrollCard 一致
   const handleMenuClick = useMemoizedFn((key: AIRightPanelMenuKey) => {
     switch (key) {
+      case 'task-list':
+      case 'timeline':
+        openPane(key)
+        break
       case 'task-board':
         syncCasualTaskTab()
         break
@@ -337,6 +400,17 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
     }
   })
 
+  const renderSmallBadge = useMemoizedFn((key: AIRightPanelMenuKey) => {
+    if (!isSmall) return undefined
+
+    switch (key) {
+      case 'risk':
+        return riskTotal > 0 ? riskTotal : undefined
+      default:
+        return undefined
+    }
+  })
+
   const renderMenuSuffix = useMemoizedFn((key: AIRightPanelMenuKey) => {
     if (key === 'traffic' && executionData?.http_flow_count) {
       return <span className={styles['count-tag']}>{executionData.http_flow_count}</span>
@@ -362,6 +436,28 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
     return null
   })
 
+  const renderPaneTitle = useMemoizedFn(() => {
+    switch (activePane) {
+      case 'task-list':
+        return t('AIRightPanel.taskList')
+      case 'timeline':
+        return t('AIRightPanel.timeline')
+      default:
+        return ''
+    }
+  })
+
+  const renderPaneContent = useMemoizedFn(() => {
+    switch (activePane) {
+      case 'task-list':
+        return <TaskListPane />
+      case 'timeline':
+        return <TimelineCard />
+      default:
+        return null
+    }
+  })
+
   const renderMoreToggle = useMemoizedFn(() => (
     <MenuItem
       icon={moreOpen ? <ChevronDoubleUpOutlined /> : <ChevronDoubleDownOutlined />}
@@ -377,6 +473,7 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
       <div
         className={classNames(styles['right-panel'], {
           [styles['right-panel-small']]: isSmall,
+          [styles['right-panel-hidden']]: !!activePane && !isSmall,
         })}
       >
         <div
@@ -393,8 +490,10 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
                 label={t(item.labelKey)}
                 small={isSmall}
                 suffix={renderMenuSuffix(item.key)}
-                smallBadge={isSmall && item.key === 'risk' && riskTotal > 0 ? riskTotal : undefined}
+                smallBadge={renderSmallBadge(item.key)}
                 onClick={() => handleMenuClick(item.key)}
+                onMouseEnter={() => handleMenuMouseEnter(item.key)}
+                onMouseLeave={() => handleMenuMouseLeave(item.key)}
               />
             ))}
           </div>
@@ -409,11 +508,24 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
                 label={t(item.labelKey)}
                 small={isSmall}
                 onClick={() => handleMenuClick(item.key)}
+                onMouseEnter={() => handleMenuMouseEnter(item.key)}
+                onMouseLeave={() => handleMenuMouseLeave(item.key)}
               />
             ))}
           {renderMoreToggle()}
         </div>
       </div>
+      {activePane && (
+        <div
+          className={classNames(styles['pane-slot'], { [styles['pane-slot-small']]: isSmall })}
+          onMouseEnter={isSmall ? cancelPaneClose : undefined}
+          onMouseLeave={isSmall ? schedulePaneClose : undefined}
+        >
+          <AIRightPanelPane title={renderPaneTitle()} onClose={closePane}>
+            {renderPaneContent()}
+          </AIRightPanelPane>
+        </div>
+      )}
       <ExportAILogsModal
         visible={exportModalVisible}
         onCancel={onExportCancel}

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
@@ -2,6 +2,9 @@ import React, { useEffect, useRef, useState } from 'react'
 import { TaskListPane } from '@/pages/ai-agent/chatTemplate/historyTaskTree/TaskListPane'
 import { AIRightPanelPane } from './AIRightPanelPane'
 import TimelineCard from '@/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard'
+import HistoryChat from '@/pages/ai-agent/historyChat/HistoryChat'
+import { AI_AGENT_HISTORY_AI_SOURCES } from '../hooks/useGetChatDataStoreKey'
+import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
 import { useCreation, useMemoizedFn } from 'ahooks'
 import classNames from 'classnames'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
@@ -29,10 +32,17 @@ import {
   NewspaperOutlined,
   ScrollTextOutlined,
   TimelineOutlined,
+  XOutlined,
 } from '@yakit-libs/yakit-ui-icons/outline'
 import { Tooltip } from 'antd'
 import styles from './AIRightPanel.module.scss'
-import type { AIRightPanelMenuKey, AIRightPanelProps, AIRightPanelRiskCounts, AIRightPanelToolStats } from './type'
+import type {
+  AIRightPanelMenuKey,
+  AIRightPanelPaneKey,
+  AIRightPanelProps,
+  AIRightPanelRiskCounts,
+  AIRightPanelToolStats,
+} from './type'
 import { AI_RIGHT_PANEL_INPUT_MAX_WIDTH, AI_RIGHT_PANEL_NORMAL_SLOT_WIDTH } from './type'
 
 /** 菜单项定义：key 为唯一标识（React key 用），labelKey 为 i18n 文案 key，icon 为入口图标 */
@@ -280,14 +290,14 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
   }, [layoutRef, small])
 
   const isSmall = small ?? chatSmall
-  const [activePane, setActivePane] = useState<'task-list' | 'timeline'>()
+  const [activePane, setActivePane] = useState<AIRightPanelPaneKey>()
   const closeTimer = useRef<ReturnType<typeof setTimeout>>()
   const cancelPaneClose = useMemoizedFn(() => clearTimeout(closeTimer.current))
   const closePane = useMemoizedFn(() => {
     cancelPaneClose()
     setActivePane(undefined)
   })
-  const openPane = useMemoizedFn((key: 'task-list' | 'timeline') => {
+  const openPane = useMemoizedFn((key: AIRightPanelPaneKey) => {
     cancelPaneClose()
     setActivePane(key)
   })
@@ -302,6 +312,7 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
     switch (key) {
       case 'task-list':
       case 'timeline':
+      case 'session-history':
         openPane(key)
         return true
       default:
@@ -314,6 +325,7 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
     switch (key) {
       case 'task-list':
       case 'timeline':
+      case 'session-history':
         schedulePaneClose()
         break
       default:
@@ -335,18 +347,23 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
     return MAIN_MENUS
   }, [currentChatStatusQuestionID])
 
-  // 任务详情/文件系统/流量/漏洞打开工作区对应 tab；导出/查看日志行为与 AIHorizontalScrollCard 一致
+  /**
+   * 菜单点击：任务列表、时间线、会话历史打开右侧内容面板；
+   * 任务详情、流量、漏洞切换工作区 tab；文件系统打开侧栏会话页；
+   * 导出日志打开导出弹窗，查看日志打开日志窗口。
+   */
   const handleMenuClick = useMemoizedFn((key: AIRightPanelMenuKey) => {
     switch (key) {
       case 'task-list':
       case 'timeline':
+      case 'session-history':
         openPane(key)
         break
       case 'task-board':
         syncCasualTaskTab()
         break
       case 'file-system':
-        // 文件树在左侧边栏的会话 tab 分栏内，激活侧边栏并切到该 tab（emit 协议与 AIModelSelect.onSwitchAIAgentTab 一致）
+        // 文件树位于左侧边栏的会话页，展开侧边栏并切换到该页。
         emiter.emit(
           'switchAIAgentTab',
           JSON.stringify({
@@ -438,6 +455,8 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
 
   const renderPaneTitle = useMemoizedFn(() => {
     switch (activePane) {
+      case 'session-history':
+        return t('AIRightPanel.sessionHistory')
       case 'task-list':
         return t('AIRightPanel.taskList')
       case 'timeline':
@@ -449,6 +468,17 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
 
   const renderPaneContent = useMemoizedFn(() => {
     switch (activePane) {
+      case 'session-history':
+        return (
+          <HistoryChat
+            aiSource={AI_AGENT_HISTORY_AI_SOURCES}
+            title={t('ChatSessionPane.sessionList')}
+            hidePinButton
+            headerActionsExtra={
+              <YakitButton type="text2" aria-label={t('YakitButton.close')} icon={<XOutlined />} onClick={closePane} />
+            }
+          />
+        )
       case 'task-list':
         return <TaskListPane />
       case 'timeline':
@@ -521,7 +551,12 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
           onMouseEnter={isSmall ? cancelPaneClose : undefined}
           onMouseLeave={isSmall ? schedulePaneClose : undefined}
         >
-          <AIRightPanelPane title={renderPaneTitle()} onClose={closePane}>
+          <AIRightPanelPane
+            title={renderPaneTitle()}
+            hideHeader={activePane === 'session-history'}
+            noPadding={activePane === 'session-history'}
+            onClose={closePane}
+          >
             {renderPaneContent()}
           </AIRightPanelPane>
         </div>

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
@@ -64,6 +64,7 @@ const MAIN_MENUS: MenuItemDef[] = [
 
 /** 「更多」分组展开后追加显示的功能入口（收起态仅在底部显示「更多」按钮） */
 const MORE_MENUS: MenuItemDef[] = [
+  // { key: 'ai-settings', labelKey: 'AIRightPanel.aiSettings', icon: <CogOutlined /> },
   { key: 'timeline', labelKey: 'AIRightPanel.timeline', icon: <TimelineOutlined /> },
   { key: 'export-log', labelKey: 'AIRightPanel.exportLog', icon: <FigmaIcon2017756Outlined /> },
   { key: 'view-log', labelKey: 'AIRightPanel.viewLog', icon: <NewspaperOutlined /> },

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
@@ -1,7 +1,19 @@
 import React, { useEffect, useState } from 'react'
-import { useMemoizedFn } from 'ahooks'
+import { useCreation, useMemoizedFn } from 'ahooks'
 import classNames from 'classnames'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import { timeDiffWithMoment } from '@/utils/timeUtil'
+import { AISourceEnum, type AIAgentGrpcApi } from '../hooks/grpcApi'
+import useCurrentTaskExecution from '../hooks/useCurrentTaskData/useCurrentTaskExecution'
+import emiter from '@/utils/eventBus/eventBus'
+import { failed, yakitNotify } from '@/utils/notification'
+import { AIAgentTabListEnum, AITabsEnum, SwitchAIAgentTabEventEnum } from '@/pages/ai-agent/defaultConstant'
+import useAIAgentStore from '@/pages/ai-agent/useContext/useStore'
+import useAIAgentDispatcher from '@/pages/ai-agent/useContext/useDispatcher'
+import { useCasualTaskTab } from '@/pages/ai-agent/aiChatContent/hooks/useCasualTaskTab'
+import useAiChatLog from '@/hook/useAiChatLog/useAiChatLog.ts'
+import { ExportAILogsModal } from '@/pages/ai-agent/components/ExportAILogsModal/ExportAILogsModal'
+import { grpcExportAILogs } from '@/pages/ai-agent/grpc'
 import {
   BugOutlined,
   ChatAlt2Outlined,
@@ -15,11 +27,12 @@ import {
   ScrollTextOutlined,
   TimelineOutlined,
 } from '@yakit-libs/yakit-ui-icons/outline'
+import { Tooltip } from 'antd'
 import styles from './AIRightPanel.module.scss'
 import type { AIRightPanelMenuKey, AIRightPanelProps, AIRightPanelRiskCounts, AIRightPanelToolStats } from './type'
 import { AI_RIGHT_PANEL_INPUT_MAX_WIDTH, AI_RIGHT_PANEL_NORMAL_SLOT_WIDTH } from './type'
 
-/** 菜单项定义：key 唯一标识（回调/选中态用），labelKey 为 i18n 文案 key，icon 为入口图标 */
+/** 菜单项定义：key 为唯一标识（React key 用），labelKey 为 i18n 文案 key，icon 为入口图标 */
 interface MenuItemDef {
   key: AIRightPanelMenuKey
   labelKey: string
@@ -43,8 +56,25 @@ const MORE_MENUS: MenuItemDef[] = [
   { key: 'view-log', labelKey: 'AIRightPanel.viewLog', icon: <NewspaperOutlined /> },
 ]
 
-/** 漏洞计数角标的展示顺序（严重/高危/中危/低危/未知，颜色见 risk-tag-value-* 样式） */
-const RISK_TAG_ORDER: Array<keyof AIRightPanelRiskCounts> = ['serious', 'high', 'medium', 'low', 'unknown']
+/** 漏洞计数角标的展示顺序；后端标准等级映射到设计稿中的五种颜色。 */
+const RISK_TAG_ORDER: Array<keyof AIRightPanelRiskCounts> = ['serious', 'high', 'medium', 'low', 'info']
+
+/** 将 session_snapshot 的六个标准等级映射为面板展示的五个等级。 */
+const getRiskCounts = (execution?: AIAgentGrpcApi.SessionSnapshot['execution']): AIRightPanelRiskCounts | undefined => {
+  const levelCount = execution?.risk_level_count
+  if (!levelCount) return undefined
+  return {
+    serious: levelCount.critical,
+    high: levelCount.high,
+    medium: levelCount.warning,
+    low: levelCount.low,
+    info: levelCount.info + levelCount.other,
+  }
+}
+
+/** 小屏漏洞图标显示的总数优先使用后端 total，兼容旧快照时再按展示等级求和。 */
+const getRiskTotal = (execution?: AIAgentGrpcApi.SessionSnapshot['execution'], riskCounts?: AIRightPanelRiskCounts) =>
+  execution?.risk_level_count?.total ?? RISK_TAG_ORDER.reduce((total, field) => total + (riskCounts?.[field] ?? 0), 0)
 
 /** 工具调用统计的三个指标（成功/失败带专属色 tone，对应 stat-value-* 样式；总尝试次数用默认色） */
 const TOOL_STATS: Array<{ field: keyof AIRightPanelToolStats; labelKey: string; tone?: 'success' | 'failed' }> = [
@@ -56,55 +86,141 @@ const TOOL_STATS: Array<{ field: keyof AIRightPanelToolStats; labelKey: string; 
 /** 执行时长、工具调用统计等数据未传入时的占位符 */
 const PLACEHOLDER = '—'
 
+/** 数据卡片区：执行时长 + 工具调用统计（成功/失败/总尝试）。 */
+const DataCards: React.FC<{ executionData?: AIAgentGrpcApi.SessionSnapshot['execution'] }> = React.memo(
+  ({ executionData }) => {
+    const { t } = useI18nNamespaces(['aiAgent'])
+
+    const executionDuration = useCreation(() => {
+      const startedAt = executionData?.started_at || 0
+      const endedAt = executionData?.ended_at || 0
+      if (!startedAt) return PLACEHOLDER
+      if (startedAt && !endedAt) return t('AIRightPanel.running')
+      return timeDiffWithMoment(startedAt, endedAt)
+    }, [executionData?.started_at, executionData?.ended_at])
+
+    const toolCallStats = useCreation(() => {
+      if (!executionData) return undefined
+      return {
+        success: executionData.tool_call_success,
+        failed: executionData.tool_call_failed,
+        total: executionData.tool_call_total,
+      }
+    }, [executionData?.tool_call_success, executionData?.tool_call_failed, executionData?.tool_call_total])
+
+    return (
+      <div className={styles['data-cards']}>
+        <div className={styles['data-card']}>
+          <div className={styles['data-card-accent']} />
+          <div className={styles['data-card-row']}>
+            <span className={styles['data-card-label']}>{t('AIRightPanel.duration')}</span>
+            <span className={styles['data-card-value']}>{executionDuration ?? PLACEHOLDER}</span>
+          </div>
+        </div>
+        <div className={classNames(styles['data-card'], styles['data-card-stats'])}>
+          <div className={classNames(styles['data-card-accent'], styles['data-card-accent-blue'])} />
+          <div className={styles['data-card-body']}>
+            <span className={styles['stats-title']}>{t('AIRightPanel.toolCallStats')}</span>
+            <div className={styles['stats-row']}>
+              {TOOL_STATS.map((stat) => (
+                <div className={styles['stat']} key={stat.field}>
+                  <span className={classNames(styles['stat-value'], stat.tone && styles[`stat-value-${stat.tone}`])}>
+                    {toolCallStats?.[stat.field] ?? PLACEHOLDER}
+                  </span>
+                  <span className={styles['stat-label']}>{t(stat.labelKey)}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  },
+)
+
 interface MenuItemProps {
   icon: React.ReactNode
   label: string
-  active?: boolean
   small?: boolean
   secondary?: boolean
   suffix?: React.ReactNode
+  smallBadge?: React.ReactNode
   onClick?: () => void
 }
 
-const MenuItem: React.FC<MenuItemProps> = React.memo(({ icon, label, active, small, secondary, suffix, onClick }) => {
-  return (
-    <div
-      className={classNames(
-        styles['menu-item'],
-        small && styles['menu-item-small'],
-        active && styles['menu-item-active'],
-      )}
-      role="button"
-      tabIndex={0}
-      aria-label={label}
-      onClick={onClick}
-      onKeyDown={(event) => {
-        if ((event.key === 'Enter' || event.key === ' ') && onClick) {
-          event.preventDefault()
-          onClick()
-        }
-      }}
-    >
-      <div className={styles['menu-item-base']}>
-        <span
-          className={classNames(
-            styles['menu-item-icon'],
-            small && styles['menu-item-icon-small'],
-            secondary && styles['menu-item-icon-secondary'],
-          )}
-        >
-          {icon}
-        </span>
-        {!small && (
-          <span className={classNames(styles['menu-item-label'], secondary && styles['menu-item-label-secondary'])}>
-            {label}
-          </span>
-        )}
+const MenuItem: React.FC<MenuItemProps> = React.memo(
+  ({ icon, label, small, secondary, suffix, smallBadge, onClick }) => {
+    const [tooltipOpen, setTooltipOpen] = useState(false)
+
+    const onItemClick = useMemoizedFn(() => {
+      if (onClick) {
+        onClick()
+      }
+      setTooltipOpen(false)
+    })
+
+    // 菜单容器和交互行为在两种尺寸下相同，具体内容由大小屏分支分别生成。
+    const renderMenuContainer = useMemoizedFn((children: React.ReactNode, className?: string) => (
+      <div
+        className={classNames(styles['menu-item'], className)}
+        aria-label={label}
+        onClick={onItemClick}
+        onMouseEnter={() => setTooltipOpen(true)}
+        onMouseLeave={() => setTooltipOpen(false)}
+      >
+        {children}
       </div>
-      {!small && suffix}
-    </div>
-  )
-})
+    ))
+
+    // 正常态使用独立的文案和右侧 suffix，不渲染小屏专用结构。
+    const renderNormalContent = useMemoizedFn(() =>
+      renderMenuContainer(
+        <>
+          <div className={styles['menu-item-base']}>
+            <span className={classNames(styles['menu-item-icon'], secondary && styles['menu-item-icon-secondary'])}>
+              {icon}
+            </span>
+            <span className={classNames(styles['menu-item-label'], secondary && styles['menu-item-label-secondary'])}>
+              {label}
+            </span>
+          </div>
+          {suffix}
+        </>,
+      ),
+    )
+
+    // 小屏态只保留图标和可选角标，不渲染正常态文案或 suffix。
+    const renderSmallContent = useMemoizedFn(() =>
+      renderMenuContainer(
+        <div className={styles['menu-item-base']}>
+          <span
+            className={classNames(
+              styles['menu-item-icon'],
+              styles['menu-item-icon-small'],
+              secondary && styles['menu-item-icon-secondary'],
+            )}
+          >
+            {icon}
+            {smallBadge && (
+              <span className={styles['risk-count-badge']} aria-label={`漏洞总数 ${smallBadge}`}>
+                {smallBadge}
+              </span>
+            )}
+          </span>
+        </div>,
+        styles['menu-item-small'],
+      ),
+    )
+
+    return small ? (
+      <Tooltip key={label} title={label} placement="left" open={tooltipOpen}>
+        {renderSmallContent()}
+      </Tooltip>
+    ) : (
+      renderNormalContent()
+    )
+  },
+)
 
 /**
  * Memfit AI 右侧功能面板：
@@ -112,24 +228,27 @@ const MenuItem: React.FC<MenuItemProps> = React.memo(({ icon, label, active, sma
  * - 小屏态（正常态面板会使列表可用宽度小于最大宽度时）：仅图标的窄栏（宽 41px）
  */
 export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
-  const {
-    layoutRef,
-    small,
-    activeKey,
-    onMenuClick,
-    executionDuration,
-    toolCallStats,
-    trafficCount,
-    riskCounts,
-    className,
-    style,
-  } = props
-  const { t } = useI18nNamespaces(['aiAgent'])
+  const { layoutRef, small } = props
+  const { t } = useI18nNamespaces(['aiAgent', 'yakitUi'])
   const [moreOpen, setMoreOpen] = useState(false)
   const [chatSmall, setChatSmall] = useState(false)
+  // 菜单点击交互：打开工作区 tab / 导出与查看日志
+  const { activeChat } = useAIAgentStore()
+  const { getSetting } = useAIAgentDispatcher()
+  const { currentChatStatusQuestionID, syncCasualTaskTab } = useCasualTaskTab()
+  const executionData = useCurrentTaskExecution(currentChatStatusQuestionID)
+  const riskCounts = useCreation(() => getRiskCounts(executionData), [executionData?.risk_level_count])
+  const riskTotal = useCreation(
+    () => getRiskTotal(executionData, riskCounts),
+    [executionData?.risk_level_count, riskCounts],
+  )
+  const { onOpenLogWindow } = useAiChatLog()
+  const [exportModalVisible, setExportModalVisible] = useState(false)
+  const [exportLoading, setExportLoading] = useState(false)
 
   useEffect(() => {
-    // 监听面板外层宽度；chat-layout-wrapper 会随当前态改变宽度，不能把它作为判断输入，否则会形成反馈回路。
+    // 监听滚动容器的父级（.ai-re-act-chat）宽度：内容轨道避让在 Virtuoso 内部 List 上，
+    // 父级保持全宽不随面板态变化，宽度稳定可安全作为小屏判断输入。
     const layoutElement = layoutRef?.current
     if (small !== undefined || !layoutElement || typeof ResizeObserver === 'undefined') return
 
@@ -148,15 +267,83 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
 
   const isSmall = small ?? chatSmall
 
-  const handleClick = useMemoizedFn((key: AIRightPanelMenuKey) => () => onMenuClick?.(key))
+  const mainMenus = useCreation(() => {
+    // 无 questionID 或非 ai-agent 来源时不展示「任务详情」入口
+    const showTaskBoard = !!currentChatStatusQuestionID && getSetting().Source === AISourceEnum.aiAgent
+    if (!showTaskBoard) {
+      return MAIN_MENUS.filter((item) => item.key !== 'task-board')
+    }
+    return MAIN_MENUS
+  }, [currentChatStatusQuestionID])
+
+  // 任务详情/文件系统/流量/漏洞打开工作区对应 tab；导出/查看日志行为与 AIHorizontalScrollCard 一致
+  const handleMenuClick = useMemoizedFn((key: AIRightPanelMenuKey) => {
+    switch (key) {
+      case 'task-board':
+        syncCasualTaskTab()
+        break
+      case 'file-system':
+        // 文件树在左侧边栏的会话 tab 分栏内，激活侧边栏并切到该 tab（emit 协议与 AIModelSelect.onSwitchAIAgentTab 一致）
+        emiter.emit(
+          'switchAIAgentTab',
+          JSON.stringify({
+            type: SwitchAIAgentTabEventEnum.SET_TAB_ACTIVE,
+            params: { active: AIAgentTabListEnum.Session, show: true },
+          }),
+        )
+        break
+      case 'traffic':
+        emiter.emit('switchAIActTab', JSON.stringify({ key: AITabsEnum.HTTP }))
+        break
+      case 'risk':
+        emiter.emit('switchAIActTab', JSON.stringify({ key: AITabsEnum.Risk }))
+        break
+      case 'export-log':
+        setExportModalVisible(true)
+        break
+      case 'view-log':
+        onOpenLogWindow()
+        break
+      default:
+        break
+    }
+  })
+
+  const onExportCancel = useMemoizedFn(() => {
+    setExportModalVisible(false)
+  })
+
+  const onExportOk = useMemoizedFn(async (data: { types: string[]; outputPath: string }) => {
+    if (!activeChat?.Id) {
+      failed(t('AIChatContent.noActiveChat'))
+      return
+    }
+    setExportLoading(true)
+    try {
+      await grpcExportAILogs(
+        {
+          SessionID: activeChat.SessionID,
+          ExportDataTypes: data.types,
+          OutputPath: data.outputPath,
+        },
+        true,
+      )
+      yakitNotify('success', t('YakitNotification.exportSuccess'))
+      setExportModalVisible(false)
+    } catch (error) {
+      failed(t('YakitNotification.exportFailed', { error: error + '' }))
+    } finally {
+      setExportLoading(false)
+    }
+  })
 
   const renderMenuSuffix = useMemoizedFn((key: AIRightPanelMenuKey) => {
-    if (key === 'traffic' && trafficCount !== undefined) {
-      return <span className={styles['count-tag']}>{trafficCount}</span>
+    if (key === 'traffic' && executionData?.http_flow_count) {
+      return <span className={styles['count-tag']}>{executionData.http_flow_count}</span>
     }
     if (key === 'risk' && riskCounts) {
       const entries = RISK_TAG_ORDER.map((field) => ({ field, value: riskCounts[field] })).filter(
-        (entry) => entry.value !== undefined,
+        (entry) => !!entry.value,
       )
       if (!entries.length) return null
       return (
@@ -175,34 +362,6 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
     return null
   })
 
-  const renderDataCards = useMemoizedFn(() => (
-    <div className={styles['data-cards']}>
-      <div className={styles['data-card']}>
-        <div className={styles['data-card-accent']} />
-        <div className={styles['data-card-row']}>
-          <span className={styles['data-card-label']}>{t('AIRightPanel.duration')}</span>
-          <span className={styles['data-card-value']}>{executionDuration ?? PLACEHOLDER}</span>
-        </div>
-      </div>
-      <div className={classNames(styles['data-card'], styles['data-card-stats'])}>
-        <div className={classNames(styles['data-card-accent'], styles['data-card-accent-blue'])} />
-        <div className={styles['data-card-body']}>
-          <span className={styles['stats-title']}>{t('AIRightPanel.toolCallStats')}</span>
-          <div className={styles['stats-row']}>
-            {TOOL_STATS.map((stat) => (
-              <div className={styles['stat']} key={stat.field}>
-                <span className={classNames(styles['stat-value'], stat.tone && styles[`stat-value-${stat.tone}`])}>
-                  {toolCallStats?.[stat.field] ?? PLACEHOLDER}
-                </span>
-                <span className={styles['stat-label']}>{t(stat.labelKey)}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
-  ))
-
   const renderMoreToggle = useMemoizedFn(() => (
     <MenuItem
       icon={moreOpen ? <ChevronDoubleUpOutlined /> : <ChevronDoubleDownOutlined />}
@@ -214,12 +373,7 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
   ))
 
   return (
-    <div
-      className={classNames(styles['right-panel-wrapper'], className)}
-      data-ai-right-panel
-      data-ai-right-panel-small={isSmall}
-      style={style}
-    >
+    <div className={styles['right-panel-wrapper']} data-ai-right-panel data-ai-right-panel-small={isSmall}>
       <div
         className={classNames(styles['right-panel'], {
           [styles['right-panel-small']]: isSmall,
@@ -231,16 +385,16 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
           })}
         >
           <div className={styles['menu-group']}>
-            {!isSmall && renderDataCards()}
-            {MAIN_MENUS.map((item) => (
+            {!isSmall && <DataCards executionData={executionData} />}
+            {mainMenus.map((item) => (
               <MenuItem
                 key={item.key}
                 icon={item.icon}
                 label={t(item.labelKey)}
-                active={activeKey === item.key}
                 small={isSmall}
                 suffix={renderMenuSuffix(item.key)}
-                onClick={handleClick(item.key)}
+                smallBadge={isSmall && item.key === 'risk' && riskTotal > 0 ? riskTotal : undefined}
+                onClick={() => handleMenuClick(item.key)}
               />
             ))}
           </div>
@@ -253,14 +407,19 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
                 key={item.key}
                 icon={item.icon}
                 label={t(item.labelKey)}
-                active={activeKey === item.key}
                 small={isSmall}
-                onClick={handleClick(item.key)}
+                onClick={() => handleMenuClick(item.key)}
               />
             ))}
           {renderMoreToggle()}
         </div>
       </div>
+      <ExportAILogsModal
+        visible={exportModalVisible}
+        onCancel={onExportCancel}
+        onOk={onExportOk}
+        loading={exportLoading}
+      />
     </div>
   )
 })

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
@@ -1,0 +1,268 @@
+import React, { useEffect, useState } from 'react'
+import { useMemoizedFn } from 'ahooks'
+import classNames from 'classnames'
+import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import {
+  BugOutlined,
+  ChatAlt2Outlined,
+  ChevronDoubleDownOutlined,
+  ChevronDoubleUpOutlined,
+  FigmaIcon2017756Outlined,
+  FigmaIcon348196674Outlined,
+  FlagOutlined,
+  FolderOpenOutlined,
+  NewspaperOutlined,
+  ScrollTextOutlined,
+  TimelineOutlined,
+} from '@yakit-libs/yakit-ui-icons/outline'
+import styles from './AIRightPanel.module.scss'
+import type { AIRightPanelMenuKey, AIRightPanelProps, AIRightPanelRiskCounts, AIRightPanelToolStats } from './type'
+import { AI_RIGHT_PANEL_INPUT_MAX_WIDTH, AI_RIGHT_PANEL_NORMAL_SLOT_WIDTH } from './type'
+
+/** 菜单项定义：key 唯一标识（回调/选中态用），labelKey 为 i18n 文案 key，icon 为入口图标 */
+interface MenuItemDef {
+  key: AIRightPanelMenuKey
+  labelKey: string
+  icon: React.ReactNode
+}
+
+/** 主菜单：数据卡片下方常驻展示的六个功能入口（正常态与小屏态共用，小屏态仅渲染图标） */
+const MAIN_MENUS: MenuItemDef[] = [
+  { key: 'task-board', labelKey: 'AIRightPanel.taskBoard', icon: <ScrollTextOutlined /> },
+  { key: 'file-system', labelKey: 'AIRightPanel.fileSystem', icon: <FolderOpenOutlined /> },
+  { key: 'traffic', labelKey: 'AIRightPanel.traffic', icon: <FigmaIcon348196674Outlined /> },
+  { key: 'risk', labelKey: 'AIRightPanel.risk', icon: <BugOutlined /> },
+  { key: 'session-history', labelKey: 'AIRightPanel.sessionHistory', icon: <ChatAlt2Outlined /> },
+  { key: 'task-list', labelKey: 'AIRightPanel.taskList', icon: <FlagOutlined /> },
+]
+
+/** 「更多」分组展开后追加显示的功能入口（收起态仅在底部显示「更多」按钮） */
+const MORE_MENUS: MenuItemDef[] = [
+  { key: 'timeline', labelKey: 'AIRightPanel.timeline', icon: <TimelineOutlined /> },
+  { key: 'export-log', labelKey: 'AIRightPanel.exportLog', icon: <FigmaIcon2017756Outlined /> },
+  { key: 'view-log', labelKey: 'AIRightPanel.viewLog', icon: <NewspaperOutlined /> },
+]
+
+/** 漏洞计数角标的展示顺序（严重/高危/中危/低危/未知，颜色见 risk-tag-value-* 样式） */
+const RISK_TAG_ORDER: Array<keyof AIRightPanelRiskCounts> = ['serious', 'high', 'medium', 'low', 'unknown']
+
+/** 工具调用统计的三个指标（成功/失败带专属色 tone，对应 stat-value-* 样式；总尝试次数用默认色） */
+const TOOL_STATS: Array<{ field: keyof AIRightPanelToolStats; labelKey: string; tone?: 'success' | 'failed' }> = [
+  { field: 'success', labelKey: 'AIRightPanel.success', tone: 'success' },
+  { field: 'failed', labelKey: 'AIRightPanel.failed', tone: 'failed' },
+  { field: 'total', labelKey: 'AIRightPanel.totalAttempts' },
+]
+
+/** 执行时长、工具调用统计等数据未传入时的占位符 */
+const PLACEHOLDER = '—'
+
+interface MenuItemProps {
+  icon: React.ReactNode
+  label: string
+  active?: boolean
+  small?: boolean
+  secondary?: boolean
+  suffix?: React.ReactNode
+  onClick?: () => void
+}
+
+const MenuItem: React.FC<MenuItemProps> = React.memo(({ icon, label, active, small, secondary, suffix, onClick }) => {
+  return (
+    <div
+      className={classNames(
+        styles['menu-item'],
+        small && styles['menu-item-small'],
+        active && styles['menu-item-active'],
+      )}
+      role="button"
+      tabIndex={0}
+      aria-label={label}
+      onClick={onClick}
+      onKeyDown={(event) => {
+        if ((event.key === 'Enter' || event.key === ' ') && onClick) {
+          event.preventDefault()
+          onClick()
+        }
+      }}
+    >
+      <div className={styles['menu-item-base']}>
+        <span
+          className={classNames(
+            styles['menu-item-icon'],
+            small && styles['menu-item-icon-small'],
+            secondary && styles['menu-item-icon-secondary'],
+          )}
+        >
+          {icon}
+        </span>
+        {!small && (
+          <span className={classNames(styles['menu-item-label'], secondary && styles['menu-item-label-secondary'])}>
+            {label}
+          </span>
+        )}
+      </div>
+      {!small && suffix}
+    </div>
+  )
+})
+
+/**
+ * Memfit AI 右侧功能面板：
+ * - 正常态（宽 301px）：数据卡片 + 主菜单 + 底部「更多」分组，更多分组可在 展开/收起 间切换
+ * - 小屏态（正常态面板会使列表可用宽度小于最大宽度时）：仅图标的窄栏（宽 41px）
+ */
+export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
+  const {
+    layoutRef,
+    small,
+    activeKey,
+    onMenuClick,
+    executionDuration,
+    toolCallStats,
+    trafficCount,
+    riskCounts,
+    className,
+    style,
+  } = props
+  const { t } = useI18nNamespaces(['aiAgent'])
+  const [moreOpen, setMoreOpen] = useState(false)
+  const [chatSmall, setChatSmall] = useState(false)
+
+  useEffect(() => {
+    // 监听面板外层宽度；chat-layout-wrapper 会随当前态改变宽度，不能把它作为判断输入，否则会形成反馈回路。
+    const layoutElement = layoutRef?.current
+    if (small !== undefined || !layoutElement || typeof ResizeObserver === 'undefined') return
+
+    const getLayoutWidth = () => layoutElement.clientWidth || layoutElement.getBoundingClientRect().width
+    const update = (layoutWidth: number) => {
+      const nextChatSmall = layoutWidth - AI_RIGHT_PANEL_NORMAL_SLOT_WIDTH < AI_RIGHT_PANEL_INPUT_MAX_WIDTH
+      setChatSmall((previous) => (previous === nextChatSmall ? previous : nextChatSmall))
+    }
+    update(getLayoutWidth())
+    const observer = new ResizeObserver((entries) => {
+      update(entries?.[0]?.contentRect.width ?? getLayoutWidth())
+    })
+    observer.observe(layoutElement)
+    return () => observer.disconnect()
+  }, [layoutRef, small])
+
+  const isSmall = small ?? chatSmall
+
+  const handleClick = useMemoizedFn((key: AIRightPanelMenuKey) => () => onMenuClick?.(key))
+
+  const renderMenuSuffix = useMemoizedFn((key: AIRightPanelMenuKey) => {
+    if (key === 'traffic' && trafficCount !== undefined) {
+      return <span className={styles['count-tag']}>{trafficCount}</span>
+    }
+    if (key === 'risk' && riskCounts) {
+      const entries = RISK_TAG_ORDER.map((field) => ({ field, value: riskCounts[field] })).filter(
+        (entry) => entry.value !== undefined,
+      )
+      if (!entries.length) return null
+      return (
+        <span className={styles['risk-tag']}>
+          {entries.map((entry, index) => (
+            <React.Fragment key={entry.field}>
+              {index > 0 && <span className={styles['risk-tag-separator']}>｜</span>}
+              <span className={classNames(styles['risk-tag-value'], styles[`risk-tag-value-${entry.field}`])}>
+                {entry.value}
+              </span>
+            </React.Fragment>
+          ))}
+        </span>
+      )
+    }
+    return null
+  })
+
+  const renderDataCards = useMemoizedFn(() => (
+    <div className={styles['data-cards']}>
+      <div className={styles['data-card']}>
+        <div className={styles['data-card-accent']} />
+        <div className={styles['data-card-row']}>
+          <span className={styles['data-card-label']}>{t('AIRightPanel.duration')}</span>
+          <span className={styles['data-card-value']}>{executionDuration ?? PLACEHOLDER}</span>
+        </div>
+      </div>
+      <div className={classNames(styles['data-card'], styles['data-card-stats'])}>
+        <div className={classNames(styles['data-card-accent'], styles['data-card-accent-blue'])} />
+        <div className={styles['data-card-body']}>
+          <span className={styles['stats-title']}>{t('AIRightPanel.toolCallStats')}</span>
+          <div className={styles['stats-row']}>
+            {TOOL_STATS.map((stat) => (
+              <div className={styles['stat']} key={stat.field}>
+                <span className={classNames(styles['stat-value'], stat.tone && styles[`stat-value-${stat.tone}`])}>
+                  {toolCallStats?.[stat.field] ?? PLACEHOLDER}
+                </span>
+                <span className={styles['stat-label']}>{t(stat.labelKey)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  ))
+
+  const renderMoreToggle = useMemoizedFn(() => (
+    <MenuItem
+      icon={moreOpen ? <ChevronDoubleUpOutlined /> : <ChevronDoubleDownOutlined />}
+      label={moreOpen ? t('AIRightPanel.collapse') : t('AIRightPanel.more')}
+      small={isSmall}
+      secondary
+      onClick={() => setMoreOpen((prev) => !prev)}
+    />
+  ))
+
+  return (
+    <div
+      className={classNames(styles['right-panel-wrapper'], className)}
+      data-ai-right-panel
+      data-ai-right-panel-small={isSmall}
+      style={style}
+    >
+      <div
+        className={classNames(styles['right-panel'], {
+          [styles['right-panel-small']]: isSmall,
+        })}
+      >
+        <div
+          className={classNames(styles['panel-top'], {
+            [styles['panel-top-small']]: isSmall,
+          })}
+        >
+          <div className={styles['menu-group']}>
+            {!isSmall && renderDataCards()}
+            {MAIN_MENUS.map((item) => (
+              <MenuItem
+                key={item.key}
+                icon={item.icon}
+                label={t(item.labelKey)}
+                active={activeKey === item.key}
+                small={isSmall}
+                suffix={renderMenuSuffix(item.key)}
+                onClick={handleClick(item.key)}
+              />
+            ))}
+          </div>
+        </div>
+        <div className={styles['divider']} />
+        <div className={styles['bottom-group']}>
+          {moreOpen &&
+            MORE_MENUS.map((item) => (
+              <MenuItem
+                key={item.key}
+                icon={item.icon}
+                label={t(item.labelKey)}
+                active={activeKey === item.key}
+                small={isSmall}
+                onClick={handleClick(item.key)}
+              />
+            ))}
+          {renderMoreToggle()}
+        </div>
+      </div>
+    </div>
+  )
+})
+
+export default AIRightPanel

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanelPane.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanelPane.module.scss
@@ -14,6 +14,11 @@
   overflow: hidden;
 }
 
+// 内容自带内边距的变体（如会话历史）：去掉面板 padding
+.pane-no-padding {
+  padding: 0;
+}
+
 .header {
   display: flex;
   flex: none;

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanelPane.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanelPane.module.scss
@@ -1,0 +1,50 @@
+@use '../../../theme/themeify.scss' as themeify;
+
+.pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  padding: 8px 12px;
+  background: var(--Colors-Use-Neutral-Bg);
+  @include themeify.color-mix-border(1px, solid, var(--Colors-Use-Neutral-Disable), 50%);
+  border-radius: 12px;
+  box-shadow: 0 4px 4px 0 var(--Colors-Use-Basic-Shadow);
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 0 8px 4px;
+}
+
+.title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--Colors-Use-Neutral-Text-1-Title);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: 0.1px;
+}
+
+.actions {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 4px;
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanelPane.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanelPane.tsx
@@ -1,0 +1,32 @@
+import type React from 'react'
+import { XOutlined } from '@yakit-libs/yakit-ui-icons/outline'
+import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
+import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
+import styles from './AIRightPanelPane.module.scss'
+
+export interface AIRightPanelPaneProps {
+  title: React.ReactNode
+  actions?: React.ReactNode
+  onClose: () => void
+  children: React.ReactNode
+}
+
+export const AIRightPanelPane: React.FC<AIRightPanelPaneProps> = ({ title, actions, onClose, children }) => {
+  const { t } = useI18nNamespaces(['yakitUi'])
+
+  return (
+    <section className={styles['pane']}>
+      <header className={styles['header']}>
+        <div className={styles['title']}>{title}</div>
+        <div className={styles['actions']}>
+          {actions === undefined ? (
+            <YakitButton type="text2" aria-label={t('YakitButton.close')} icon={<XOutlined />} onClick={onClose} />
+          ) : (
+            actions
+          )}
+        </div>
+      </header>
+      <div className={styles['body']}>{children}</div>
+    </section>
+  )
+}

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanelPane.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanelPane.tsx
@@ -1,4 +1,5 @@
 import type React from 'react'
+import classNames from 'classnames'
 import { XOutlined } from '@yakit-libs/yakit-ui-icons/outline'
 import { YakitButton } from '@/components/yakitUI/YakitButton/YakitButton'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
@@ -7,25 +8,38 @@ import styles from './AIRightPanelPane.module.scss'
 export interface AIRightPanelPaneProps {
   title: React.ReactNode
   actions?: React.ReactNode
+  /** 内容组件自带头部时，使用其头部承载操作按钮。 */
+  hideHeader?: boolean
+  /** 内容组件自带内边距时（如会话历史），面板自身不再加 padding。 */
+  noPadding?: boolean
   onClose: () => void
   children: React.ReactNode
 }
 
-export const AIRightPanelPane: React.FC<AIRightPanelPaneProps> = ({ title, actions, onClose, children }) => {
+export const AIRightPanelPane: React.FC<AIRightPanelPaneProps> = ({
+  title,
+  actions,
+  hideHeader,
+  noPadding,
+  onClose,
+  children,
+}) => {
   const { t } = useI18nNamespaces(['yakitUi'])
 
   return (
-    <section className={styles['pane']}>
-      <header className={styles['header']}>
-        <div className={styles['title']}>{title}</div>
-        <div className={styles['actions']}>
-          {actions === undefined ? (
-            <YakitButton type="text2" aria-label={t('YakitButton.close')} icon={<XOutlined />} onClick={onClose} />
-          ) : (
-            actions
-          )}
-        </div>
-      </header>
+    <section className={classNames(styles['pane'], noPadding && styles['pane-no-padding'])}>
+      {!hideHeader && (
+        <header className={styles['header']}>
+          <div className={styles['title']}>{title}</div>
+          <div className={styles['actions']}>
+            {actions === undefined ? (
+              <YakitButton type="text2" aria-label={t('YakitButton.close')} icon={<XOutlined />} onClick={onClose} />
+            ) : (
+              actions
+            )}
+          </div>
+        </header>
+      )}
       <div className={styles['body']}>{children}</div>
     </section>
   )

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.layout.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.layout.test.ts
@@ -8,7 +8,11 @@ const currentDir = path.dirname(fileURLToPath(import.meta.url))
 const pageDir = path.resolve(currentDir, '..')
 const chatStylePath = path.resolve(pageDir, '../aiReActChat/AIReActChat.module.scss')
 const contentsStylePath = path.resolve(pageDir, '../aiReActChatContents/AIReActChatContents.module.scss')
+const contentsComponentPath = path.resolve(pageDir, '../aiReActChatContents/AIReActChatContents.tsx')
 const panelStylePath = path.resolve(pageDir, 'AIRightPanel.module.scss')
+const todoWrapperStylePath = path.resolve(pageDir, '../aiReActChat/aiToDoListWrapper/AIToDoListWrapper.module.scss')
+const mixinStylePath = path.resolve(pageDir, '../styles/mixin.scss')
+const agentChatStylePath = path.resolve(pageDir, '../../ai-agent/aiAgentChat/AIAgentChat.module.scss')
 
 describe('AIRightPanel layout contract', () => {
   it('keeps the panel interactive while allowing the far-right scrollbar to receive input', () => {
@@ -19,23 +23,63 @@ describe('AIRightPanel layout contract', () => {
     // themeify.color-mix-border 会同时生成普通颜色 fallback 与 color-mix 支持分支
     expect(css).toContain('border: 1px solid var(--Colors-Use-Neutral-Disable)')
     expect(css).toContain('border: 1px solid color-mix(in srgb, var(--Colors-Use-Neutral-Disable) 50%, transparent)')
+    expect(css).toContain('right: -8px')
+    expect(css).toContain('bottom: -6px')
+    expect(css).toContain('width: 16px')
+    expect(css).toContain('height: 14px')
+    expect(css).toContain('background: var(--Colors-Use-Status-High)')
+    expect(css).toContain('border: 1px solid var(--Colors-Use-Neutral-Bg)')
   })
 
-  it('uses the recalculated list offsets after item-wrapper padding removal', () => {
+  it('keeps the Virtuoso scroller full width and shares one content track', () => {
     const chatSource = readFileSync(chatStylePath, 'utf8')
     const contentsSource = readFileSync(contentsStylePath, 'utf8')
+    const contentsComponentSource = readFileSync(contentsComponentPath, 'utf8')
+    const mixinSource = readFileSync(mixinStylePath, 'utf8')
 
     expect(chatSource).toContain('--ai-right-panel-slot-width: 0px')
     expect(chatSource).toContain('--ai-right-panel-content-shift: 0px')
-    expect(chatSource).toContain('--ai-right-panel-list-content-shift: 0px')
+    expect(chatSource).not.toContain('--ai-right-panel-list-content-shift')
     expect(chatSource).toContain('--ai-right-panel-slot-width: 325px')
     expect(chatSource).toContain('--ai-right-panel-content-shift: -162.5px')
     expect(chatSource).toContain('--ai-right-panel-slot-width: 61px')
     expect(chatSource).toContain('--ai-right-panel-content-shift: -30.5px')
-    expect(chatSource).toContain('width: min(784px, calc(100% - var(--ai-right-panel-slot-width)))')
-    expect(chatSource).toContain('transform: translateX(var(--ai-right-panel-list-content-shift))')
+    expect(chatSource).toContain(
+      '--ai-right-panel-content-track-width: min(784px, calc(100% - var(--ai-right-panel-slot-width)))',
+    )
+    // 轨道的实际声明收敛在共享 mixin，面板态 footer include 同一条轨道
+    expect(chatSource).toContain('@include mixin.ai-right-panel-content-track')
     expect(chatSource).toContain('.chat-layout-wrapper')
+    const trackMixinBlock =
+      mixinSource.match(/@mixin\s+ai-right-panel-content-track\([^)]*\)\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
+    expect(trackMixinBlock).toContain('width: var(--ai-right-panel-content-track-width)')
+    expect(trackMixinBlock).toContain('margin: 0 auto')
+    expect(trackMixinBlock).toContain('transform: translateX(var(--ai-right-panel-content-shift))')
+    expect(contentsSource).toContain('.re-act-contents-track')
+    expect(contentsSource).toContain('@include mixin.ai-right-panel-content-track')
+    expect(contentsComponentSource).toContain('List: VirtuosoListContainer')
+    expect(contentsComponentSource).toContain("styles['re-act-contents-track']")
     const itemWrapperBlock = contentsSource.match(/\.item-wrapper\s*\{([\s\S]*?)\n\s*\.item-inner/)?.[1] ?? ''
     expect(itemWrapperBlock).not.toMatch(/padding-(left|right):/)
+  })
+
+  it('keeps the Virtuoso footer, todo card and review popup on the same content track as the message list', () => {
+    const contentsSource = readFileSync(contentsStylePath, 'utf8')
+    const todoWrapperSource = readFileSync(todoWrapperStylePath, 'utf8')
+    const agentChatSource = readFileSync(agentChatStylePath, 'utf8')
+
+    // Virtuoso 的 Footer 与内部 List 是兄弟节点，脱离 List 轨道后需自行套用轨道 mixin
+    const footerLoadingBlock = contentsSource.match(/\.footer-loading\s*\{([\s\S]*?)\n\s*\}/)?.[1] ?? ''
+    const endBlock = contentsSource.match(/\.end\s*\{([\s\S]*?)\n\s*\}/)?.[1] ?? ''
+    expect(footerLoadingBlock).toContain('@include mixin.ai-right-panel-content-track')
+    expect(endBlock).toContain('@include mixin.ai-right-panel-content-track')
+
+    // 待办卡片与消息列表共用同一条内容轨道
+    const todoListBlock = todoWrapperSource.match(/\.to-do-list\s*\{([\s\S]*?)\n\s*\}/)?.[1] ?? ''
+    expect(todoListBlock).toContain('@include mixin.ai-right-panel-content-track')
+
+    // review 弹层绝对定位于全宽根容器上，同样需要轨道对齐消息区中心
+    const reviewBoxBlock = agentChatSource.match(/\.review-box\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
+    expect(reviewBoxBlock).toContain('@include mixin.ai-right-panel-content-track')
   })
 })

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.layout.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.layout.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { compile } from 'sass'
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+const pageDir = path.resolve(currentDir, '..')
+const chatStylePath = path.resolve(pageDir, '../aiReActChat/AIReActChat.module.scss')
+const contentsStylePath = path.resolve(pageDir, '../aiReActChatContents/AIReActChatContents.module.scss')
+const panelStylePath = path.resolve(pageDir, 'AIRightPanel.module.scss')
+
+describe('AIRightPanel layout contract', () => {
+  it('keeps the panel interactive while allowing the far-right scrollbar to receive input', () => {
+    const css = compile(panelStylePath).css
+
+    expect(css).toContain('pointer-events: none')
+    expect(css).toContain('pointer-events: auto')
+    // themeify.color-mix-border 会同时生成普通颜色 fallback 与 color-mix 支持分支
+    expect(css).toContain('border: 1px solid var(--Colors-Use-Neutral-Disable)')
+    expect(css).toContain('border: 1px solid color-mix(in srgb, var(--Colors-Use-Neutral-Disable) 50%, transparent)')
+  })
+
+  it('uses the recalculated list offsets after item-wrapper padding removal', () => {
+    const chatSource = readFileSync(chatStylePath, 'utf8')
+    const contentsSource = readFileSync(contentsStylePath, 'utf8')
+
+    expect(chatSource).toContain('--ai-right-panel-slot-width: 0px')
+    expect(chatSource).toContain('--ai-right-panel-content-shift: 0px')
+    expect(chatSource).toContain('--ai-right-panel-list-content-shift: 0px')
+    expect(chatSource).toContain('--ai-right-panel-slot-width: 325px')
+    expect(chatSource).toContain('--ai-right-panel-content-shift: -162.5px')
+    expect(chatSource).toContain('--ai-right-panel-slot-width: 61px')
+    expect(chatSource).toContain('--ai-right-panel-content-shift: -30.5px')
+    expect(chatSource).toContain('width: min(784px, calc(100% - var(--ai-right-panel-slot-width)))')
+    expect(chatSource).toContain('transform: translateX(var(--ai-right-panel-list-content-shift))')
+    expect(chatSource).toContain('.chat-layout-wrapper')
+    const itemWrapperBlock = contentsSource.match(/\.item-wrapper\s*\{([\s\S]*?)\n\s*\.item-inner/)?.[1] ?? ''
+    expect(itemWrapperBlock).not.toMatch(/padding-(left|right):/)
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.layout.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.layout.test.ts
@@ -15,6 +15,18 @@ const mixinStylePath = path.resolve(pageDir, '../styles/mixin.scss')
 const agentChatStylePath = path.resolve(pageDir, '../../ai-agent/aiAgentChat/AIAgentChat.module.scss')
 
 describe('AIRightPanel layout contract', () => {
+  it('小屏面板的父级层叠上下文高于 TodoList，浮层可以覆盖待办卡片', () => {
+    const panelCss = compile(panelStylePath).css
+    const todoCss = compile(todoWrapperStylePath).css
+    const panelLayer = panelCss.match(
+      /\.right-panel-wrapper\[data-ai-right-panel-small=true\]\s*\{[^}]*z-index:\s*(\d+)/,
+    )
+    const todoLayer = todoCss.match(/\.todoList-wrapper\s*\{[^}]*z-index:\s*(\d+)/)
+    expect(panelLayer).not.toBeNull()
+    expect(todoLayer).not.toBeNull()
+    expect(Number(panelLayer?.[1])).toBeGreaterThan(Number(todoLayer?.[1]))
+  })
+
   it('keeps the panel interactive while allowing the far-right scrollbar to receive input', () => {
     const css = compile(panelStylePath).css
 

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
@@ -1,0 +1,190 @@
+import type React from 'react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+// 资源表必须定义在工厂内部：i18n.init 的预加载在 import 阶段就会触发 read
+vi.mock('i18next-resources-to-backend', () => {
+  const resources: Record<string, Record<string, unknown>> = {
+    zh: {
+      aiAgent: {
+        AIRightPanel: {
+          taskBoard: '任务详情看板',
+          fileSystem: '文件系统',
+          traffic: '流量',
+          risk: '漏洞',
+          sessionHistory: '会话历史',
+          taskList: '任务列表',
+          timeline: '时间线',
+          exportLog: '导出日志',
+          viewLog: '查看日志',
+          collapse: '折叠',
+          more: '更多',
+          duration: '执行时长',
+          toolCallStats: '工具调用统计',
+          success: '成功',
+          failed: '失败',
+          totalAttempts: '总尝试次数',
+        },
+      },
+    },
+  }
+  return {
+    default: () => ({
+      type: 'backend' as const,
+      init() {},
+      read(language: string, namespace: string, callback: (err: unknown, data: unknown) => void) {
+        const data = resources[language]?.[namespace]
+        callback(null, data !== undefined ? data : {})
+      },
+    }),
+  }
+})
+
+import { AIRightPanel } from '../AIRightPanel'
+
+const renderPanel = async (ui: React.ReactElement) => {
+  render(ui)
+  await waitFor(() => expect(screen.getByText('任务详情看板')).toBeInTheDocument())
+}
+
+describe('AIRightPanel', () => {
+  it('正常态渲染数据卡片、六个主菜单与「更多」按钮', async () => {
+    await renderPanel(<AIRightPanel executionDuration="7s" toolCallStats={{ success: 1, failed: 2, total: 3 }} />)
+    expect(screen.getByText('执行时长')).toBeInTheDocument()
+    expect(screen.getByText('7s')).toBeInTheDocument()
+    expect(screen.getByText('工具调用统计')).toBeInTheDocument()
+    expect(screen.getByText('文件系统')).toBeInTheDocument()
+    expect(screen.getByText('会话历史')).toBeInTheDocument()
+    // 底部「更多」分组默认收起
+    expect(screen.getByText('更多')).toBeInTheDocument()
+    expect(screen.queryByText('时间线')).not.toBeInTheDocument()
+  })
+
+  it('点击「更多」展开底部分组，点击「折叠」收起', async () => {
+    await renderPanel(<AIRightPanel />)
+    fireEvent.click(screen.getByText('更多'))
+    expect(screen.getByText('时间线')).toBeInTheDocument()
+    expect(screen.getByText('导出日志')).toBeInTheDocument()
+    expect(screen.getByText('查看日志')).toBeInTheDocument()
+    expect(screen.getByText('折叠')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('折叠'))
+    expect(screen.queryByText('时间线')).not.toBeInTheDocument()
+    expect(screen.getByText('更多')).toBeInTheDocument()
+  })
+
+  it('主菜单点击回调与选中态、计数角标', async () => {
+    const onMenuClick = vi.fn()
+    await renderPanel(
+      <AIRightPanel
+        activeKey="traffic"
+        trafficCount={12}
+        riskCounts={{ serious: 4, high: 6, medium: 1, low: 3, unknown: 8 }}
+        onMenuClick={onMenuClick}
+      />,
+    )
+    fireEvent.click(screen.getByText('流量'))
+    expect(onMenuClick).toHaveBeenCalledWith('traffic')
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('8')).toBeInTheDocument()
+    const activeItem = screen.getByText('流量').closest('[role="button"]')
+    expect(activeItem).toHaveAttribute('aria-label', '流量')
+  })
+
+  it('small 强制小屏态：仅图标，不渲染数据卡片与文案', () => {
+    render(<AIRightPanel small executionDuration="7s" />)
+    expect(screen.queryByText('执行时长')).not.toBeInTheDocument()
+    expect(screen.queryByText('任务详情看板')).not.toBeInTheDocument()
+    expect(screen.queryByText('更多')).not.toBeInTheDocument()
+  })
+
+  it('small 小屏态点击「更多」展开额外功能入口，再次点击收起', async () => {
+    render(<AIRightPanel small />)
+    const moreButton = screen.getByRole('button', { name: '更多' })
+
+    expect(screen.queryByLabelText('时间线')).not.toBeInTheDocument()
+    fireEvent.click(moreButton)
+    expect(screen.getByLabelText('时间线')).toBeInTheDocument()
+    expect(screen.getByLabelText('导出日志')).toBeInTheDocument()
+    expect(screen.getByLabelText('查看日志')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '折叠' }))
+    expect(screen.queryByLabelText('时间线')).not.toBeInTheDocument()
+  })
+
+  it('当正常态面板会遮挡列表时切换为小屏态', async () => {
+    const listElement = document.createElement('div')
+    let listWidth = 1108
+    Object.defineProperty(listElement, 'clientWidth', {
+      configurable: true,
+      get: () => listWidth,
+    })
+    Object.defineProperty(listElement, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: listWidth }),
+    })
+    const layoutRef = { current: listElement } as React.RefObject<HTMLElement | null>
+    let resizeCallback: (() => void) | undefined
+    class ResizeObserverMock {
+      constructor(callback: () => void) {
+        resizeCallback = callback
+      }
+
+      observe() {}
+
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+
+    try {
+      render(<AIRightPanel layoutRef={layoutRef} />)
+      await waitFor(() => expect(screen.getByRole('button', { name: '任务详情看板' })).toBeInTheDocument())
+      expect(screen.queryByText('任务详情看板')).not.toBeInTheDocument()
+
+      // 1108 - 325 = 783，小于列表最大宽度，进入小屏；达到 784px 后恢复正常态。
+      listWidth = 1109
+      act(() => resizeCallback?.())
+      await waitFor(() => expect(screen.getByText('任务详情看板')).toBeInTheDocument())
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('小屏判断跟随聊天容器宽度并在最大宽度边界切换', async () => {
+    const listElement = document.createElement('div')
+
+    let listWidth = 783
+    Object.defineProperty(listElement, 'clientWidth', {
+      configurable: true,
+      get: () => listWidth,
+    })
+    Object.defineProperty(listElement, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: listWidth }),
+    })
+    const layoutRef = { current: listElement } as React.RefObject<HTMLElement | null>
+    let resizeCallback: (() => void) | undefined
+    class ResizeObserverMock {
+      constructor(callback: () => void) {
+        resizeCallback = callback
+      }
+
+      observe() {}
+
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+
+    try {
+      render(<AIRightPanel layoutRef={layoutRef} />)
+      await waitFor(() => expect(screen.queryByText('任务详情看板')).not.toBeInTheDocument())
+
+      // 聊天容器宽度达到 1109px 后，扣除 325px 面板槽位正好剩余 784px，恢复正常态。
+      listWidth = 1109
+      act(() => resizeCallback?.())
+      await waitFor(() => expect(screen.getByText('任务详情看板')).toBeInTheDocument())
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
@@ -2,6 +2,14 @@ import type React from 'react'
 import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
+// CI 的根配置将样式模块替换为空对象；为这里验证的状态类提供稳定映射。
+vi.mock('../AIRightPanel.module.scss', () => ({
+  default: {
+    'right-panel-hidden': 'right-panel-hidden',
+    'pane-slot-small': 'pane-slot-small',
+  },
+}))
+
 // 数据源 mock：用真实 zustand vanilla store 构造（订阅语义与产品一致），
 // rawData.taskDetailsMap 由各用例按需覆写；改写状态用 mockTaskStore.setState 原生推送更新
 import { createStore } from 'zustand/vanilla'
@@ -124,6 +132,14 @@ vi.mock('i18next-resources-to-backend', () => {
 })
 
 import { AIRightPanel } from '../AIRightPanel'
+import { AIRightPanelPane } from '../AIRightPanelPane'
+
+vi.mock('@/pages/ai-agent/chatTemplate/historyTaskTree/TaskListPane', () => ({
+  TaskListPane: () => <div data-testid="task-list-pane" />,
+}))
+vi.mock('@/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard', () => ({
+  default: () => <div data-testid="timeline-pane" />,
+}))
 
 const renderPanel = async (ui: React.ReactElement) => {
   const renderResult = render(ui)
@@ -133,6 +149,86 @@ const renderPanel = async (ui: React.ReactElement) => {
 }
 
 describe('AIRightPanel', () => {
+  it('正常态点击时间线打开面板，关闭后恢复菜单', async () => {
+    await renderPanel(<AIRightPanel />)
+    fireEvent.click(screen.getByLabelText('更多'))
+    fireEvent.click(screen.getByLabelText('时间线'))
+    expect(screen.getByTestId('timeline-pane')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.queryByTestId('timeline-pane')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('文件系统')).toBeInTheDocument()
+  })
+
+  it('小屏在任务列表和时间线间悬停切换，移出时间线后销毁', async () => {
+    render(<AIRightPanel small />)
+    fireEvent.click(screen.getByLabelText('更多'))
+    const taskItem = screen.getByLabelText('任务列表')
+    const timelineItem = screen.getByLabelText('时间线')
+    fireEvent.mouseEnter(taskItem)
+    fireEvent.mouseLeave(taskItem)
+    fireEvent.mouseEnter(timelineItem)
+    expect(screen.queryByTestId('task-list-pane')).not.toBeInTheDocument()
+    expect(screen.getByTestId('timeline-pane')).toBeInTheDocument()
+    fireEvent.mouseLeave(timelineItem)
+    await waitFor(() => expect(screen.queryByTestId('timeline-pane')).not.toBeInTheDocument())
+    fireEvent.click(timelineItem)
+    expect(screen.getByTestId('timeline-pane')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.queryByTestId('timeline-pane')).not.toBeInTheDocument()
+  })
+  it('正常态点击任务列表替换菜单，关闭后恢复菜单', async () => {
+    await renderPanel(<AIRightPanel />)
+    fireEvent.click(screen.getByLabelText('任务列表'))
+    expect(screen.getByTestId('task-list-pane')).toBeVisible()
+    expect(screen.getByLabelText('文件系统').parentElement?.parentElement?.parentElement?.className).toContain(
+      'right-panel-hidden',
+    )
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.queryByTestId('task-list-pane')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('文件系统').parentElement?.parentElement?.parentElement?.className).not.toContain(
+      'right-panel-hidden',
+    )
+  })
+
+  it('小屏悬停打开，移入浮层保持，移出后销毁', async () => {
+    render(<AIRightPanel small />)
+    const item = screen.getByLabelText('任务列表')
+    fireEvent.mouseEnter(item)
+    const pane = screen.getByTestId('task-list-pane').closest('section')!.parentElement!
+    expect(pane.className).toContain('pane-slot-small')
+    fireEvent.mouseLeave(item)
+    fireEvent.mouseEnter(pane)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    })
+    expect(screen.getByTestId('task-list-pane')).toBeInTheDocument()
+    fireEvent.mouseLeave(pane)
+    await waitFor(() => expect(screen.queryByTestId('task-list-pane')).not.toBeInTheDocument())
+    fireEvent.mouseEnter(item)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.queryByTestId('task-list-pane')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('文件系统')).toBeInTheDocument()
+  })
+
+  it('切换屏幕模式时清理打开的任务浮层', () => {
+    const result = render(<AIRightPanel small />)
+    fireEvent.mouseEnter(screen.getByLabelText('任务列表'))
+    result.rerender(<AIRightPanel small={false} />)
+    expect(screen.queryByTestId('task-list-pane')).not.toBeInTheDocument()
+  })
+
+  it('包裹组件支持自定义标题和操作区', () => {
+    render(
+      <AIRightPanelPane title="自定义标题" actions={<button>操作</button>} onClose={vi.fn()}>
+        内容
+      </AIRightPanelPane>,
+    )
+    expect(screen.getByText('自定义标题')).toBeInTheDocument()
+    expect(screen.getAllByRole('button')).toHaveLength(1)
+    expect(screen.getByRole('button', { name: '操作' })).toBeInTheDocument()
+    expect(screen.getByText('内容')).toBeInTheDocument()
+  })
+
   it('正常态渲染数据卡片、六个主菜单与「更多」按钮', async () => {
     setMockQuestionID('task-normal')
     // 「任务详情」入口需要 questionID 与 ai-agent 来源同时满足
@@ -205,8 +301,8 @@ describe('AIRightPanel', () => {
   it('small 小屏态 hover 展开项后收起分组（触发元素卸载），浮层随之销毁', async () => {
     render(<AIRightPanel small />)
     fireEvent.click(screen.getByLabelText('更多'))
-    const timelineButton = screen.getByLabelText('时间线')
-    // hover 打开「时间线」浮层
+    const timelineButton = screen.getByLabelText('导出日志')
+    // hover 打开普通菜单的文案提示
     fireEvent.mouseEnter(timelineButton)
     await waitFor(() => expect(document.querySelector('.ant-tooltip')).toBeInTheDocument())
 
@@ -306,8 +402,6 @@ describe('AIRightPanel', () => {
       const riskTotalBadge = screen.getByText('22')
 
       expect(riskButton).toContainElement(riskTotalBadge)
-      expect(riskTotalBadge.className).toContain('risk-count-badge')
-      expect(riskTotalBadge.parentElement?.className).toContain('menu-item-icon-small')
     } finally {
       resetMockStore()
     }

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
@@ -170,14 +170,20 @@ const renderPanel = async (ui: React.ReactElement) => {
 }
 
 describe('AIRightPanel', () => {
-  it.each([false, true])('AI 设置位于底部分组的时间线上方，随更多分组展开和收起（小屏：%s）', async (small) => {
+  it.each([false, true])('暂不显示 AI 设置，更多分组按顺序展开和收起（小屏：%s）', async (small) => {
     render(<AIRightPanel small={small} />)
     fireEvent.click(await screen.findByLabelText('更多'))
-    const settings = screen.getByLabelText('AI 设置')
-    expect(settings.nextElementSibling).toBe(screen.getByLabelText('时间线'))
-    expect(settings.parentElement?.firstElementChild).toBe(settings)
+    expect(screen.queryByLabelText('AI 设置')).not.toBeInTheDocument()
+    const timeline = screen.getByLabelText('时间线')
+    const exportLog = screen.getByLabelText('导出日志')
+    expect(timeline.parentElement?.firstElementChild).toBe(timeline)
+    expect(timeline.nextElementSibling).toBe(exportLog)
+    expect(exportLog.nextElementSibling).toBe(screen.getByLabelText('查看日志'))
     fireEvent.click(screen.getByLabelText('折叠'))
     expect(screen.queryByLabelText('AI 设置')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('时间线')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('导出日志')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('查看日志')).not.toBeInTheDocument()
   })
 
   it('点击会话历史打开 HistoryChat，关闭按钮位于原头部最右侧且没有固定按钮', async () => {

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
@@ -140,6 +140,26 @@ vi.mock('@/pages/ai-agent/chatTemplate/historyTaskTree/TaskListPane', () => ({
 vi.mock('@/pages/ai-agent/chatTemplate/TimelineCard/TimelineCard', () => ({
   default: () => <div data-testid="timeline-pane" />,
 }))
+vi.mock('@/pages/ai-agent/historyChat/HistoryChat', () => ({
+  default: ({
+    hidePinButton,
+    headerActionsExtra,
+    aiSource,
+  }: {
+    hidePinButton?: boolean
+    headerActionsExtra?: React.ReactNode
+    aiSource: string[]
+  }) => (
+    <div data-testid="history-chat" data-sources={aiSource.join(',')}>
+      <header>
+        <span>会话列表</span>
+        <button>新建会话</button>
+        {headerActionsExtra}
+        {!hidePinButton && <button>固定</button>}
+      </header>
+    </div>
+  ),
+}))
 
 const renderPanel = async (ui: React.ReactElement) => {
   const renderResult = render(ui)
@@ -149,6 +169,34 @@ const renderPanel = async (ui: React.ReactElement) => {
 }
 
 describe('AIRightPanel', () => {
+  it('点击会话历史打开 HistoryChat，关闭按钮位于原头部最右侧且没有固定按钮', async () => {
+    await renderPanel(<AIRightPanel />)
+    fireEvent.click(screen.getByLabelText('会话历史'))
+    const history = screen.getByTestId('history-chat')
+    expect(history).toHaveAttribute('data-sources', 'ai,im,')
+    const pane = history.closest('section')!
+    expect(pane.querySelectorAll('header')).toHaveLength(1)
+    expect(screen.queryByRole('button', { name: '固定' })).not.toBeInTheDocument()
+    const closeButton = pane.querySelector('header')!.lastElementChild!
+    expect(closeButton).toHaveAttribute('aria-label')
+    fireEvent.click(closeButton)
+    expect(screen.queryByTestId('history-chat')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('文件系统')).toBeInTheDocument()
+  })
+
+  it('小屏会话历史支持悬停打开、移出销毁和点击关闭', async () => {
+    render(<AIRightPanel small />)
+    const item = screen.getByLabelText('会话历史')
+    fireEvent.mouseEnter(item)
+    expect(screen.getByTestId('history-chat')).toBeInTheDocument()
+    fireEvent.mouseLeave(item)
+    await waitFor(() => expect(screen.queryByTestId('history-chat')).not.toBeInTheDocument())
+    fireEvent.click(item)
+    fireEvent.click(screen.getByTestId('history-chat').querySelector('header')!.lastElementChild!)
+    expect(screen.queryByTestId('history-chat')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('文件系统')).toBeInTheDocument()
+  })
+
   it('正常态点击时间线打开面板，关闭后恢复菜单', async () => {
     await renderPanel(<AIRightPanel />)
     fireEvent.click(screen.getByLabelText('更多'))

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
@@ -1,6 +1,88 @@
 import type React from 'react'
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
+
+// 数据源 mock：用真实 zustand vanilla store 构造（订阅语义与产品一致），
+// rawData.taskDetailsMap 由各用例按需覆写；改写状态用 mockTaskStore.setState 原生推送更新
+import { createStore } from 'zustand/vanilla'
+import type { StoreApi } from 'zustand/vanilla'
+
+interface MockTaskStoreState {
+  currentChatStatus: { questionID: string }
+}
+// 详情条目带 uuid：DataCards 轮询比较 uuid 判断详情是否被流数据刷新（参照 AITaskExecutionDetails）
+interface MockTaskDetails {
+  uuid?: string
+  execution?: Record<string, unknown>
+}
+const mockTaskDetailsMap = new Map<string, MockTaskDetails>()
+const mockTaskStore: StoreApi<MockTaskStoreState> = createStore<MockTaskStoreState>(() => ({
+  currentChatStatus: { questionID: '' },
+}))
+const setMockQuestionID = (questionID: string) => {
+  mockTaskStore.setState((state) => ({ currentChatStatus: { ...state.currentChatStatus, questionID } }))
+  casualTaskState.questionID = questionID
+}
+const resetMockStore = () => {
+  mockTaskStore.setState({ currentChatStatus: { questionID: '' } })
+  mockTaskDetailsMap.clear()
+  casualTaskState.questionID = ''
+}
+vi.mock('../../hooks/useCurrentDataBySession', () => ({
+  useCurrentStore: () => mockTaskStore,
+  useCurrentRawData: () => ({
+    taskDetailsMap: mockTaskDetailsMap,
+    httpRunTimeIDs: [] as string[],
+  }),
+}))
+
+// grpc.ts 顶层依赖 electron，测试中只保留日志导出方法的 mock。
+vi.mock('@/pages/ai-agent/grpc', () => ({
+  grpcExportAILogs: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@/pages/ai-agent/useContext/useStore', () => ({
+  default: () => ({ activeChat: undefined }),
+}))
+
+// 菜单点击交互依赖（vi.hoisted：vi.mock 工厂引用的变量需先于 mock 提升初始化）
+const { mockEmit, casualTaskState, mockSyncCasualTaskTab, mockOpenLogWindow, mockExportModalState, dispatcherState } =
+  vi.hoisted(() => ({
+    mockEmit: vi.fn(),
+    casualTaskState: { questionID: '' },
+    mockSyncCasualTaskTab: vi.fn(),
+    mockOpenLogWindow: vi.fn(),
+    mockExportModalState: { lastVisible: undefined as boolean | undefined },
+    // getSetting 返回的可控配置，「任务详情」入口按 Source 决定是否渲染
+    dispatcherState: { setting: { Source: 'ai' } as { Source: string } },
+  }))
+vi.mock('@/utils/eventBus/eventBus', () => ({ default: { emit: mockEmit, on: vi.fn(), off: vi.fn() } }))
+
+// useCasualTaskTab / useAiChatLog / useDispatcher 的模块链含 electron IPC，统一 mock
+vi.mock('@/pages/ai-agent/aiChatContent/hooks/useCasualTaskTab', () => ({
+  useCasualTaskTab: () => ({
+    currentChatStatusQuestionID: casualTaskState.questionID,
+    syncCasualTaskTab: mockSyncCasualTaskTab,
+  }),
+}))
+vi.mock('@/hook/useAiChatLog/useAiChatLog.ts', () => ({
+  default: () => ({ onOpenLogWindow: mockOpenLogWindow }),
+}))
+vi.mock('@/pages/ai-agent/useContext/useDispatcher', () => ({
+  default: () => ({ getSetting: () => dispatcherState.setting }),
+}))
+
+vi.mock('@/pages/ai-agent/components/ExportAILogsModal/ExportAILogsModal', () => ({
+  ExportAILogsModal: ({ visible }: { visible: boolean }) => {
+    mockExportModalState.lastVisible = visible
+    return null
+  },
+}))
+
+vi.mock('@/utils/notification', () => ({ yakitNotify: vi.fn(), failed: vi.fn() }))
+
+vi.mock('@/utils/timeUtil', () => ({
+  timeDiffWithMoment: vi.fn((startedAt: number, endedAt: number) => `${endedAt - startedAt}s`),
+}))
 
 // 资源表必须定义在工厂内部：i18n.init 的预加载在 import 阶段就会触发 read
 vi.mock('i18next-resources-to-backend', () => {
@@ -24,6 +106,7 @@ vi.mock('i18next-resources-to-backend', () => {
           success: '成功',
           failed: '失败',
           totalAttempts: '总尝试次数',
+          running: '执行中',
         },
       },
     },
@@ -43,21 +126,36 @@ vi.mock('i18next-resources-to-backend', () => {
 import { AIRightPanel } from '../AIRightPanel'
 
 const renderPanel = async (ui: React.ReactElement) => {
-  render(ui)
-  await waitFor(() => expect(screen.getByText('任务详情看板')).toBeInTheDocument())
+  const renderResult = render(ui)
+  // 「任务详情」按条件渲染可能缺席，用常驻菜单「文件系统」作为就绪探针
+  await waitFor(() => expect(screen.getByText('文件系统')).toBeInTheDocument())
+  return renderResult
 }
 
 describe('AIRightPanel', () => {
   it('正常态渲染数据卡片、六个主菜单与「更多」按钮', async () => {
-    await renderPanel(<AIRightPanel executionDuration="7s" toolCallStats={{ success: 1, failed: 2, total: 3 }} />)
-    expect(screen.getByText('执行时长')).toBeInTheDocument()
-    expect(screen.getByText('7s')).toBeInTheDocument()
-    expect(screen.getByText('工具调用统计')).toBeInTheDocument()
-    expect(screen.getByText('文件系统')).toBeInTheDocument()
-    expect(screen.getByText('会话历史')).toBeInTheDocument()
-    // 底部「更多」分组默认收起
-    expect(screen.getByText('更多')).toBeInTheDocument()
-    expect(screen.queryByText('时间线')).not.toBeInTheDocument()
+    setMockQuestionID('task-normal')
+    // 「任务详情」入口需要 questionID 与 ai-agent 来源同时满足
+    casualTaskState.questionID = 'task-normal'
+    mockTaskDetailsMap.set('task-normal', {
+      execution: { started_at: 1000, ended_at: 7000, tool_call_success: 1, tool_call_failed: 2, tool_call_total: 3 },
+    })
+    try {
+      await renderPanel(<AIRightPanel />)
+      expect(screen.getByText('执行时长')).toBeInTheDocument()
+      // timeDiffWithMoment mock 返回差值 "6000s"
+      expect(screen.getByText('6000s')).toBeInTheDocument()
+      expect(screen.getByText('工具调用统计')).toBeInTheDocument()
+      expect(screen.getByText('任务详情看板')).toBeInTheDocument()
+      expect(screen.getByText('文件系统')).toBeInTheDocument()
+      expect(screen.getByText('会话历史')).toBeInTheDocument()
+      // 底部「更多」分组默认收起
+      expect(screen.getByText('更多')).toBeInTheDocument()
+      expect(screen.queryByText('时间线')).not.toBeInTheDocument()
+    } finally {
+      resetMockStore()
+      casualTaskState.questionID = ''
+    }
   })
 
   it('点击「更多」展开底部分组，点击「折叠」收起', async () => {
@@ -73,34 +171,53 @@ describe('AIRightPanel', () => {
     expect(screen.getByText('更多')).toBeInTheDocument()
   })
 
-  it('主菜单点击回调与选中态、计数角标', async () => {
-    const onMenuClick = vi.fn()
-    await renderPanel(
-      <AIRightPanel
-        activeKey="traffic"
-        trafficCount={12}
-        riskCounts={{ serious: 4, high: 6, medium: 1, low: 3, unknown: 8 }}
-        onMenuClick={onMenuClick}
-      />,
-    )
-    fireEvent.click(screen.getByText('流量'))
-    expect(onMenuClick).toHaveBeenCalledWith('traffic')
-    expect(screen.getByText('12')).toBeInTheDocument()
-    expect(screen.getByText('8')).toBeInTheDocument()
-    const activeItem = screen.getByText('流量').closest('[role="button"]')
-    expect(activeItem).toHaveAttribute('aria-label', '流量')
-  })
-
   it('small 强制小屏态：仅图标，不渲染数据卡片与文案', () => {
-    render(<AIRightPanel small executionDuration="7s" />)
+    render(<AIRightPanel small />)
     expect(screen.queryByText('执行时长')).not.toBeInTheDocument()
     expect(screen.queryByText('任务详情看板')).not.toBeInTheDocument()
     expect(screen.queryByText('更多')).not.toBeInTheDocument()
   })
 
+  it('small 小屏态悬停菜单项时左侧出现文案提示', async () => {
+    render(<AIRightPanel small />)
+    const fileSystemButton = screen.getByLabelText('文件系统')
+    // antd Tooltip 悬停触发，浮层渲染到 body 下
+    fireEvent.mouseEnter(fileSystemButton)
+    await waitFor(() => expect(screen.getByText('文件系统')).toBeInTheDocument())
+  })
+
+  it('small 小屏态「更多」hover 后点击展开，Tooltip 浮层不残留', async () => {
+    render(<AIRightPanel small />)
+    const moreButton = screen.getByLabelText('更多')
+    // 悬停展开提示（受控 open 同步渲染浮层）
+    fireEvent.mouseEnter(moreButton)
+    await waitFor(() => expect(document.querySelector('.ant-tooltip')).toBeInTheDocument())
+    fireEvent.click(moreButton)
+    fireEvent.mouseLeave(moreButton)
+    // label 切换为「折叠」：key={label} 重建 Tooltip，受控 open 状态下浮层同步销毁/隐藏
+    await waitFor(() => {
+      const tooltip = document.querySelector<HTMLElement>('.ant-tooltip')
+      // 已卸载或不可见（屏外定位）均视为不残留
+      if (tooltip) expect(tooltip.style.left).toBe('-1000vw')
+    })
+  })
+
+  it('small 小屏态 hover 展开项后收起分组（触发元素卸载），浮层随之销毁', async () => {
+    render(<AIRightPanel small />)
+    fireEvent.click(screen.getByLabelText('更多'))
+    const timelineButton = screen.getByLabelText('时间线')
+    // hover 打开「时间线」浮层
+    fireEvent.mouseEnter(timelineButton)
+    await waitFor(() => expect(document.querySelector('.ant-tooltip')).toBeInTheDocument())
+
+    // 点击「折叠」：MORE_MENUS 整组卸载，触发元素消失，受控浮层随组件卸载同步销毁
+    fireEvent.click(screen.getByLabelText('折叠'))
+    await waitFor(() => expect(document.querySelector('.ant-tooltip')).not.toBeInTheDocument())
+  })
+
   it('small 小屏态点击「更多」展开额外功能入口，再次点击收起', async () => {
     render(<AIRightPanel small />)
-    const moreButton = screen.getByRole('button', { name: '更多' })
+    const moreButton = screen.getByLabelText('更多')
 
     expect(screen.queryByLabelText('时间线')).not.toBeInTheDocument()
     fireEvent.click(moreButton)
@@ -108,8 +225,92 @@ describe('AIRightPanel', () => {
     expect(screen.getByLabelText('导出日志')).toBeInTheDocument()
     expect(screen.getByLabelText('查看日志')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: '折叠' }))
+    fireEvent.click(screen.getByLabelText('折叠'))
     expect(screen.queryByLabelText('时间线')).not.toBeInTheDocument()
+  })
+
+  it('session_snapshot 提供流量总数和各等级漏洞计数', async () => {
+    setMockQuestionID('task-risk')
+    mockTaskDetailsMap.set('task-risk', {
+      uuid: 'uuid-risk',
+      execution: {
+        http_flow_count: 42,
+        risk_level_count: { critical: 4, high: 6, warning: 1, low: 3, info: 5, other: 3, total: 22 },
+      },
+    })
+    try {
+      await renderPanel(<AIRightPanel />)
+      expect(screen.getByText('42')).toBeInTheDocument()
+      // 面板展示严重/高危/中危/低危/信息，其中 info 与 other 合并到信息。
+      expect(screen.getByText('4')).toBeInTheDocument()
+      expect(screen.getByText('6')).toBeInTheDocument()
+      expect(screen.getByText('1')).toBeInTheDocument()
+      expect(screen.getByText('3')).toBeInTheDocument()
+      expect(screen.getByText('8')).toBeInTheDocument()
+    } finally {
+      resetMockStore()
+    }
+  })
+
+  it('漏洞等级计数为 0 的等级不展示角标', async () => {
+    setMockQuestionID('task-risk-partial-zero')
+    mockTaskDetailsMap.set('task-risk-partial-zero', {
+      uuid: 'uuid-risk-partial-zero',
+      execution: {
+        risk_level_count: { critical: 2, high: 0, warning: 0, low: 1, info: 0, other: 0, total: 3 },
+      },
+    })
+    try {
+      await renderPanel(<AIRightPanel />)
+      const riskButton = screen.getByLabelText('漏洞')
+      // 仅展示非零等级：严重 2、低危 1
+      expect(riskButton).toContainElement(screen.getByText('2'))
+      expect(riskButton).toContainElement(screen.getByText('1'))
+      expect(screen.queryByText('0')).not.toBeInTheDocument()
+    } finally {
+      resetMockStore()
+    }
+  })
+
+  it('漏洞等级计数全部为 0 时不渲染等级角标', async () => {
+    setMockQuestionID('task-risk-all-zero')
+    mockTaskDetailsMap.set('task-risk-all-zero', {
+      uuid: 'uuid-risk-all-zero',
+      execution: {
+        risk_level_count: { critical: 0, high: 0, warning: 0, low: 0, info: 0, other: 0, total: 0 },
+      },
+    })
+    try {
+      await renderPanel(<AIRightPanel />)
+      const riskButton = screen.getByLabelText('漏洞')
+      // 无任何等级数字与分隔符，整个 risk-tag 角标隐藏
+      expect(riskButton.textContent).toBe('漏洞')
+      expect(screen.queryByText('｜')).not.toBeInTheDocument()
+    } finally {
+      resetMockStore()
+    }
+  })
+
+  it('小屏漏洞菜单在图标右下角显示漏洞总数角标', () => {
+    setMockQuestionID('task-risk-small')
+    mockTaskDetailsMap.set('task-risk-small', {
+      uuid: 'uuid-risk-small',
+      execution: {
+        risk_level_count: { critical: 4, high: 6, warning: 1, low: 3, info: 5, other: 3, total: 22 },
+      },
+    })
+    try {
+      render(<AIRightPanel small />)
+
+      const riskButton = screen.getByLabelText('漏洞')
+      const riskTotalBadge = screen.getByText('22')
+
+      expect(riskButton).toContainElement(riskTotalBadge)
+      expect(riskTotalBadge.className).toContain('risk-count-badge')
+      expect(riskTotalBadge.parentElement?.className).toContain('menu-item-icon-small')
+    } finally {
+      resetMockStore()
+    }
   })
 
   it('当正常态面板会遮挡列表时切换为小屏态', async () => {
@@ -138,13 +339,14 @@ describe('AIRightPanel', () => {
 
     try {
       render(<AIRightPanel layoutRef={layoutRef} />)
-      await waitFor(() => expect(screen.getByRole('button', { name: '任务详情看板' })).toBeInTheDocument())
-      expect(screen.queryByText('任务详情看板')).not.toBeInTheDocument()
+      // 1108 - 325 = 783 < 784 进入小屏（仅图标）；宽度到 1109 恢复正常态后菜单文案出现
+      await waitFor(() => expect(screen.getByLabelText('文件系统')).toBeInTheDocument())
+      expect(screen.queryByText('文件系统')).not.toBeInTheDocument()
 
       // 1108 - 325 = 783，小于列表最大宽度，进入小屏；达到 784px 后恢复正常态。
       listWidth = 1109
       act(() => resizeCallback?.())
-      await waitFor(() => expect(screen.getByText('任务详情看板')).toBeInTheDocument())
+      await waitFor(() => expect(screen.getByText('文件系统')).toBeInTheDocument())
     } finally {
       vi.unstubAllGlobals()
     }
@@ -177,14 +379,150 @@ describe('AIRightPanel', () => {
 
     try {
       render(<AIRightPanel layoutRef={layoutRef} />)
-      await waitFor(() => expect(screen.queryByText('任务详情看板')).not.toBeInTheDocument())
+      await waitFor(() => expect(screen.queryByText('文件系统')).not.toBeInTheDocument())
 
       // 聊天容器宽度达到 1109px 后，扣除 325px 面板槽位正好剩余 784px，恢复正常态。
       listWidth = 1109
       act(() => resizeCallback?.())
-      await waitFor(() => expect(screen.getByText('任务详情看板')).toBeInTheDocument())
+      await waitFor(() => expect(screen.getByText('文件系统')).toBeInTheDocument())
     } finally {
       vi.unstubAllGlobals()
     }
+  })
+
+  it('数据源：未传 props 时读取当前任务的执行详情展示时长与工具统计', async () => {
+    setMockQuestionID('task-1')
+    mockTaskDetailsMap.set('task-1', {
+      uuid: 'uuid-1',
+      execution: {
+        started_at: 1000,
+        ended_at: 7000,
+        tool_call_success: 3,
+        tool_call_failed: 1,
+        tool_call_total: 4,
+      },
+    })
+    try {
+      await renderPanel(<AIRightPanel />)
+      // timeDiffWithMoment mock 返回差值 "6000s"
+      expect(screen.getByText('6000s')).toBeInTheDocument()
+      // 统计值与其 label 同属一个 stat 块，经 label 定位避免与 risk 角标写死值（4｜6｜1｜3｜8）撞车
+      const statValue = (label: string) => screen.getByText(label).previousElementSibling?.textContent
+      expect(statValue('成功')).toBe('3')
+      expect(statValue('失败')).toBe('1')
+      expect(statValue('总尝试次数')).toBe('4')
+    } finally {
+      resetMockStore()
+    }
+  })
+
+  it('数据源：任务执行中展示「执行中」，无执行数据时展示占位符', async () => {
+    setMockQuestionID('task-2')
+    mockTaskDetailsMap.set('task-2', {
+      uuid: 'uuid-2',
+      execution: {
+        started_at: 1000,
+        ended_at: 0,
+        tool_call_success: 2,
+        tool_call_failed: 0,
+        tool_call_total: 2,
+      },
+    })
+    mockTaskDetailsMap.set('task-empty', { uuid: 'uuid-empty' })
+    try {
+      // 有 started_at 无 ended_at：执行中
+      const renderResult = await renderPanel(<AIRightPanel />)
+      expect(screen.getByText('执行中')).toBeInTheDocument()
+
+      // 切到无 execution 的任务：外部 taskId 变化后重新渲染，executionData 立即重读
+      act(() => {
+        setMockQuestionID('task-empty')
+      })
+      renderResult.rerender(<AIRightPanel key="task-empty" />)
+      // 时长 + 成功/失败/总尝试 共 4 个占位符
+      await waitFor(() => expect(screen.getAllByText('—')).toHaveLength(4))
+    } finally {
+      resetMockStore()
+    }
+  })
+
+  it('数据源：同任务详情更新（uuid 变化）后轮询刷新卡片数据', async () => {
+    setMockQuestionID('task-3')
+    mockTaskDetailsMap.set('task-3', {
+      uuid: 'uuid-3a',
+      execution: { started_at: 1000, ended_at: 0, tool_call_success: 0, tool_call_failed: 0, tool_call_total: 0 },
+    })
+    try {
+      await renderPanel(<AIRightPanel />)
+      expect(screen.getByText('执行中')).toBeInTheDocument()
+
+      // session_snapshot 刷新详情：store 无计数信号，靠 uuid 轮询（3s 间隔）感知后重读 execution
+      mockTaskDetailsMap.set('task-3', {
+        uuid: 'uuid-3b',
+        execution: { started_at: 1000, ended_at: 9000, tool_call_success: 5, tool_call_failed: 2, tool_call_total: 7 },
+      })
+      // 轮询间隔 3s，超时放宽到 5s 预留余量，避免慢环境下 flaky
+      await waitFor(() => expect(screen.getByText('8000s')).toBeInTheDocument(), { timeout: 5000 })
+      expect(screen.getByText('5')).toBeInTheDocument()
+      expect(screen.getByText('2')).toBeInTheDocument()
+      expect(screen.getByText('7')).toBeInTheDocument()
+    } finally {
+      resetMockStore()
+    }
+  })
+
+  it('菜单点击：文件系统激活侧边栏会话 tab，流量/漏洞打开工作区对应 tab', async () => {
+    await renderPanel(<AIRightPanel />)
+    // 文件树位于左侧边栏会话 tab 分栏，emit switchAIAgentTab 激活
+    fireEvent.click(screen.getByText('文件系统'))
+    expect(mockEmit).toHaveBeenCalledWith(
+      'switchAIAgentTab',
+      JSON.stringify({ type: 'setTabActive', params: { active: 'session', show: true } }),
+    )
+    fireEvent.click(screen.getByText('流量'))
+    expect(mockEmit).toHaveBeenCalledWith('switchAIActTab', JSON.stringify({ key: 'http' }))
+    fireEvent.click(screen.getByText('漏洞'))
+    expect(mockEmit).toHaveBeenCalledWith('switchAIActTab', JSON.stringify({ key: 'risk' }))
+  })
+
+  it('菜单点击：任务详情入口按条件渲染，点击同步任务 tab', async () => {
+    // questionID + ai-agent 来源均满足：入口展示，点击同步
+    casualTaskState.questionID = 'q-1'
+    try {
+      await renderPanel(<AIRightPanel />)
+      fireEvent.click(screen.getByText('任务详情看板'))
+      expect(mockSyncCasualTaskTab).toHaveBeenCalledTimes(1)
+    } finally {
+      casualTaskState.questionID = ''
+      cleanup()
+    }
+
+    // 无 questionID：入口不渲染
+    mockSyncCasualTaskTab.mockClear()
+    await renderPanel(<AIRightPanel />)
+    expect(screen.queryByText('任务详情看板')).not.toBeInTheDocument()
+    cleanup()
+
+    // 非 ai-agent 来源（如 history）：入口不渲染
+    casualTaskState.questionID = 'q-2'
+    dispatcherState.setting = { Source: 'history' }
+    try {
+      await renderPanel(<AIRightPanel />)
+      expect(screen.queryByText('任务详情看板')).not.toBeInTheDocument()
+      expect(mockSyncCasualTaskTab).not.toHaveBeenCalled()
+    } finally {
+      dispatcherState.setting = { Source: 'ai' }
+      casualTaskState.questionID = ''
+    }
+  })
+
+  it('菜单点击：导出日志打开弹窗、查看日志打开日志窗口', async () => {
+    await renderPanel(<AIRightPanel />)
+    // 「导出日志/查看日志」位于「更多」分组内，先展开
+    fireEvent.click(screen.getByText('更多'))
+    fireEvent.click(screen.getByText('导出日志'))
+    expect(mockExportModalState.lastVisible).toBe(true)
+    fireEvent.click(screen.getByText('查看日志'))
+    expect(mockOpenLogWindow).toHaveBeenCalledTimes(1)
   })
 })

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
@@ -105,6 +105,7 @@ vi.mock('i18next-resources-to-backend', () => {
           sessionHistory: '会话历史',
           taskList: '任务列表',
           timeline: '时间线',
+          aiSettings: 'AI 设置',
           exportLog: '导出日志',
           viewLog: '查看日志',
           collapse: '折叠',
@@ -169,6 +170,16 @@ const renderPanel = async (ui: React.ReactElement) => {
 }
 
 describe('AIRightPanel', () => {
+  it.each([false, true])('AI 设置位于底部分组的时间线上方，随更多分组展开和收起（小屏：%s）', async (small) => {
+    render(<AIRightPanel small={small} />)
+    fireEvent.click(await screen.findByLabelText('更多'))
+    const settings = screen.getByLabelText('AI 设置')
+    expect(settings.nextElementSibling).toBe(screen.getByLabelText('时间线'))
+    expect(settings.parentElement?.firstElementChild).toBe(settings)
+    fireEvent.click(screen.getByLabelText('折叠'))
+    expect(screen.queryByLabelText('AI 设置')).not.toBeInTheDocument()
+  })
+
   it('点击会话历史打开 HistoryChat，关闭按钮位于原头部最右侧且没有固定按钮', async () => {
     await renderPanel(<AIRightPanel />)
     fireEvent.click(screen.getByLabelText('会话历史'))

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/type.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/type.ts
@@ -1,0 +1,55 @@
+import type React from 'react'
+
+/** 右侧面板菜单项标识 */
+export type AIRightPanelMenuKey =
+  | 'task-board'
+  | 'file-system'
+  | 'traffic'
+  | 'risk'
+  | 'session-history'
+  | 'task-list'
+  | 'timeline'
+  | 'export-log'
+  | 'view-log'
+
+/** 工具调用统计 */
+export interface AIRightPanelToolStats {
+  success?: number
+  failed?: number
+  total?: number
+}
+
+/** 漏洞各等级计数，展示顺序为 严重/高危/中危/低危/未知，等级色走主题 Status 语义色 */
+export interface AIRightPanelRiskCounts {
+  serious?: number
+  high?: number
+  medium?: number
+  low?: number
+  unknown?: number
+}
+
+export interface AIRightPanelProps {
+  /** AI 聊天外层容器 ref：用于计算扣除正常态面板槽位后的列表可用宽度 */
+  layoutRef?: React.RefObject<HTMLElement | null>
+  /** 是否使用小屏图标栏 */
+  small?: boolean
+  /** 当前选中的菜单项 */
+  activeKey?: AIRightPanelMenuKey
+  onMenuClick?: (key: AIRightPanelMenuKey) => void
+  /** 执行时长展示文案，如 "7s"；未传时展示占位 "—" */
+  executionDuration?: string
+  /** 工具调用统计，未传的数值展示占位 "—" */
+  toolCallStats?: AIRightPanelToolStats
+  /** 流量条目右侧计数角标，未传不展示 */
+  trafficCount?: number | string
+  /** 漏洞条目右侧各等级计数角标，未传不展示 */
+  riskCounts?: AIRightPanelRiskCounts
+  className?: string
+  style?: React.CSSProperties
+}
+
+/** AIReActChat 列表与输入框内容轨道的最大宽度（px） */
+export const AI_RIGHT_PANEL_INPUT_MAX_WIDTH = 784
+
+/** 正常态面板槽位：301px 面板 + 12px 右侧留白 + 12px 内容间距 */
+export const AI_RIGHT_PANEL_NORMAL_SLOT_WIDTH = 325

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/type.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/type.ts
@@ -19,13 +19,13 @@ export interface AIRightPanelToolStats {
   total?: number
 }
 
-/** 漏洞各等级计数，展示顺序为 严重/高危/中危/低危/未知，等级色走主题 Status 语义色 */
+/** 漏洞各等级计数，展示顺序为 严重/高危/中危/低危/信息，等级色走主题 Status 语义色 */
 export interface AIRightPanelRiskCounts {
   serious?: number
   high?: number
   medium?: number
   low?: number
-  unknown?: number
+  info?: number
 }
 
 export interface AIRightPanelProps {
@@ -33,19 +33,6 @@ export interface AIRightPanelProps {
   layoutRef?: React.RefObject<HTMLElement | null>
   /** 是否使用小屏图标栏 */
   small?: boolean
-  /** 当前选中的菜单项 */
-  activeKey?: AIRightPanelMenuKey
-  onMenuClick?: (key: AIRightPanelMenuKey) => void
-  /** 执行时长展示文案，如 "7s"；未传时展示占位 "—" */
-  executionDuration?: string
-  /** 工具调用统计，未传的数值展示占位 "—" */
-  toolCallStats?: AIRightPanelToolStats
-  /** 流量条目右侧计数角标，未传不展示 */
-  trafficCount?: number | string
-  /** 漏洞条目右侧各等级计数角标，未传不展示 */
-  riskCounts?: AIRightPanelRiskCounts
-  className?: string
-  style?: React.CSSProperties
 }
 
 /** AIReActChat 列表与输入框内容轨道的最大宽度（px） */

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/type.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/type.ts
@@ -12,6 +12,7 @@ export type AIRightPanelMenuKey =
   | 'session-history'
   | 'task-list'
   | 'timeline'
+  | 'ai-settings'
   | 'export-log'
   | 'view-log'
 

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/type.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/type.ts
@@ -1,5 +1,8 @@
 import type React from 'react'
 
+/** 右侧可打开的内容面板标识 */
+export type AIRightPanelPaneKey = 'task-list' | 'timeline' | 'session-history'
+
 /** 右侧面板菜单项标识 */
 export type AIRightPanelMenuKey =
   | 'task-board'

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/ChatMultiSessionController.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/ChatMultiSessionController.ts
@@ -1177,6 +1177,12 @@ export class ChatMultiSessionController {
       SyncType: AIInputEventSyncTypeEnum.SYNC_TYPE_PLAN_EXEC_TASKS,
     })
 
+    // 会话流建立且 pong 校验通过后，通知后端做一次会话快照同步
+    this.requestMessage(sessionId, {
+      IsSyncMessage: true,
+      SyncType: AIInputEventSyncTypeEnum.SYNC_TYPE_SESSION_SNAPSHOT_SYNC,
+    })
+
     // 获取最新记忆列表数据, 并注册轮询定时器
     this.requestMessage(sessionId, { IsSyncMessage: true, SyncType: AIInputEventSyncTypeEnum.SYNC_TYPE_MEMORY_CONTEXT })
     if (meta.memoryPollingTimer) clearInterval(meta.memoryPollingTimer)

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/ChatMultiSessionController.pageIndex.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/ChatMultiSessionController.pageIndex.test.ts
@@ -527,6 +527,36 @@ describe('ChatMultiSessionController start / send / history', () => {
     ctrl.handleSessionEnd('s-runtime-snapshot')
   })
 
+  it.each(['', '新会话问题'])('有效 pong 后同步一次会话快照（UserQuery=%j）', async (userQuery) => {
+    const sessionId = 's-session-snapshot'
+    const snapshotCalls = () =>
+      ipcRendererMock.invoke.mock.calls.filter(
+        ([channel, token, params]) =>
+          channel === 'send-ai-re-act' && token === sessionId && params?.SyncType === 'session_snapshot_sync',
+      )
+
+    try {
+      ctrl.handleStartSession(startParams(sessionId, 'page-1', userQuery))
+      await Promise.resolve()
+      expect(snapshotCalls()).toHaveLength(0)
+
+      ctrl.handleGrpcOutputEvent(sessionId, makeGrpcJsonRes('pong', {}, { SyncID: 'expired-ping' }))
+      await Promise.resolve()
+      expect(snapshotCalls()).toHaveLength(0)
+
+      const { meta } = ctrl.ensureSession(sessionId)
+      ctrl.handleGrpcOutputEvent(sessionId, makeGrpcJsonRes('pong', {}, { SyncID: meta.pingSyncID }))
+
+      await vi.waitFor(() => {
+        expect(snapshotCalls()).toEqual([
+          ['send-ai-re-act', sessionId, { IsSyncMessage: true, SyncType: 'session_snapshot_sync' }],
+        ])
+      })
+    } finally {
+      ctrl.handleSessionEnd(sessionId)
+    }
+  })
+
   it('A17: send without ready warns when active', () => {
     ctrl.setActiveShowSession('ghost')
     expect(() =>

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/aiTaskDetail.handlers.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/aiTaskDetail.handlers.test.ts
@@ -65,4 +65,43 @@ describe('aiTaskDetail handlers', () => {
     // 但 taskDetailsMap 仍应写入
     expect(req.rawData.taskDetailsMap.get(taskId)).toBeDefined()
   })
+
+  it('session_snapshot writes flow/risk aggregates and ignores stale revisions', () => {
+    const taskId = 'task-snapshot-1'
+    const snapshot = {
+      revision: 2,
+      execution: {
+        http_flow_count: 42,
+        risk_count: 22,
+        risk_level_count: { critical: 4, high: 6, warning: 1, low: 3, info: 5, other: 3, total: 22 },
+      },
+      background_processes: [],
+    }
+    const req = makeHandlerRequest({
+      res: makeGrpcJsonRes('structured', snapshot, {
+        NodeId: 'session_snapshot',
+        TaskId: taskId,
+        IsJson: true,
+        IsSystem: true,
+      }),
+    })
+
+    aiTaskDetailDataHandlers.session_snapshot(req)
+    const detail = req.rawData.taskDetailsMap.get(taskId)
+    expect(detail?.execution?.http_flow_count).toBe(42)
+    expect(detail?.execution?.risk_level_count).toEqual(snapshot.execution.risk_level_count)
+    expect(detail?.sessionSnapshotRevision).toBe(2)
+
+    const staleRequest = makeHandlerRequest({
+      rawData: req.rawData,
+      store: req.store,
+      res: makeGrpcJsonRes(
+        'structured',
+        { ...snapshot, revision: 1, execution: { ...snapshot.execution, http_flow_count: 7 } },
+        { NodeId: 'session_snapshot', TaskId: taskId, IsJson: true, IsSystem: true },
+      ),
+    })
+    aiTaskDetailDataHandlers.session_snapshot(staleRequest)
+    expect(req.rawData.taskDetailsMap.get(taskId)?.execution?.http_flow_count).toBe(42)
+  })
 })

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/aiTaskDetail.handlers.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/aiTaskDetail.handlers.test.ts
@@ -104,4 +104,19 @@ describe('aiTaskDetail handlers', () => {
     aiTaskDetailDataHandlers.session_snapshot(staleRequest)
     expect(req.rawData.taskDetailsMap.get(taskId)?.execution?.http_flow_count).toBe(42)
   })
+
+  it('session_snapshot ignores responses that are not structured', () => {
+    const taskId = 'task-snapshot-unstructured'
+    const req = makeHandlerRequest({
+      res: makeGrpcJsonRes(
+        'session_snapshot',
+        { revision: 1, execution: { http_flow_count: 99 } },
+        { NodeId: 'session_snapshot', TaskId: taskId, IsJson: true, IsSystem: true },
+      ),
+    })
+
+    aiTaskDetailDataHandlers.session_snapshot(req)
+
+    expect(req.rawData.taskDetailsMap.has(taskId)).toBe(false)
+  })
 })

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/useCurrentTaskData.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/useCurrentTaskData.test.tsx
@@ -1,0 +1,144 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MockTaskData {
+  uuid: string
+  taskId: string
+  execution?: {
+    task_name?: string
+  }
+}
+
+interface MockRawData {
+  taskDetailsMap: Map<string, MockTaskData>
+}
+
+const hoisted = vi.hoisted(() => ({
+  currentSessionId: { value: 'session-a' },
+  sessions: new Map<string, MockRawData>(),
+}))
+
+vi.mock('../useCurrentDataBySession', () => ({
+  useCurrentRawData: () => {
+    const rawData = hoisted.sessions.get(hoisted.currentSessionId.value)
+    if (!rawData) throw new Error(`未找到测试会话：${hoisted.currentSessionId.value}`)
+    return rawData
+  },
+}))
+
+vi.mock('../useCurrentSessionId', () => ({
+  default: () => hoisted.currentSessionId.value,
+}))
+
+import useCurrentTaskData from '../useCurrentTaskData/useCurrentTaskData'
+import useCurrentTaskExecution from '../useCurrentTaskData/useCurrentTaskExecution'
+
+const createRawData = (): MockRawData => ({ taskDetailsMap: new Map() })
+
+const createTaskData = (taskId: string, uuid: string, taskName: string): MockTaskData => ({
+  uuid,
+  taskId,
+  execution: { task_name: taskName },
+})
+
+const getSession = (sessionId: string): MockRawData => {
+  const rawData = hoisted.sessions.get(sessionId)
+  if (!rawData) throw new Error(`未找到测试会话：${sessionId}`)
+  return rawData
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  hoisted.currentSessionId.value = 'session-a'
+  hoisted.sessions.clear()
+  hoisted.sessions.set('session-a', createRawData())
+  hoisted.sessions.set('session-b', createRawData())
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('useCurrentTaskData', () => {
+  it('条目从不存在变成默认空 uuid 条目时会刷新', () => {
+    const session = getSession('session-a')
+    const { result } = renderHook(() => useCurrentTaskData('task-1', 1)?.taskId ?? 'missing')
+
+    expect(result.current).toBe('missing')
+
+    session.taskDetailsMap.set('task-1', createTaskData('task-1', '', 'task-1'))
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(result.current).toBe('task-1')
+  })
+
+  it('uuid 变化时会重新执行派生读取', () => {
+    const session = getSession('session-a')
+    const taskData = createTaskData('task-1', 'uuid-1', 'before')
+    session.taskDetailsMap.set('task-1', taskData)
+
+    const { result } = renderHook(() => useCurrentTaskData('task-1', 1)?.execution?.task_name ?? 'missing')
+    expect(result.current).toBe('before')
+
+    taskData.execution = { task_name: 'after' }
+    taskData.uuid = 'uuid-2'
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(result.current).toBe('after')
+  })
+
+  it('切换会话后会读取新会话的同名任务', () => {
+    getSession('session-a').taskDetailsMap.set('shared-task', createTaskData('shared-task', 'same-uuid', 'session-a'))
+    getSession('session-b').taskDetailsMap.set('shared-task', createTaskData('shared-task', 'same-uuid', 'session-b'))
+
+    const { result, rerender } = renderHook(
+      () => useCurrentTaskData('shared-task', 60)?.execution?.task_name ?? 'missing',
+    )
+    expect(result.current).toBe('session-a')
+
+    act(() => {
+      hoisted.currentSessionId.value = 'session-b'
+      rerender()
+    })
+
+    expect(result.current).toBe('session-b')
+  })
+})
+
+describe('useCurrentTaskExecution', () => {
+  it('切换 taskId 后会读取新任务的 execution，即使 uuid 相同', () => {
+    const session = getSession('session-a')
+    session.taskDetailsMap.set('task-a', createTaskData('task-a', '', 'task-a'))
+    session.taskDetailsMap.set('task-b', createTaskData('task-b', '', 'task-b'))
+
+    const { result, rerender } = renderHook(
+      ({ taskId }: { taskId: string }) => useCurrentTaskExecution(taskId, 60)?.task_name ?? 'missing',
+      { initialProps: { taskId: 'task-a' } },
+    )
+    expect(result.current).toBe('task-a')
+
+    rerender({ taskId: 'task-b' })
+
+    expect(result.current).toBe('task-b')
+  })
+
+  it('切换会话后会读取新会话的 execution，即使 uuid 相同', () => {
+    getSession('session-a').taskDetailsMap.set('shared-task', createTaskData('shared-task', 'same-uuid', 'session-a'))
+    getSession('session-b').taskDetailsMap.set('shared-task', createTaskData('shared-task', 'same-uuid', 'session-b'))
+
+    const { result, rerender } = renderHook(() => useCurrentTaskExecution('shared-task', 60)?.task_name ?? 'missing')
+    expect(result.current).toBe('session-a')
+
+    act(() => {
+      hoisted.currentSessionId.value = 'session-b'
+      rerender()
+    })
+
+    expect(result.current).toBe('session-b')
+  })
+})

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/aiRender.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/aiRender.ts
@@ -53,6 +53,8 @@ export type ForgesAndSkillsDynamicItem = Omit<AIAgentGrpcApi.PlanItemDetailsDyna
 export interface PlanItemDetailsData {
   /** UI定时刷新数据渲染，用于确定数据是否有更新 */
   uuid: string
+  /** 最近一次写入的 session_snapshot revision，用于丢弃乱序的旧快照 */
+  sessionSnapshotRevision: number
   /** 任务id */
   taskId: string
   todoList: TodoListCardData

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/defaultConstant.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/defaultConstant.ts
@@ -186,6 +186,7 @@ export const DefaultTodoListCardData: TodoListCardData = {
 
 export const DefaultPlanItemDetailsData: PlanItemDetailsData = {
   uuid: '',
+  sessionSnapshotRevision: 0,
   taskId: '',
   todoList: { ...DefaultTodoListCardData },
   tool: {
@@ -234,6 +235,15 @@ export const DefaultPlanItemDetailsData: PlanItemDetailsData = {
     execution_minutes: 0,
     http_flow_count: 0,
     risk_count: 0,
+    risk_level_count: {
+      critical: 0,
+      high: 0,
+      warning: 0,
+      low: 0,
+      info: 0,
+      other: 0,
+      total: 0,
+    },
     modified_file_count: 0,
   },
   backgroundProcesses: [],

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcApi.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcApi.ts
@@ -261,6 +261,8 @@ export enum AIInputEventSyncTypeEnum {
   SYNC_EXECUTE_DETACHED_PLAN = 'execute_detached_plan',
   /** 关闭浏览器进程 */
   SYNC_CLOSE_BROWSER = 'close_browser_sync',
+  /** 请求后端做一次会话快照同步 */
+  SYNC_TYPE_SESSION_SNAPSHOT_SYNC = 'session_snapshot_sync',
 }
 
 export interface AIInputEvent {
@@ -697,6 +699,15 @@ export declare namespace AIAgentGrpcApi {
       execution_minutes: number
       http_flow_count: number
       risk_count: number
+      risk_level_count: {
+        critical: number
+        high: number
+        warning: number
+        low: number
+        info: number
+        other: number
+        total: number
+      }
       modified_file_count: number
     }
     background_processes: {

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcStreamHandler/aiTaskDetail.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/grpcStreamHandler/aiTaskDetail.ts
@@ -158,20 +158,32 @@ const handleCurrentTaskTodoListUpdate: AIMessageHandler = (requestInfo) => {
 
 const handleSessionSnapshot: AIMessageHandler = (requestInfo) => {
   const { res, rawData } = requestInfo
-  if (res.NodeId !== 'session_snapshot') return
+  if (res.Type !== 'structured' || res.NodeId !== 'session_snapshot') return
   if (!res.TaskId) return
 
   const ipcContent = Uint8ArrayToString(res.Content) || ''
   const snapshot = (JSON.parse(ipcContent) as AIAgentGrpcApi.SessionSnapshot) || {}
   if (isEmpty(snapshot)) return
+
+  const oldData = rawData.taskDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
+  if (
+    typeof snapshot.revision === 'number' &&
+    snapshot.revision > 0 &&
+    snapshot.revision <= (oldData.sessionSnapshotRevision ?? 0)
+  ) {
+    return
+  }
+
   const applySnapshotFields = (target: PlanItemDetailsData) => {
     target.uuid = uuidv4()
     target.taskId = target.taskId || res.TaskId
     target.execution = snapshot.execution
     target.backgroundProcesses = snapshot.background_processes
+    if (typeof snapshot.revision === 'number' && snapshot.revision > 0) {
+      target.sessionSnapshotRevision = snapshot.revision
+    }
   }
 
-  const oldData = rawData.taskDetailsMap.get(res.TaskId) || cloneDeep(DefaultPlanItemDetailsData)
   applySnapshotFields(oldData)
   rawData.taskDetailsMap.set(res.TaskId, oldData)
 }

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/useCurrentTaskData/useCurrentTaskData.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/useCurrentTaskData/useCurrentTaskData.ts
@@ -1,0 +1,44 @@
+import { useCreation, useInterval, useMemoizedFn } from 'ahooks'
+import { useEffect, useState } from 'react'
+import type { PlanItemDetailsData } from '../aiRender'
+import { useCurrentRawData } from '../useCurrentDataBySession'
+import useCurrentSessionId from '../useCurrentSessionId'
+
+/**
+ * 根据外部传入的 taskId，从当前会话的 taskDetailsMap 读取任务详情。
+ * taskDetailsMap 由流事件原地更新（不触发渲染），靠轮询比对条目是否存在和 uuid 感知变化，
+ * 信号不变时引用稳定。轮询间隔单位为秒，默认 3 秒。
+ * 返回 map 里的活引用，需要不可变快照的调用方请自行 cloneDeep。
+ */
+const useCurrentTaskData = (taskId: string, intervalSeconds = 3): PlanItemDetailsData | undefined => {
+  const sessionId = useCurrentSessionId()
+  const rawData = useCurrentRawData()
+
+  // 条目存在性和 uuid 共同构成变更信号，避免“缺失条目”和“默认空 uuid 条目”无法区分
+  const [detailsSignal, setDetailsSignal] = useState('missing')
+
+  useEffect(() => {
+    onReset()
+    getData()
+  }, [sessionId, taskId])
+
+  useInterval(() => {
+    getData()
+  }, intervalSeconds * 1000)
+
+  const onReset = useMemoizedFn(() => {
+    setDetailsSignal('missing')
+  })
+  const getData = useMemoizedFn(() => {
+    const taskData = taskId ? rawData.taskDetailsMap.get(taskId) : undefined
+    const nextSignal = taskData ? `present:${taskData.uuid}` : 'missing'
+    setDetailsSignal((previous) => (previous === nextSignal ? previous : nextSignal))
+  })
+
+  return useCreation(() => {
+    if (!taskId) return undefined
+    return rawData.taskDetailsMap.get(taskId)
+  }, [sessionId, taskId, detailsSignal])
+}
+
+export default useCurrentTaskData

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/useCurrentTaskData/useCurrentTaskExecution.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/useCurrentTaskData/useCurrentTaskExecution.ts
@@ -1,0 +1,17 @@
+import { useCreation } from 'ahooks'
+import type { AIAgentGrpcApi } from '../grpcApi'
+import useCurrentSessionId from '../useCurrentSessionId'
+import useCurrentTaskData from './useCurrentTaskData'
+
+/** 根据外部传入的 taskId，读取当前会话任务详情中最近一次 session_snapshot 的 execution；会话、任务或 uuid 变化时重新取值。 */
+const useCurrentTaskExecution = (
+  taskId: string,
+  intervalSeconds = 3,
+): AIAgentGrpcApi.SessionSnapshot['execution'] | undefined => {
+  const sessionId = useCurrentSessionId()
+  const taskData = useCurrentTaskData(taskId, intervalSeconds)
+  // taskDetailsMap 中的条目会原地更新，使用会话、任务和 uuid 作为变更信号，避免继续持有旧 execution 引用。
+  return useCreation(() => taskData?.execution, [sessionId, taskId, taskData?.uuid])
+}
+
+export default useCurrentTaskExecution

--- a/app/renderer/src/main/src/pages/ai-re-act/styles/mixin.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/styles/mixin.scss
@@ -1,0 +1,8 @@
+/// AI ReAct 消息内容轨道：配合 ai-re-act 根容器上的 --ai-right-panel-content-* 变量使用。
+/// 变量沿 DOM 继承，但 width/transform 声明不继承，进入轨道的元素需各自 @include；
+/// 调用方必须位于 ai-re-act 容器内，否则变量无定义。
+@mixin ai-right-panel-content-track() {
+  width: var(--ai-right-panel-content-track-width);
+  margin: 0 auto;
+  transform: translateX(var(--ai-right-panel-content-shift));
+}

--- a/app/renderer/src/main/src/pages/risks/YakitRiskTable/YakitRiskTable.tsx
+++ b/app/renderer/src/main/src/pages/risks/YakitRiskTable/YakitRiskTable.tsx
@@ -116,6 +116,7 @@ import { getMainOperatorPageBodyContainer } from '@/utils/getMainOperatorPageBod
 import { type TFunction, useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { SafeMarkdown } from '@/pages/assetViewer/reportRenders/markdownRender'
 import type { HTTPFlow } from '@/components/HTTPFlowTable/HTTPFlowTable'
+import { getDiscoveryTimeColumnFixed } from './riskTableUtils'
 
 const { ipcRenderer } = window.require('electron')
 
@@ -604,6 +605,7 @@ export const YakitRiskTable: React.FC<YakitRiskTableProps> = React.memo((props) 
       {
         title: t('YakitRiskTable.discovery_time'),
         dataKey: 'CreatedAt',
+        fixed: getDiscoveryTimeColumnFixed(excludeColumnsKey),
         filterProps: {
           filterKey: 'CreatedAt',
           filtersType: 'dateTime',

--- a/app/renderer/src/main/src/pages/risks/YakitRiskTable/__test__/riskTableUtils.test.ts
+++ b/app/renderer/src/main/src/pages/risks/YakitRiskTable/__test__/riskTableUtils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { getDiscoveryTimeColumnFixed } from '../riskTableUtils'
+
+describe('getDiscoveryTimeColumnFixed', () => {
+  it('keeps the discovery time column fixed when the action column is shown', () => {
+    expect(getDiscoveryTimeColumnFixed([])).toBe('right')
+    expect(getDiscoveryTimeColumnFixed(['title'])).toBe('right')
+  })
+
+  it('removes the fixed position when the action column is excluded', () => {
+    expect(getDiscoveryTimeColumnFixed(['action'])).toBeUndefined()
+    expect(getDiscoveryTimeColumnFixed(['title', 'action'])).toBeUndefined()
+  })
+})

--- a/app/renderer/src/main/src/pages/risks/YakitRiskTable/riskTableUtils.ts
+++ b/app/renderer/src/main/src/pages/risks/YakitRiskTable/riskTableUtils.ts
@@ -1,5 +1,9 @@
 import type { Risk } from '../schema'
 
+export const getDiscoveryTimeColumnFixed = (excludeColumnsKey: string[]): 'right' | undefined => {
+  return excludeColumnsKey.includes('action') ? undefined : 'right'
+}
+
 export const isShowCodeScanDetail = (selectItem: Risk) => {
   const { ResultID, SyntaxFlowVariable, ProgramName } = selectItem
   if (ResultID && SyntaxFlowVariable && ProgramName) {

--- a/app/renderer/src/main/src/theme/componentsTheme/notification.scss
+++ b/app/renderer/src/main/src/theme/componentsTheme/notification.scss
@@ -6,7 +6,7 @@
   .yakit-notification-failed,
   .yakit-notification-error {
     background: var(--Colors-Use-Basic-Background);
-    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow, rgba(23, 23, 23, 0.08));
+    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow);
     padding: 0;
     border-radius: 4px;
 
@@ -36,7 +36,7 @@
 
   .yakit-notification-success {
     background: var(--Colors-Use-Basic-Background);
-    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow, rgba(23, 23, 23, 0.08));
+    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow);
     padding: 0;
     border-radius: 4px;
 
@@ -66,7 +66,7 @@
 
   .yakit-notification-warning {
     background: var(--Colors-Use-Basic-Background);
-    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow, rgba(23, 23, 23, 0.08));
+    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow);
     padding: 0;
     border-radius: 4px;
 
@@ -96,7 +96,7 @@
 
   .yakit-notification-info {
     background: var(--Colors-Use-Basic-Background);
-    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow, rgba(23, 23, 23, 0.08));
+    box-shadow: 0 2px 4px 0 var(--Colors-Use-Basic-Shadow);
     padding: 0;
     border-radius: 4px;
 

--- a/app/renderer/src/main/yarn.lock
+++ b/app/renderer/src/main/yarn.lock
@@ -2935,10 +2935,10 @@
   resolved "https://registry.npmjs.org/@yakit-libs/color/-/color-1.4.1.tgz#876a8314dab6bd9d83256eff6ab768a228c89f4a"
   integrity sha512-RK/Qm8IUaLrCBgfYn33411qpTu3JQ07EHc7jFYfeUxALDhwo4JqxST60CkOS2Mx0EY13mJLg6f/o7yPI+oe+Qw==
 
-"@yakit-libs/yakit-ui-icons@0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@yakit-libs/yakit-ui-icons/-/yakit-ui-icons-0.2.3.tgz#ece76295c7af368ba9da63801103f8485d534aa8"
-  integrity sha512-boSNuvUdgE/4FEG2ZBXFCul8CFKPd0PAmAq/6FRZIL35Dx6qiXfu2j/L0wgS7GG34nVnONbGd4oDSNIexoaFyQ==
+"@yakit-libs/yakit-ui-icons@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@yakit-libs/yakit-ui-icons/-/yakit-ui-icons-0.2.5.tgz#779a1ce91bef3521ee720f9be5ff109abfc82018"
+  integrity sha512-5zTl4rPkT3K2FsUJws7faIPbcUlOj4Bvu3Ci7lWhqXjInXT4U22Io/1KjccMcIza+Og1lC9aQBjekmk0JmB+LA==
   dependencies:
     "@yakit-libs/color" "1.4.1"
 

--- a/scripts/icon-migration/__test__/icon-color-compat.test.ts
+++ b/scripts/icon-migration/__test__/icon-color-compat.test.ts
@@ -94,8 +94,8 @@ if (!createIconFile) throw new Error('Missing yakit-ui-icons createIcon build ar
 const createIconSource = readFileSync(path.join(packageDist, createIconFile), 'utf8')
 
 describe('yakit-ui-icons color compatibility contract', () => {
-  it('tests the installed 0.2.3 package contract', () => {
-    expect(packageJson.version).toBe('0.2.3')
+  it('tests the installed 0.2.5 package contract', () => {
+    expect(packageJson.version).toBe('0.2.5')
   })
 
   it('keeps the package default color in a zero-specificity :where rule', () => {


### PR DESCRIPTION
## 改动类型

- [x] 新功能（新页面 / 新选项 / 新能力）
- [x] 样式 / UI 调整（无逻辑变化）

## 🔗 关联 Issue / PR

None

## 💡 背景与方案

AI ReAct 自由对话缺少任务执行数据与常用功能入口的聚合视图：任务详情、流量、漏洞、会话历史等入口分散在侧栏或聊天头部，执行时长/工具调用统计无直观展示。本 PR 在自由对话右侧新增功能面板（AIRightPanel），基于 session_snapshot 展示执行数据卡片并聚合功能入口，正常态宽面板、空间不足时自动折叠为图标窄栏，消息列表与输入框统一沿内容轨道避让对齐；同时将聊天与时间线列表的首屏渲染 loading 抽取为公共 hook，修复模型选择器浮层定位问题，并升级 yakit-ui-icons 至 0.2.5。

## 改动内容

### AI ReAct 右侧功能面板
- 新增 `AIRightPanel` / `AIRightPanelPane`：数据卡片（执行时长、工具调用成功/失败/总尝试、流量数、各等级漏洞计数）+ 主菜单六个入口 + 「更多」分组（时间线/导出日志/查看日志）；任务列表/时间线/会话历史以浮层面板打开，小屏态支持悬停打开
- 小屏自适应：监听聊天容器宽度，正常面板会使列表可用宽度不足时自动切换 41px 图标栏（含漏洞总数角标）；消息列表、输入框、TodoList、置底按钮、review 卡片统一接入 `ai-right-panel-content-track` 内容轨道 mixin
- 数据接入：`grpcApi` 新增 `risk_level_count` 与 `session_snapshot_sync` 同步类型；`ChatMultiSessionController` 会话流建立后请求快照同步；`aiTaskDetail` handler 新增 revision 乱序丢弃；新增 `useCurrentTaskData` / `useCurrentTaskExecution` 轮询 hooks（AITaskExecutionDetails 同步改用）

### 侧栏与聊天卡片精简
- `AIAgentSideList` 移除「设置」「AI 模型」侧栏 tab 及对应枚举；`AIHorizontalScrollCard` 精简为标题 + 上下文统计 + 新建会话（任务详情/更多菜单迁移至右侧面板）
- `TaskListPane` 无任务数据时展示空状态；`HistoryChat` 新增 `hidePinButton`；`AIChatWorkspace` 工作区 tab 手动切换放开空数据限制，由内容区展示空状态

### 首屏渲染 loading 公共 hook
- 新增 `useVirtuosoInitialRender` / `useVirtuosoListReady`：Virtuoso 首次定位完成前展示 loading，就绪信号经 context 传递；`AIReActChatContents`、`TimelineCard` 接入，并按会话 key 重挂载列表以正确处理会话切换

### AI 模型选择器修复
- `AIModelSelectList` 改为通过 `dropdownRef` 实时测量下拉区域定位编辑浮层（替代打开后 200ms 延迟快照），触发器宽度变化时同步收起一级下拉框与二级编辑浮层，高度变化保留状态

### 风险表与其他
- `YakitRiskTable` 发现时间列默认固定在右侧（`fixed: 'right'`）；当 `excludeColumnsKey` 包含 `action`、隐藏操作列时取消固定，由 `getDiscoveryTimeColumnFixed` 统一判断
- `FuncDomain` 功能域风险按钮图标改用 `BugOutlined`，lazy 导入归拢；`YakitCollapse` 箭头样式选择器适配 antd 新 DOM 结构（`destroyOnHidden`）；通知组件阴影去除硬编码回退色
- 升级 `@yakit-libs/yakit-ui-icons` 至 0.2.5（主渲染端与 Link 端，lock 同步）

## 影响范围

- AI Agent / AI ReAct 自由对话区：右侧新增功能面板，消息列表与输入框在面板存在时沿内容轨道避让对齐；小窗口下自动切换图标窄栏
- AI Agent 侧边栏：移除「设置」「AI 模型」两个 tab（模型管理仍可从选择器进入）；聊天头部移除任务详情/更多菜单（能力迁移至右侧面板）
- 聊天与时间线列表首屏增加 loading 占位；工作区流量/漏洞 tab 可无数据手动打开（内容区展示空状态）
- 全局：功能域风险按钮图标更换；通知阴影颜色跟随主题变量；无配置与接口行为变化

## 代码评审结论

**结论：可以合并**（增量复评于 29e6f864c：tsc 通过；AIRightPanel 33 用例与 icon-migration 83 用例全通过；PR 全部 12 项 CI 检查通过；此前全部问题已处置——2 项已修复、1 项按产品需求保持现状、1 项经评估不算问题、1 项复核为误报）

## 建议合并前修复的问题

- [x] ~~`app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx:66` 「AI 设置」菜单项实现缺失，`AIRightPanel.test.tsx:173` 两个用例失败~~（✅ 已修复：85573a8c——入口改为注释保留（暂时下线），测试改为断言不显示并校验「更多」分组顺序）
- [ ] `app/renderer/src/main/src/components/HistroryAIReActChat.tsx:212` 未传 `showAIRightPanel`（按产品需求保持现状，不修复：历史弹窗场景不展示右侧面板为预期行为）
- [ ] `app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx:229` `aria-label={`漏洞总数 ${smallBadge}`}` 硬编码中文（经评估不算问题，不修复）
- [x] ~~`app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx:274` 注释声明监听元素与实现不符~~（✅ 复核为误报：`layoutRef` 实际挂载在 `.ai-re-act-chat` 上，见 `AIReActChat.tsx:306-307`，原注释正确，无需修改）
- [x] ~~`scripts/icon-migration/__test__/icon-color-compat.test.ts:97` 版本哨兵用例仍锁定 0.2.3，与依赖升级 0.2.5 不一致导致 ci-icon-migration 失败~~（✅ 已修复：29e6f864——版本哨兵同步为 0.2.5，CI 已变绿）

## 合并方式

选择Create a merge commit合并



