### PR TITLE
style: 项目管理「最近打开」卡片项目名过长时单行省略

### DIFF
--- a/app/renderer/src/main/src/pages/softwareSettings/ProjectManage.module.scss
+++ b/app/renderer/src/main/src/pages/softwareSettings/ProjectManage.module.scss
@@ -62,10 +62,17 @@
             display: flex;
             align-items: center;
             gap: 8px;
+            min-width: 0;
+            .title-wrapper {
+              min-width: 0;
+            }
             .title-style {
               font-size: 14px;
               line-height: 20px;
               color: var(--Colors-Use-Neutral-Text-1-Title);
+              overflow: hidden;
+              white-space: nowrap;
+              text-overflow: ellipsis;
             }
             .subtitle-style {
               margin-top: 4px;

--- a/app/renderer/src/main/src/pages/softwareSettings/ProjectManage.tsx
+++ b/app/renderer/src/main/src/pages/softwareSettings/ProjectManage.tsx
@@ -1155,8 +1155,10 @@ const ProjectManage: React.FC<ProjectManageProp> = memo((props) => {
             <div className={styles['open-recent-body']} onClick={() => operateFunc('setCurrent', latestProject)}>
               <div className={styles['body-title']}>
                 <DocumentTextSvgIcon />
-                <div>
-                  <div className={styles['title-style']}>{latestProject?.ProjectName || '[default]'}</div>
+                <div className={styles['title-wrapper']}>
+                  <div className={styles['title-style']} title={latestProject?.ProjectName || '[default]'}>
+                    {latestProject?.ProjectName || '[default]'}
+                  </div>
                   <div className={styles['subtitle-style']}>{`${t('ProjectManage.recentOperation')}：${
                     latestProject ? formatTimestamp(latestProject?.UpdateAt) : '- -'
                   }`}</div>


### PR DESCRIPTION
## 改动类型

- [ ] 新功能（新页面 / 新选项 / 新能力）
- [ ] Bug 修复（有用户可见行为修正）
- [ ] 文档改动
- [x] 样式 / UI 调整（无逻辑变化）
- [ ] 性能优化
- [ ] 重构（不改变外部行为）
- [ ] 测试改动
- [ ] 构建 / 依赖 / 打包配置
- [ ] CI 流程改动
- [ ] 杂项（脚本 / 工程化 / 版本号）
- [ ] 其他

## 🔗 关联 Issue / PR

None

## 💡 背景与方案

项目管理页「最近打开」卡片为固定宽度（326px），项目名过长时会把卡片撑开溢出而非截断，原因是文本容器作为 flex 子项默认 `min-width: auto` 不可收缩。

本次在 `.body-title` 与新增的 `.title-wrapper` 两层补 `min-width: 0` 建立完整的 flex 收缩链，并给卡片作用域内的 `.title-style` 加 `overflow: hidden; white-space: nowrap; text-overflow: ellipsis` 实现单行省略；同时补原生 `title` 属性，截断后悬浮可查看完整项目名（与表格中项目名列的既有做法一致）。同名 `.title-style` 在页头与空状态处因嵌套作用域隔离不受影响。

## 影响范围

仅项目管理页「最近打开」卡片：长项目名显示为单行省略号，悬浮显示全名；其余区域与逻辑无变化。

## 代码评审结论

**结论：可以合并**（正确 5 项 / 问题 0 项（P0 0 项 / P1 0 项）/ 警告 1 项）

## 合并方式

- [ ] Create a merge commit（保留完整提交历史）
- [x] Squash and merge（压缩为一条提交）
- [ ] Rebase and merge（线性历史）
