### PR TITLE
fix: AI 配置加载前禁写与保存回拉防覆盖，右键插件测试按插件名定位开关

### DIFF
--- a/app/renderer/src/main/src/pages/ai-agent/AIAgent.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/AIAgent.tsx
@@ -105,9 +105,9 @@ export const AIAgent: React.FC<AIAgentProps> = (props) => {
    * 读取全局配置 setting
    */
   const initToCacheData = useMemoizedFn(async () => {
-    const next = await loadAIAgentChatSetting()
-    if (!next) return
-    setSetting(applyAIAgentChatSettingSessionDefaults(next))
+    const result = await loadAIAgentChatSetting()
+    if (result.status !== 'success') return
+    setSetting(applyAIAgentChatSettingSessionDefaults(result.setting))
   })
 
   useEffect(() => {

--- a/app/renderer/src/main/src/pages/ai-agent/utils/__test__/aiAgentChatSettingCache.test.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/utils/__test__/aiAgentChatSettingCache.test.ts
@@ -105,19 +105,24 @@ describe('loadAIAgentChatSetting', () => {
     getRemoteValueMock.mockReset()
   })
 
-  it('远端无缓存时返回 undefined', async () => {
+  it('远端无缓存时返回 empty', async () => {
     getRemoteValueMock.mockResolvedValue('')
-    await expect(loadAIAgentChatSetting()).resolves.toBeUndefined()
+    await expect(loadAIAgentChatSetting()).resolves.toEqual({ status: 'empty' })
   })
 
-  it('非法 JSON 返回 undefined，不抛错', async () => {
+  it('非法 JSON 返回 error，不抛错', async () => {
     getRemoteValueMock.mockResolvedValue('{')
-    await expect(loadAIAgentChatSetting()).resolves.toBeUndefined()
+    await expect(loadAIAgentChatSetting()).resolves.toEqual({ status: 'error' })
   })
 
-  it('非对象 JSON 返回 undefined', async () => {
+  it('非对象 JSON 返回 error', async () => {
     getRemoteValueMock.mockResolvedValue('"not-object"')
-    await expect(loadAIAgentChatSetting()).resolves.toBeUndefined()
+    await expect(loadAIAgentChatSetting()).resolves.toEqual({ status: 'error' })
+  })
+
+  it('读取异常返回 error', async () => {
+    getRemoteValueMock.mockRejectedValue(new Error('kv-fail'))
+    await expect(loadAIAgentChatSetting()).resolves.toEqual({ status: 'error' })
   })
 
   it('合法缓存走合并规则后再返回', async () => {
@@ -126,10 +131,12 @@ describe('loadAIAgentChatSetting', () => {
     )
     const loaded = await loadAIAgentChatSetting()
     expect(getRemoteValueMock).toHaveBeenCalledWith(RemoteAIAgentGV.AIAgentChatSetting)
-    expect(loaded?.ReviewPolicy).toBe('ai')
-    expect(loaded?.EnablePlan).toBe(true)
-    expect(loaded?.DisableMemoryTriage).toBe(true)
-    expect(loaded?.Source).toBe(AIAgentSettingDefault.Source)
+    expect(loaded.status).toBe('success')
+    if (loaded.status !== 'success') return
+    expect(loaded.setting.ReviewPolicy).toBe('ai')
+    expect(loaded.setting.EnablePlan).toBe(true)
+    expect(loaded.setting.DisableMemoryTriage).toBe(true)
+    expect(loaded.setting.Source).toBe(AIAgentSettingDefault.Source)
   })
 })
 

--- a/app/renderer/src/main/src/pages/ai-agent/utils/aiAgentChatSettingCache.ts
+++ b/app/renderer/src/main/src/pages/ai-agent/utils/aiAgentChatSettingCache.ts
@@ -64,15 +64,20 @@ export const applyAIAgentChatSettingSessionDefaults = (setting: AIAgentSetting):
   }
 }
 
-export const loadAIAgentChatSetting = async (): Promise<AIAgentSetting | undefined> => {
+export type LoadAIAgentChatSettingResult =
+  | { status: 'success'; setting: AIAgentSetting }
+  | { status: 'empty' }
+  | { status: 'error' }
+
+export const loadAIAgentChatSetting = async (): Promise<LoadAIAgentChatSettingResult> => {
   try {
     const res = await getRemoteValue(RemoteAIAgentGV.AIAgentChatSetting)
-    if (!res) return undefined
-    const cache = JSON.parse(res) as AIAgentSetting
-    if (typeof cache !== 'object' || !cache) return undefined
-    return mergeAIAgentChatSettingCache(cache)
-  } catch (_) {
-    return undefined
+    if (!res) return { status: 'empty' }
+    const cache = JSON.parse(res) as unknown
+    if (typeof cache !== 'object' || !cache) return { status: 'error' }
+    return { status: 'success', setting: mergeAIAgentChatSettingCache(cache as AIAgentSetting) }
+  } catch {
+    return { status: 'error' }
   }
 }
 

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/useAIGlobalConfig.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/useAIGlobalConfig.test.ts
@@ -107,4 +107,47 @@ describe('useAIGlobalConfig', () => {
     expect(setMock).toHaveBeenCalledTimes(2)
     expect(setMock.mock.calls[1][0]).toMatchObject({ DisableFallback: true })
   })
+
+  it('先前保存失败的回拉不会覆盖后续已成功的保存', async () => {
+    let rejectFirst: (err: Error) => void = () => undefined
+    const firstWrite = new Promise<null>((_, reject) => {
+      rejectFirst = reject
+    })
+    let resolveGet: (value: typeof defaultAIGlobalConfig) => void = () => undefined
+    const delayedGet = new Promise<typeof defaultAIGlobalConfig>((resolve) => {
+      resolveGet = resolve
+    })
+    setMock.mockImplementationOnce(() => firstWrite).mockResolvedValue(null)
+    getMock.mockImplementation(() => delayedGet)
+
+    const { result } = renderHook(() => useAIGlobalConfig())
+    await act(async () => {
+      void result.current[1].setAIGlobalConfig({ DisableFallback: true }).catch(() => undefined)
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(setMock).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      rejectFirst(new Error('save-fail'))
+    })
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalled()
+    })
+
+    await act(async () => {
+      await result.current[1].setAIGlobalConfig({ RoutingPolicy: AIModelPolicyEnum.PolicyPerformance })
+    })
+
+    await act(async () => {
+      resolveGet({ ...defaultAIGlobalConfig, DisableFallback: false })
+      await delayedGet
+    })
+
+    expect(useAIGlobalConfigStore.getState().aiGlobalConfig).toMatchObject({
+      DisableFallback: true,
+      RoutingPolicy: AIModelPolicyEnum.PolicyPerformance,
+    })
+  })
 })

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/useAIGlobalConfig.test.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/__test__/useAIGlobalConfig.test.ts
@@ -150,4 +150,34 @@ describe('useAIGlobalConfig', () => {
       RoutingPolicy: AIModelPolicyEnum.PolicyPerformance,
     })
   })
+
+  it('普通刷新的迟到回包不会覆盖后续已成功的保存', async () => {
+    let resolveGet: (value: typeof defaultAIGlobalConfig) => void = () => undefined
+    const delayedGet = new Promise<typeof defaultAIGlobalConfig>((resolve) => {
+      resolveGet = resolve
+    })
+    getMock.mockImplementationOnce(() => delayedGet).mockResolvedValue({ ...defaultAIGlobalConfig })
+
+    const { result } = renderHook(() => useAIGlobalConfig())
+    await act(async () => {
+      result.current[1].onRefresh(false)
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(getMock).toHaveBeenCalled()
+    })
+
+    await act(async () => {
+      await result.current[1].setAIGlobalConfig({ DisableFallback: true })
+    })
+
+    await act(async () => {
+      resolveGet({ ...defaultAIGlobalConfig, DisableFallback: false })
+      await delayedGet
+    })
+
+    expect(useAIGlobalConfigStore.getState().aiGlobalConfig).toMatchObject({
+      DisableFallback: true,
+    })
+  })
 })

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/useAIGlobalConfig.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/useAIGlobalConfig.ts
@@ -81,10 +81,11 @@ function useAIGlobalConfig(params) {
   })
 
   const getAIGlobalConfig = useMemoizedFn((isShowLoading?: boolean) => {
+    const epoch = saveEpoch
     const showLoading = isShowLoading !== false
     showLoading && setQueryLoading(true)
     grpcGetAIGlobalConfig()
-      .then((res) => applyFetchedConfig(res))
+      .then((res) => applyFetchedConfig(res, epoch))
       .finally(() => {
         showLoading &&
           setTimeout(() => {

--- a/app/renderer/src/main/src/pages/ai-re-act/hooks/useAIGlobalConfig.ts
+++ b/app/renderer/src/main/src/pages/ai-re-act/hooks/useAIGlobalConfig.ts
@@ -22,6 +22,7 @@ const AI_MODEL_CONFIG_KEYS = [
 ] as const
 
 let saveQueue: Promise<unknown> = Promise.resolve()
+let saveEpoch = 0
 
 interface UseAIGlobalConfigData {
   aiGlobalConfig: AIGlobalConfig
@@ -70,17 +71,20 @@ function useAIGlobalConfig(params) {
     isInit && getAIGlobalConfig(isShowLoading !== false)
   }, [isInit])
   /** 刷新，会设置全局变量中的值和ref */
+  const applyFetchedConfig = useMemoizedFn((res: AIGlobalConfig, applyEpoch?: number) => {
+    if (applyEpoch !== undefined && applyEpoch !== saveEpoch) return
+    setConfig(res)
+    aiGlobalConfigRef.current = res
+    setTotal(
+      (res.IntelligentModels?.length || 0) + (res.LightweightModels?.length || 0) + (res.VisionModels?.length || 0),
+    )
+  })
+
   const getAIGlobalConfig = useMemoizedFn((isShowLoading?: boolean) => {
     const showLoading = isShowLoading !== false
     showLoading && setQueryLoading(true)
     grpcGetAIGlobalConfig()
-      .then((res) => {
-        setConfig(res)
-        aiGlobalConfigRef.current = res
-        const total =
-          (res.IntelligentModels?.length || 0) + (res.LightweightModels?.length || 0) + (res.VisionModels?.length || 0)
-        setTotal(total)
-      })
+      .then((res) => applyFetchedConfig(res))
       .finally(() => {
         showLoading &&
           setTimeout(() => {
@@ -90,6 +94,7 @@ function useAIGlobalConfig(params) {
   })
 
   const setAIGlobalConfig = useMemoizedFn(async (data: Partial<AIGlobalConfig>): Promise<void> => {
+    const epoch = ++saveEpoch
     const next: AIGlobalConfig = {
       ...useAIGlobalConfigStore.getState().aiGlobalConfig,
       ...data,
@@ -106,7 +111,11 @@ function useAIGlobalConfig(params) {
     try {
       await task
     } catch (err) {
-      getAIGlobalConfig(false)
+      if (epoch === saveEpoch) {
+        grpcGetAIGlobalConfig()
+          .then((res) => applyFetchedConfig(res, epoch))
+          .catch(() => undefined)
+      }
       throw err
     } finally {
       setTimeout(() => {

--- a/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/AIConfigSettings.module.scss
+++ b/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/AIConfigSettings.module.scss
@@ -8,6 +8,10 @@
   min-width: 0;
 }
 
+.ai-config-pending {
+  pointer-events: none;
+}
+
 .page-head {
   display: flex;
   align-items: center;

--- a/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/AIConfigSettings.tsx
+++ b/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/AIConfigSettings.tsx
@@ -87,6 +87,7 @@ export const AIConfigSettings: React.FC = () => {
   const lastPayloadRef = useRef(serializeAIAgentChatSetting(AIAgentSettingDefault))
   const settingRef = useRef(setting)
   const readyRef = useRef(false)
+  const hasBroadcastRef = useRef(false)
   settingRef.current = setting
 
   const apply = useMemoizedFn((patch: Partial<AIAgentSetting>) => {
@@ -107,16 +108,17 @@ export const AIConfigSettings: React.FC = () => {
   useEffect(() => {
     let cancelled = false
     loadAIAgentChatSetting()
-      .then((next) => {
-        if (cancelled || !next) return
-        lastPayloadRef.current = serializeAIAgentChatSetting(next)
-        setSetting(next)
-      })
-      .finally(() => {
+      .then((result) => {
         if (cancelled) return
+        if (result.status === 'error') return
+        if (!hasBroadcastRef.current && result.status === 'success') {
+          lastPayloadRef.current = serializeAIAgentChatSetting(result.setting)
+          setSetting(result.setting)
+        }
         readyRef.current = true
         setReady(true)
       })
+      .catch(() => {})
     return () => {
       cancelled = true
     }
@@ -129,6 +131,7 @@ export const AIConfigSettings: React.FC = () => {
         const cache = JSON.parse(payload) as AIAgentSetting
         if (typeof cache !== 'object' || !cache) return
         lastPayloadRef.current = payload
+        hasBroadcastRef.current = true
         setSetting((old) => applyAIAgentChatSettingBroadcast(old, cache))
       } catch (_) {}
     }

--- a/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/AIConfigSettings.tsx
+++ b/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/AIConfigSettings.tsx
@@ -107,6 +107,18 @@ export const AIConfigSettings: React.FC = () => {
 
   useEffect(() => {
     let cancelled = false
+    const onChange = (payload?: string) => {
+      if (!payload) return
+      try {
+        const cache = JSON.parse(payload) as AIAgentSetting
+        if (typeof cache !== 'object' || !cache) return
+        hasBroadcastRef.current = true
+        if (payload === lastPayloadRef.current) return
+        lastPayloadRef.current = payload
+        setSetting((old) => applyAIAgentChatSettingBroadcast(old, cache))
+      } catch (_) {}
+    }
+    emiter.on('onAIAgentChatSettingChange', onChange)
     loadAIAgentChatSetting()
       .then((result) => {
         if (cancelled) return
@@ -121,22 +133,6 @@ export const AIConfigSettings: React.FC = () => {
       .catch(() => {})
     return () => {
       cancelled = true
-    }
-  }, [])
-
-  useEffect(() => {
-    const onChange = (payload?: string) => {
-      if (!payload || payload === lastPayloadRef.current) return
-      try {
-        const cache = JSON.parse(payload) as AIAgentSetting
-        if (typeof cache !== 'object' || !cache) return
-        lastPayloadRef.current = payload
-        hasBroadcastRef.current = true
-        setSetting((old) => applyAIAgentChatSettingBroadcast(old, cache))
-      } catch (_) {}
-    }
-    emiter.on('onAIAgentChatSettingChange', onChange)
-    return () => {
       emiter.off('onAIAgentChatSettingChange', onChange)
     }
   }, [])

--- a/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/AIConfigSettings.tsx
+++ b/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/AIConfigSettings.tsx
@@ -83,11 +83,14 @@ const digitsOnly = (raw: string) => {
 export const AIConfigSettings: React.FC = () => {
   const { t } = useI18nNamespaces(['setting', 'aiAgent', 'yakitUi'])
   const [setting, setSetting] = useState<AIAgentSetting>(() => cloneDeep(AIAgentSettingDefault))
+  const [ready, setReady] = useState(false)
   const lastPayloadRef = useRef(serializeAIAgentChatSetting(AIAgentSettingDefault))
   const settingRef = useRef(setting)
+  const readyRef = useRef(false)
   settingRef.current = setting
 
   const apply = useMemoizedFn((patch: Partial<AIAgentSetting>) => {
+    if (!readyRef.current) return
     const next = { ...settingRef.current, ...patch }
     setSetting(next)
     lastPayloadRef.current = serializeAIAgentChatSetting(next)
@@ -95,17 +98,28 @@ export const AIConfigSettings: React.FC = () => {
   })
 
   const applyAll = useMemoizedFn((next: AIAgentSetting) => {
+    if (!readyRef.current) return
     setSetting(next)
     lastPayloadRef.current = serializeAIAgentChatSetting(next)
     persistAIAgentChatSetting(next)
   })
 
   useEffect(() => {
-    loadAIAgentChatSetting().then((next) => {
-      if (!next) return
-      lastPayloadRef.current = serializeAIAgentChatSetting(next)
-      setSetting(next)
-    })
+    let cancelled = false
+    loadAIAgentChatSetting()
+      .then((next) => {
+        if (cancelled || !next) return
+        lastPayloadRef.current = serializeAIAgentChatSetting(next)
+        setSetting(next)
+      })
+      .finally(() => {
+        if (cancelled) return
+        readyRef.current = true
+        setReady(true)
+      })
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   useEffect(() => {
@@ -127,7 +141,11 @@ export const AIConfigSettings: React.FC = () => {
   const reviewDesc = AIReviewRuleOptions.find((item) => item.value === setting.ReviewPolicy)?.describe
 
   return (
-    <div className={styles['ai-config']}>
+    <div
+      className={classNames(styles['ai-config'], { [styles['ai-config-pending']]: !ready })}
+      data-ai-config-ready={ready ? '1' : '0'}
+      aria-busy={!ready}
+    >
       <div className={styles['page-head']}>
         <div className={styles['page-title']}>{t('SettingsPage.item.ai-config')}</div>
         <YakitButton

--- a/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/__test__/AIConfigSettings.test.tsx
+++ b/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/__test__/AIConfigSettings.test.tsx
@@ -211,6 +211,34 @@ describe('AIConfigSettings', () => {
     expect(saved.ReviewPolicy).toBe('yolo')
   })
 
+  it('迟到的读取不会覆盖等于初始默认值的广播', async () => {
+    let resolveLoad: (value: LoadAIAgentChatSettingResult) => void = () => undefined
+    vi.mocked(loadAIAgentChatSetting).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveLoad = resolve
+        }),
+    )
+    render(<AIConfigSettings />)
+    act(() => {
+      emiter.emit('onAIAgentChatSettingChange', serializeAIAgentChatSetting(AIAgentSettingDefault))
+    })
+    expect(document.querySelector('[data-ai-config-ready="1"]')).toBeFalsy()
+    await act(async () => {
+      resolveLoad(
+        successLoad({
+          DisableMemoryTriage: true,
+          ReviewPolicy: 'yolo',
+        }),
+      )
+    })
+    await waitReady()
+    fireEvent.click(document.querySelector('button.ant-switch') as HTMLElement)
+    const saved = vi.mocked(persistAIAgentChatSetting).mock.calls[0][0]
+    expect(saved.DisableMemoryTriage).toBe(AIAgentSettingDefault.DisableMemoryTriage)
+    expect(saved.ReviewPolicy).toBe(AIAgentSettingDefault.ReviewPolicy)
+  })
+
   it('读取失败后即使收到广播也不解锁写盘', async () => {
     vi.mocked(loadAIAgentChatSetting).mockResolvedValueOnce({ status: 'error' })
     render(<AIConfigSettings />)

--- a/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/__test__/AIConfigSettings.test.tsx
+++ b/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/__test__/AIConfigSettings.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { persistAIAgentChatSetting, loadAIAgentChatSetting } from '@/pages/ai-agent/utils/aiAgentChatSettingCache'
@@ -20,6 +20,12 @@ vi.mock('@/pages/ai-agent/utils/aiAgentChatSettingCache', async (importOriginal)
   }
 })
 
+const waitReady = async () => {
+  await waitFor(() => {
+    expect(document.querySelector('[data-ai-config-ready="1"]')).toBeTruthy()
+  })
+}
+
 describe('AIConfigSettings', () => {
   beforeEach(() => {
     vi.mocked(persistAIAgentChatSetting).mockClear()
@@ -30,9 +36,7 @@ describe('AIConfigSettings', () => {
     render(<AIConfigSettings />)
     expect(document.querySelector('[data-settings-section="permissions"]')).toBeTruthy()
     expect(document.querySelector('[data-settings-section="planning"]')).toBeTruthy()
-    await waitFor(() => {
-      expect(screen.getByText('SettingsPage.item.ai-config')).toBeInTheDocument()
-    })
+    await waitReady()
     await user.click(screen.getByText('YakitButton.reset'))
     await waitFor(() => {
       expect(persistAIAgentChatSetting).toHaveBeenCalled()
@@ -41,9 +45,7 @@ describe('AIConfigSettings', () => {
 
   it('没有改动时卸载不会保存', async () => {
     const { unmount } = render(<AIConfigSettings />)
-    await waitFor(() => {
-      expect(screen.getByText('SettingsPage.item.ai-config')).toBeInTheDocument()
-    })
+    await waitReady()
     vi.mocked(persistAIAgentChatSetting).mockClear()
     unmount()
     expect(persistAIAgentChatSetting).not.toHaveBeenCalled()
@@ -51,15 +53,41 @@ describe('AIConfigSettings', () => {
 
   it('修改后马上保存，离开页面也不会丢', async () => {
     const { unmount } = render(<AIConfigSettings />)
-    await waitFor(() => {
-      expect(screen.getByText('SettingsPage.item.ai-config')).toBeInTheDocument()
-    })
+    await waitReady()
     vi.mocked(persistAIAgentChatSetting).mockClear()
     const switchBtn = document.querySelector('button.ant-switch') as HTMLElement
     expect(switchBtn).toBeTruthy()
     fireEvent.click(switchBtn)
     expect(persistAIAgentChatSetting).toHaveBeenCalled()
     unmount()
+  })
+
+  it('远端未返回前改开关不会把默认配置写盘，过期读取也不会覆盖后续修改', async () => {
+    let resolveLoad: (value: typeof AIAgentSettingDefault) => void = () => undefined
+    vi.mocked(loadAIAgentChatSetting).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveLoad = resolve
+        }),
+    )
+    render(<AIConfigSettings />)
+    const switchBtn = document.querySelector('button.ant-switch') as HTMLButtonElement
+    expect(switchBtn).toBeTruthy()
+    fireEvent.click(switchBtn)
+    expect(persistAIAgentChatSetting).not.toHaveBeenCalled()
+    await act(async () => {
+      resolveLoad({
+        ...AIAgentSettingDefault,
+        DisallowRequireForUserPrompt: false,
+        DisableMemoryTriage: true,
+      })
+    })
+    await waitReady()
+    expect(persistAIAgentChatSetting).not.toHaveBeenCalled()
+    fireEvent.click(document.querySelector('button.ant-switch') as HTMLElement)
+    expect(persistAIAgentChatSetting).toHaveBeenCalled()
+    const saved = vi.mocked(persistAIAgentChatSetting).mock.calls[0][0]
+    expect(saved.DisableMemoryTriage).toBe(true)
   })
 
   it('加载后改其他项，不会把记忆处理开关写回默认值', async () => {
@@ -74,12 +102,7 @@ describe('AIConfigSettings', () => {
       },
     })
     render(<AIConfigSettings />)
-    await waitFor(() => {
-      expect(loadAIAgentChatSetting).toHaveBeenCalled()
-    })
-    await waitFor(() => {
-      expect(screen.getByText('SettingsPage.item.ai-config')).toBeInTheDocument()
-    })
+    await waitReady()
     vi.mocked(persistAIAgentChatSetting).mockClear()
     const switchBtn = document.querySelector('button.ant-switch') as HTMLElement
     fireEvent.click(switchBtn)

--- a/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/__test__/AIConfigSettings.test.tsx
+++ b/app/renderer/src/main/src/pages/settings/settingsContent/aiConfig/__test__/AIConfigSettings.test.tsx
@@ -1,8 +1,15 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { persistAIAgentChatSetting, loadAIAgentChatSetting } from '@/pages/ai-agent/utils/aiAgentChatSettingCache'
+import {
+  persistAIAgentChatSetting,
+  loadAIAgentChatSetting,
+  serializeAIAgentChatSetting,
+  type LoadAIAgentChatSettingResult,
+} from '@/pages/ai-agent/utils/aiAgentChatSettingCache'
 import { AIAgentSettingDefault } from '@/pages/ai-agent/defaultConstant'
+import type { AIAgentSetting } from '@/pages/ai-agent/aiAgentType'
+import emiter from '@/utils/eventBus/eventBus'
 import { AIConfigSettings } from '../AIConfigSettings'
 
 vi.mock('@/i18n/useI18nNamespaces', () => ({
@@ -13,11 +20,18 @@ vi.mock('@/pages/ai-agent/utils/aiAgentChatSettingCache', async (importOriginal)
   const actual = (await importOriginal()) as Record<string, unknown>
   return {
     ...actual,
-    loadAIAgentChatSetting: vi.fn().mockResolvedValue({
-      DisallowRequireForUserPrompt: false,
-    }),
+    loadAIAgentChatSetting: vi.fn(),
     persistAIAgentChatSetting: vi.fn(),
   }
+})
+
+const successLoad = (patch: Partial<AIAgentSetting> = {}): LoadAIAgentChatSettingResult => ({
+  status: 'success',
+  setting: {
+    ...AIAgentSettingDefault,
+    DisallowRequireForUserPrompt: false,
+    ...patch,
+  },
 })
 
 const waitReady = async () => {
@@ -26,17 +40,30 @@ const waitReady = async () => {
   })
 }
 
+const waitLocked = async () => {
+  await waitFor(() => {
+    expect(loadAIAgentChatSetting).toHaveBeenCalled()
+  })
+  await act(async () => {
+    await Promise.resolve()
+  })
+  expect(document.querySelector('[data-ai-config-ready="1"]')).toBeFalsy()
+}
+
 describe('AIConfigSettings', () => {
   beforeEach(() => {
-    vi.mocked(persistAIAgentChatSetting).mockClear()
+    cleanup()
+    vi.mocked(loadAIAgentChatSetting).mockReset()
+    vi.mocked(loadAIAgentChatSetting).mockResolvedValue(successLoad())
+    vi.mocked(persistAIAgentChatSetting).mockReset()
   })
 
   it('加载缓存后展示权限分区，重置会写回默认配置', async () => {
     const user = userEvent.setup()
     render(<AIConfigSettings />)
+    await waitReady()
     expect(document.querySelector('[data-settings-section="permissions"]')).toBeTruthy()
     expect(document.querySelector('[data-settings-section="planning"]')).toBeTruthy()
-    await waitReady()
     await user.click(screen.getByText('YakitButton.reset'))
     await waitFor(() => {
       expect(persistAIAgentChatSetting).toHaveBeenCalled()
@@ -63,7 +90,7 @@ describe('AIConfigSettings', () => {
   })
 
   it('远端未返回前改开关不会把默认配置写盘，过期读取也不会覆盖后续修改', async () => {
-    let resolveLoad: (value: typeof AIAgentSettingDefault) => void = () => undefined
+    let resolveLoad: (value: LoadAIAgentChatSettingResult) => void = () => undefined
     vi.mocked(loadAIAgentChatSetting).mockImplementationOnce(
       () =>
         new Promise((resolve) => {
@@ -76,11 +103,12 @@ describe('AIConfigSettings', () => {
     fireEvent.click(switchBtn)
     expect(persistAIAgentChatSetting).not.toHaveBeenCalled()
     await act(async () => {
-      resolveLoad({
-        ...AIAgentSettingDefault,
-        DisallowRequireForUserPrompt: false,
-        DisableMemoryTriage: true,
-      })
+      resolveLoad(
+        successLoad({
+          DisallowRequireForUserPrompt: false,
+          DisableMemoryTriage: true,
+        }),
+      )
     })
     await waitReady()
     expect(persistAIAgentChatSetting).not.toHaveBeenCalled()
@@ -91,16 +119,16 @@ describe('AIConfigSettings', () => {
   })
 
   it('加载后改其他项，不会把记忆处理开关写回默认值', async () => {
-    vi.mocked(loadAIAgentChatSetting).mockResolvedValueOnce({
-      ...AIAgentSettingDefault,
-      DisallowRequireForUserPrompt: false,
-      DisableMemoryTriage: true,
-      Strategy: {
-        ...AIAgentSettingDefault.Strategy,
-        GoalMinIterations: 9,
-        MaxSubAgents: 4,
-      },
-    })
+    vi.mocked(loadAIAgentChatSetting).mockResolvedValueOnce(
+      successLoad({
+        DisableMemoryTriage: true,
+        Strategy: {
+          ...AIAgentSettingDefault.Strategy,
+          GoalMinIterations: 9,
+          MaxSubAgents: 4,
+        },
+      }),
+    )
     render(<AIConfigSettings />)
     await waitReady()
     vi.mocked(persistAIAgentChatSetting).mockClear()
@@ -111,5 +139,111 @@ describe('AIConfigSettings', () => {
     expect(saved.DisableMemoryTriage).toBe(true)
     expect(saved.Strategy?.GoalMinIterations).toBe(9)
     expect(saved.Strategy?.MaxSubAgents).toBe(4)
+  })
+
+  it('读取失败保持锁定，改开关不会把默认配置写盘', async () => {
+    vi.mocked(loadAIAgentChatSetting).mockResolvedValueOnce({ status: 'error' })
+    render(<AIConfigSettings />)
+    await waitLocked()
+    fireEvent.click(document.querySelector('button.ant-switch') as HTMLElement)
+    expect(persistAIAgentChatSetting).not.toHaveBeenCalled()
+  })
+
+  it('读取失败后重新进入页面才解锁并允许保存', async () => {
+    vi.mocked(loadAIAgentChatSetting)
+      .mockResolvedValueOnce({ status: 'error' })
+      .mockResolvedValueOnce(
+        successLoad({
+          DisableMemoryTriage: true,
+        }),
+      )
+    const { unmount } = render(<AIConfigSettings />)
+    await waitLocked()
+    unmount()
+    render(<AIConfigSettings />)
+    await waitReady()
+    fireEvent.click(document.querySelector('button.ant-switch') as HTMLElement)
+    const saved = vi.mocked(persistAIAgentChatSetting).mock.calls[0][0]
+    expect(saved.DisableMemoryTriage).toBe(true)
+  })
+
+  it('无缓存时按默认配置解锁，不会在加载阶段写盘', async () => {
+    vi.mocked(loadAIAgentChatSetting).mockResolvedValueOnce({ status: 'empty' })
+    render(<AIConfigSettings />)
+    await waitReady()
+    expect(persistAIAgentChatSetting).not.toHaveBeenCalled()
+    fireEvent.click(document.querySelector('button.ant-switch') as HTMLElement)
+    expect(persistAIAgentChatSetting).toHaveBeenCalled()
+  })
+
+  it('迟到的初次读取不会覆盖更新的广播配置', async () => {
+    let resolveLoad: (value: LoadAIAgentChatSettingResult) => void = () => undefined
+    vi.mocked(loadAIAgentChatSetting).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveLoad = resolve
+        }),
+    )
+    render(<AIConfigSettings />)
+    const payload = serializeAIAgentChatSetting({
+      ...AIAgentSettingDefault,
+      DisableMemoryTriage: true,
+      ReviewPolicy: 'yolo',
+    })
+    act(() => {
+      emiter.emit('onAIAgentChatSettingChange', payload)
+    })
+    expect(document.querySelector('[data-ai-config-ready="1"]')).toBeFalsy()
+    fireEvent.click(document.querySelector('button.ant-switch') as HTMLElement)
+    expect(persistAIAgentChatSetting).not.toHaveBeenCalled()
+    await act(async () => {
+      resolveLoad(
+        successLoad({
+          DisableMemoryTriage: false,
+          ReviewPolicy: 'manual',
+        }),
+      )
+    })
+    await waitReady()
+    fireEvent.click(document.querySelector('button.ant-switch') as HTMLElement)
+    const saved = vi.mocked(persistAIAgentChatSetting).mock.calls[0][0]
+    expect(saved.DisableMemoryTriage).toBe(true)
+    expect(saved.ReviewPolicy).toBe('yolo')
+  })
+
+  it('读取失败后即使收到广播也不解锁写盘', async () => {
+    vi.mocked(loadAIAgentChatSetting).mockResolvedValueOnce({ status: 'error' })
+    render(<AIConfigSettings />)
+    await waitLocked()
+    act(() => {
+      emiter.emit(
+        'onAIAgentChatSettingChange',
+        serializeAIAgentChatSetting({
+          ...AIAgentSettingDefault,
+          DisableMemoryTriage: true,
+          ReviewPolicy: 'yolo',
+        }),
+      )
+    })
+    fireEvent.click(document.querySelector('button.ant-switch') as HTMLElement)
+    expect(persistAIAgentChatSetting).not.toHaveBeenCalled()
+    expect(document.querySelector('[data-ai-config-ready="1"]')).toBeFalsy()
+  })
+
+  it('卸载后过期读取不会解锁或写盘', async () => {
+    let resolveLoad: (value: LoadAIAgentChatSettingResult) => void = () => undefined
+    vi.mocked(loadAIAgentChatSetting).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveLoad = resolve
+        }),
+    )
+    const { unmount } = render(<AIConfigSettings />)
+    unmount()
+    await act(async () => {
+      resolveLoad(successLoad({ DisableMemoryTriage: true }))
+    })
+    expect(persistAIAgentChatSetting).not.toHaveBeenCalled()
+    expect(document.querySelector('[data-ai-config-ready="1"]')).toBeFalsy()
   })
 })

--- a/app/renderer/src/main/src/pages/settings/settingsContent/rightClickPlugins/PluginItem.tsx
+++ b/app/renderer/src/main/src/pages/settings/settingsContent/rightClickPlugins/PluginItem.tsx
@@ -215,6 +215,7 @@ export const PluginItem: React.FC<PluginItemProps> = React.memo((props) => {
         [styles['item-dragging']]: isDragging,
         [styles['item-actions-open']]: settingMenuOpen || keyShow || editHint,
       })}
+      data-plugin-name={plugin.PluginName}
     >
       <div className={styles['drag']} {...dragHandleProps}>
         <FigmaIcon2281144183Solid size={16} color="currentColor" />

--- a/app/renderer/src/main/src/pages/settings/settingsContent/rightClickPlugins/__test__/RightClickPluginsSettings.test.tsx
+++ b/app/renderer/src/main/src/pages/settings/settingsContent/rightClickPlugins/__test__/RightClickPluginsSettings.test.tsx
@@ -1,6 +1,6 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ManageRightClickPluginsTabKey } from '@/pages/manageRightClickPlugins/constants'
 import {
   ContextMenuExecutionType,
@@ -33,6 +33,15 @@ vi.mock('@/utils/notification', () => ({
 vi.mock('@/utils/eventBus/eventBus', () => ({
   default: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
 }))
+
+vi.mock('ahooks', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await importOriginal<typeof import('ahooks')>()
+  return {
+    ...actual,
+    useInViewport: () => [true],
+  }
+})
 
 const dnd = vi.hoisted(() => ({ onDragEnd: undefined as ((result: any) => void) | undefined }))
 
@@ -89,6 +98,8 @@ const expectBefore = (a: string, b: string) => {
     screen.getByText(a).compareDocumentPosition(screen.getByText(b)) & Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBeTruthy()
 }
+const pluginSwitch = (name: string) =>
+  within(screen.getByText(name).closest('[data-plugin-name]') as HTMLElement).getByRole('switch')
 
 const makeAction = (over: Partial<ContextMenuAction>): ContextMenuAction =>
   ({
@@ -130,6 +141,10 @@ describe('RightClickPluginsSettings', () => {
     mockBind.mockResolvedValue({})
   })
 
+  afterEach(() => {
+    cleanup()
+  })
+
   it('渲染三组 tab、计数与插件列表', async () => {
     render(<RightClickPluginsSettings />)
     expect(screen.getByText('SettingsPage.item.right-click-plugins')).toBeInTheDocument()
@@ -156,9 +171,7 @@ describe('RightClickPluginsSettings', () => {
     const user = userEvent.setup()
     render(<RightClickPluginsSettings />)
     await waitFor(() => expect(screen.getByText('path-extract')).toBeInTheDocument())
-    const switches = document.querySelectorAll('button.ant-switch')
-    expect(switches.length).toBeGreaterThan(1)
-    await user.click(switches[1])
+    await user.click(pluginSwitch('path-extract'))
     await waitFor(() => {
       expect(mockBind).toHaveBeenCalled()
     })
@@ -190,9 +203,11 @@ describe('RightClickPluginsSettings', () => {
     ])
     render(<RightClickPluginsSettings />)
     await waitFor(() => expect(screen.getByText('to-disable')).toBeInTheDocument())
-    await user.click(document.querySelectorAll('button.ant-switch')[1])
+    await user.click(pluginSwitch('to-disable'))
     await waitFor(() => {
       expect(mockBind).toHaveBeenCalled()
+    })
+    await waitFor(() => {
       expectBefore('keep-off', 'to-disable')
     })
     expect(mockBind.mock.calls.some((call) => call[0].PluginUUID === 'p3' && call[0].Enabled === false)).toBe(true)


### PR DESCRIPTION
## 概述

修复 AI 配置设置页在远端配置加载完成前用户操作导致默认值覆盖远端配置的问题，以及 AI 全局配置保存失败后回拉读取覆盖后续已成功保存的竞态问题。同时改进右键插件设置测试的开关定位方式。

## 关联 Issue / PR

None

## 改动内容

### AIConfigSettings ready 门控

加载远端配置完成前 `apply`/`applyAll` 不执行写盘操作，避免用户在默认值阶段改开关把默认配置持久化。加载完成后通过 `readyRef` 解锁交互，并在未 ready 时对容器添加 `pointer-events:none` 与 `aria-busy` 提示。加载 effect 增加 `cancelled` 守卫防止卸载后 setState。

### useAIGlobalConfig saveEpoch 防过期回拉

引入模块级 `saveEpoch` 递增计数器，保存失败后仅当当前 epoch 仍为最新时才发起回拉读取；`applyFetchedConfig` 在应用前二次校验 epoch，若回拉期间已有新保存成功则丢弃过期结果，防止旧值覆盖新值。

### 右键插件测试按插件名定位开关

`PluginItem` 根 div 添加 `data-plugin-name` 属性，测试从按 `button.ant-switch` 位置索引定位改为按插件名精确定位对应开关，消除因渲染顺序变化导致的误点击。

## 影响范围

AI 配置设置页在远端配置未返回前的交互被静默禁用（加载完成后恢复正常），用户不会观察到默认值被意外写盘。AI 全局配置保存失败后的回拉不再覆盖后续成功保存。右键插件设置页无可见行为变化。

## 代码评审结论

**结论：可以合并**（正确 7 项 / 问题 0 项 / 警告 2 项）

## 合并方式

- [ ] Create a merge commit（保留完整提交历史）
- [ ] Squash and merge（压缩为一条提交）
- [x] Rebase and merge（线性历史）
