### PR TITLE
luoluo/perf/ai-right-panel-add-settings

### DIFF
--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
@@ -12,6 +12,7 @@ import { timeDiffWithMoment } from '@/utils/timeUtil'
 import { AISourceEnum, type AIAgentGrpcApi } from '../hooks/grpcApi'
 import useCurrentTaskExecution from '../hooks/useCurrentTaskData/useCurrentTaskExecution'
 import emiter from '@/utils/eventBus/eventBus'
+import { YakitRoute } from '@/enums/yakitRoute'
 import { failed, yakitNotify } from '@/utils/notification'
 import { AIAgentTabListEnum, AITabsEnum, SwitchAIAgentTabEventEnum } from '@/pages/ai-agent/defaultConstant'
 import useAIAgentStore from '@/pages/ai-agent/useContext/useStore'
@@ -25,6 +26,7 @@ import {
   ChatAlt2Outlined,
   ChevronDoubleDownOutlined,
   ChevronDoubleUpOutlined,
+  CogOutlined,
   FigmaIcon2017756Outlined,
   FigmaIcon348196674Outlined,
   FlagOutlined,
@@ -64,7 +66,7 @@ const MAIN_MENUS: MenuItemDef[] = [
 
 /** 「更多」分组展开后追加显示的功能入口（收起态仅在底部显示「更多」按钮） */
 const MORE_MENUS: MenuItemDef[] = [
-  // { key: 'ai-settings', labelKey: 'AIRightPanel.aiSettings', icon: <CogOutlined /> },
+  { key: 'ai-settings', labelKey: 'AIRightPanel.aiSettings', icon: <CogOutlined /> },
   { key: 'timeline', labelKey: 'AIRightPanel.timeline', icon: <TimelineOutlined /> },
   { key: 'export-log', labelKey: 'AIRightPanel.exportLog', icon: <FigmaIcon2017756Outlined /> },
   { key: 'view-log', labelKey: 'AIRightPanel.viewLog', icon: <NewspaperOutlined /> },
@@ -351,7 +353,7 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
   /**
    * 菜单点击：任务列表、时间线、会话历史打开右侧内容面板；
    * 任务详情、流量、漏洞切换工作区 tab；文件系统打开侧栏会话页；
-   * 导出日志打开导出弹窗，查看日志打开日志窗口。
+   * AI 设置打开设置页，导出日志打开导出弹窗，查看日志打开日志窗口。
    */
   const handleMenuClick = useMemoizedFn((key: AIRightPanelMenuKey) => {
     switch (key) {
@@ -378,6 +380,9 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
         break
       case 'risk':
         emiter.emit('switchAIActTab', JSON.stringify({ key: AITabsEnum.Risk }))
+        break
+      case 'ai-settings':
+        emiter.emit('openPage', JSON.stringify({ route: YakitRoute.Settings, params: { anchor: 'ai-config' } }))
         break
       case 'export-log':
         setExportModalVisible(true)

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/__test__/AIRightPanel.test.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
+import { YakitRoute } from '@/enums/yakitRoute'
 
 // CI 的根配置将样式模块替换为空对象；为这里验证的状态类提供稳定映射。
 vi.mock('../AIRightPanel.module.scss', () => ({
@@ -170,15 +171,23 @@ const renderPanel = async (ui: React.ReactElement) => {
 }
 
 describe('AIRightPanel', () => {
-  it.each([false, true])('暂不显示 AI 设置，更多分组按顺序展开和收起（小屏：%s）', async (small) => {
+  it.each([false, true])('AI 设置跳转到设置页，更多分组按顺序展开和收起（小屏：%s）', async (small) => {
     render(<AIRightPanel small={small} />)
     fireEvent.click(await screen.findByLabelText('更多'))
-    expect(screen.queryByLabelText('AI 设置')).not.toBeInTheDocument()
+    const aiSettings = screen.getByLabelText('AI 设置')
     const timeline = screen.getByLabelText('时间线')
     const exportLog = screen.getByLabelText('导出日志')
-    expect(timeline.parentElement?.firstElementChild).toBe(timeline)
+    expect(aiSettings.parentElement?.firstElementChild).toBe(aiSettings)
+    expect(aiSettings.nextElementSibling).toBe(timeline)
     expect(timeline.nextElementSibling).toBe(exportLog)
     expect(exportLog.nextElementSibling).toBe(screen.getByLabelText('查看日志'))
+    mockEmit.mockClear()
+    fireEvent.click(aiSettings)
+    expect(mockEmit).toHaveBeenCalledTimes(1)
+    expect(mockEmit).toHaveBeenCalledWith(
+      'openPage',
+      JSON.stringify({ route: YakitRoute.Settings, params: { anchor: 'ai-config' } }),
+    )
     fireEvent.click(screen.getByLabelText('折叠'))
     expect(screen.queryByLabelText('AI 设置')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('时间线')).not.toBeInTheDocument()


### PR DESCRIPTION
## 改动类型

- [x] 新功能（新页面 / 新选项 / 新能力）

## 🔗 关联 Issue / PR

None

## 💡 背景与方案

AI 右侧面板「更多」分组中的「AI 设置」入口此前以注释占位（#4252 引入），待新 UI 设置页（#4246）落地后启用。本次恢复该入口：点击后通过 `openPage` 事件打开设置页并携带 `ai-config` 锚点，直达「AI 配置」分区。

## 改动内容

### AI 右侧面板「AI 设置」入口

- `AIRightPanel.tsx`：启用 `MORE_MENUS` 中的 `ai-settings` 菜单项（「更多」分组首项）；`handleMenuClick` 新增 `ai-settings` 分支，emit `openPage`（`YakitRoute.Settings` + `params.anchor: 'ai-config'`），复用既有 `MainOperatorContent.addSettingsPage` 链路与「快捷键跳设置页」同模式。
- `__test__/AIRightPanel.test.tsx`：断言「更多」分组菜单顺序（AI 设置 → 时间线 → 导出日志 → 查看日志）及点击后 emit 的事件参数，大小屏参数化覆盖。

## 影响范围

AI 右侧面板「更多」分组展开后新增「AI 设置」入口（首位），点击跳转设置页「AI 配置」分区；其余菜单与面板行为不变。i18n 三语言（zh / zh-TW / en）文案此前已就绪，本次无新增文案。

## 代码评审结论

**结论：可以合并**（正确 4 项 / 问题 0 项（P0 0 项 / P1 0 项）/ 警告 1 项；本地 tsc / vitest 因依赖缺失降级未重跑，同 commit 远端 CI TypeScript 与 Vitest 全部通过）

## 建议合并前修复的问题

本次评审未发现建议合并前修复的问题。

## 合并方式

选择Rebase and merge合并
