### PR TITLE
pref: 首页相关定时器优化

### DIFF
--- a/app/renderer/src/main/src/components/layout/FuncDomain.tsx
+++ b/app/renderer/src/main/src/components/layout/FuncDomain.tsx
@@ -44,6 +44,7 @@ import { useScreenRecorder } from '@/store/screenRecorder'
 import { YakitRoute } from '@/enums/yakitRoute'
 import { useRunNodeStore } from '@/store/runNode'
 import emiter from '@/utils/eventBus/eventBus'
+import { startIdleVisibleInterval } from '@/utils/scheduleIdleTask'
 import { useTemporaryProjectStore } from '@/store/temporaryProject'
 import { visitorsStatisticsFun } from '@/utils/visitorsStatistics'
 import { serverPushStatus } from '@/utils/duplex/duplex'
@@ -1594,18 +1595,15 @@ export const UIOpNotice: React.FC<UIOpNoticeProp> = React.memo((props) => {
   /** Yakit版本号 */
   const [yakitVersion, setYakitVersion] = useState<string>('dev')
   const [yakitLastVersion, setYakitLastVersion] = useState<string>('')
-  const yakitTime = useRef<any>(null)
 
   /** Yaklang引擎版本号 */
   const [yaklangVersion, setYaklangVersion] = useState<string>('dev') // 当前连接引擎的版本号
   const [yaklangLastVersion, setYaklangLastVersion] = useState<string>('') // 官方推荐的最新版
   const [yaklangLocalVersion, setYaklangLocalVersion] = useState<string>('') // 本地引擎文件版本号
   const [yaklangBuildType, setYaklangBuildType] = useState<'full' | 'slim'>('full') // 当前引擎标准/轻量
-  const yaklangTime = useRef<any>(null)
 
   /** 更多引擎列表 */
   const [moreYaklangVersionList, setMoreYaklangVersionList] = useState<string[]>([]) // 更多引擎版本list
-  const moreYaklangTime = useRef<any>(null)
 
   // 是否低于主推引擎版本
   const lowerYaklangLastVersion = useMemo(() => {
@@ -1620,7 +1618,6 @@ export const UIOpNotice: React.FC<UIOpNoticeProp> = React.memo((props) => {
     return false
   }, [isRemoteMode, moreYaklangVersionList, yaklangLastVersion, yaklangVersion])
 
-  const versionsInfoTime = useRef<any>(null)
   const [communityYakitContent, setCommunityYakitContent] = useState<UpdateContentProp>({ version: '', content: '' })
   const [communityYaklangContent, setCommunityYaklangContent] = useState<UpdateContentProp>({
     version: '',
@@ -1845,65 +1842,31 @@ export const UIOpNotice: React.FC<UIOpNoticeProp> = React.memo((props) => {
       })
   }, [isEngineLink, yaklangVersion])
 
-  /** 清空定时器 */
-  const handleClearIntervals = useMemoizedFn(() => {
-    if (versionsInfoTime.current) {
-      clearInterval(versionsInfoTime.current)
-      versionsInfoTime.current = null
-    }
-    if (yakitTime.current) {
-      clearInterval(yakitTime.current)
-      yakitTime.current = null
-    }
-    if (yaklangTime.current) {
-      clearInterval(yaklangTime.current)
-      yaklangTime.current = null
-    }
-    if (moreYaklangTime.current) {
-      clearInterval(moreYaklangTime.current)
-      moreYaklangTime.current = null
-    }
-  })
-
   useEffect(() => {
-    if (isEngineLink) {
-      // 获取是否 启动检测更新 的缓存状态
-      getLocalValue(LocalGV.NoAutobootLatestVersionCheck).then((val: boolean) => {
-        setIsCheck(val)
-      })
-
-      // 设置获取更新内容的定时器(yakit&yaklang)
-      if (versionsInfoTime.current) clearInterval(versionsInfoTime.current)
-      versionsInfoTime.current = setInterval(fetchYakitAndYaklangVersionInfo, 60000)
-      fetchYakitAndYaklangVersionInfo()
-
-      // 获取本地的 yakit 版本号，启动定时器(获取最新的 yakit 版本号)
-      grpcFetchLocalYakitVersion(true).then((v: string) => setYakitVersion(`v${v}`))
-      if (yakitTime.current) clearInterval(yakitTime.current)
-      fetchYakitLastVersion()
-      yakitTime.current = setInterval(fetchYakitLastVersion, 60000)
-
-      // 获取当前连接引擎的版本号，启动定时器(获取最新和本地引擎文件的版本号)
-      yakitEngine.requestYakVersion()
-      if (yaklangTime.current) clearInterval(yaklangTime.current)
-      fetchYaklangLastVersion()
-      yaklangTime.current = setInterval(fetchYaklangLastVersion, 60000)
-
-      // 获取更多引擎列表，并启动定时器
-      if (moreYaklangTime.current) clearInterval(moreYaklangTime.current)
-      fetchMoreYaklangLastVersion()
-      moreYaklangTime.current = setInterval(fetchMoreYaklangLastVersion, 60000)
-    } else {
+    if (!isEngineLink) {
       setYakitLastVersion('')
       setYaklangVersion('dev')
       setYaklangLastVersion('')
       setYaklangLocalVersion('')
       setMoreYaklangVersionList([])
+      return
     }
-
-    return () => {
-      handleClearIntervals()
-    }
+    // 获取是否 启动检测更新 的缓存状态
+    getLocalValue(LocalGV.NoAutobootLatestVersionCheck).then((val: boolean) => {
+      setIsCheck(val)
+    })
+    grpcFetchLocalYakitVersion(true).then((v: string) => setYakitVersion(`v${v}`))
+    yakitEngine.requestYakVersion()
+    return startIdleVisibleInterval(
+      () => {
+        fetchYakitAndYaklangVersionInfo()
+        fetchYakitLastVersion()
+        fetchYaklangLastVersion()
+        fetchMoreYaklangLastVersion()
+      },
+      60000,
+      { runImmediately: true },
+    )
   }, [isEngineLink])
 
   // intranetYakit为内网Yakit
@@ -2390,7 +2353,7 @@ const UIOpRisk: React.FC<UIOpRiskProp> = React.memo((props) => {
   })
 
   /** 定时器 */
-  const timeRef = useRef<any>(null)
+  const timeRef = useRef<(() => void) | null>(null)
   /** 风险详情弹窗（保证同时只存在一个） */
   const riskDetailModalRef = useRef<{ destroy: () => void } | null>(null)
   /** 打开详情中，防止同一次/连续点击叠多个弹窗 */
@@ -2422,9 +2385,13 @@ const UIOpRisk: React.FC<UIOpRiskProp> = React.memo((props) => {
 
   /** 获取最新的漏洞与风险信息(5秒一次) */
   useEffect(() => {
+    let cancelled = false
+    const clearPoll = () => {
+      timeRef.current?.()
+      timeRef.current = null
+    }
     if (isEngineLink) {
-      if (timeRef.current) clearInterval(timeRef.current)
-
+      clearPoll()
       yakitRisk
         .queryRisks({
           Pagination: { Limit: 1, Page: 1, Order: 'desc', OrderBy: 'id' },
@@ -2435,14 +2402,14 @@ const UIOpRisk: React.FC<UIOpRiskProp> = React.memo((props) => {
         })
         .catch((e) => {})
         .finally(() => {
+          if (cancelled) return
           update()
           emiter.on('onRefreshQueryNewRisk', update)
           // 以下为兼容以前的引擎 PS:以前的引擎依然为轮询
           if (!serverPushStatus) {
-            timeRef.current = setInterval(() => {
+            timeRef.current = startIdleVisibleInterval(() => {
               if (serverPushStatus) {
-                if (timeRef.current) clearInterval(timeRef.current)
-                timeRef.current = null
+                clearPoll()
                 return
               }
               update()
@@ -2451,13 +2418,13 @@ const UIOpRisk: React.FC<UIOpRiskProp> = React.memo((props) => {
         })
       emiter.on('onRefRisksRead', onRefRisksRead)
       return () => {
-        clearInterval(timeRef.current)
+        cancelled = true
+        clearPoll()
         emiter.off('onRefreshQueryNewRisk', update)
         emiter.off('onRefRisksRead', onRefRisksRead)
       }
     } else {
-      if (timeRef.current) clearInterval(timeRef.current)
-      timeRef.current = null
+      clearPoll()
       fetchNode.current = 0
       setRisks({ Data: [], Total: 0, NewRiskTotal: 0, Unread: 0 })
     }
@@ -2654,7 +2621,7 @@ const UIOpIRifyRisk: React.FC<UIOpRiskProp> = React.memo((props) => {
   })
 
   /** 定时器 */
-  const timeRef = useRef<any>(null)
+  const timeRef = useRef<(() => void) | null>(null)
   /** 风险详情弹窗（保证同时只存在一个） */
   const riskDetailModalRef = useRef<{ destroy: () => void } | null>(null)
   /** 打开详情中，防止同一次/连续点击叠多个弹窗 */
@@ -2678,8 +2645,14 @@ const UIOpIRifyRisk: React.FC<UIOpRiskProp> = React.memo((props) => {
 
   /** 获取最新的漏洞与风险信息(5秒一次) */
   useEffect(() => {
+    let cancelled = false
+    const clearPoll = () => {
+      timeRef.current?.()
+      timeRef.current = null
+    }
+
     if (isEngineLink) {
-      if (timeRef.current) clearInterval(timeRef.current)
+      clearPoll()
       apiQuerySSARisks({
         Pagination: {
           Limit: 1,
@@ -2695,14 +2668,14 @@ const UIOpIRifyRisk: React.FC<UIOpRiskProp> = React.memo((props) => {
         })
         .catch((e) => {})
         .finally(() => {
+          if (cancelled) return
           update()
           emiter.on('onRefreshQuerySSARisks', update)
           // 以下为兼容以前的引擎 PS:以前的引擎依然为轮询
           if (!serverPushStatus) {
-            timeRef.current = setInterval(() => {
+            timeRef.current = startIdleVisibleInterval(() => {
               if (serverPushStatus) {
-                if (timeRef.current) clearInterval(timeRef.current)
-                timeRef.current = null
+                clearPoll()
                 return
               }
               update()
@@ -2711,13 +2684,13 @@ const UIOpIRifyRisk: React.FC<UIOpRiskProp> = React.memo((props) => {
         })
       emiter.on('onRefRisksRead', onRefRisksRead)
       return () => {
-        clearInterval(timeRef.current)
+        cancelled = true
+        clearPoll()
         emiter.off('onRefreshQuerySSARisks', update)
         emiter.off('onRefRisksRead', onRefRisksRead)
       }
     } else {
-      if (timeRef.current) clearInterval(timeRef.current)
-      timeRef.current = null
+      clearPoll()
       fetchNode.current = 0
       setRisks({ Data: [], Total: 0, NewRiskTotal: 0, Unread: 0 })
     }

--- a/app/renderer/src/main/src/components/layout/GlobalState.tsx
+++ b/app/renderer/src/main/src/components/layout/GlobalState.tsx
@@ -47,6 +47,7 @@ import { ShieldCheckOutlined } from '@yakit-libs/yakit-ui-icons/outline'
 import { yakitApp, yakitHost, yakitPlugin, yakitReverse } from '@/services/electronBridge'
 import { YakitRoute } from '@/enums/yakitRoute'
 import { SettingsSections } from '@/pages/settings/constants'
+import { startIdleVisibleInterval } from '@/utils/scheduleIdleTask'
 
 import { ShieldCheckSolid } from '@yakit-libs/yakit-ui-icons/solid'
 
@@ -583,9 +584,15 @@ export const GlobalState: React.FC<GlobalReverseStateProp> = React.memo((props) 
     })
   })
 
-  const [timeInterval, setTimeInterval, getTimeInterval] = useGetState<number>(5)
+  const [timeInterval, setTimeInterval] = useState<number>(5)
   const [zoomScale, setZoomScale] = useState<number>(100)
-  const timeRef = useRef<any>(null)
+
+  const onTimeIntervalChange = useMemoizedFn((value: number | string | null) => {
+    const next = !value ? 1 : +value || 5
+    if (next === timeInterval) return
+    setTimeInterval(next)
+    setRemoteValue(RemoteGV.GlobalStateTimeInterval, `${next}`)
+  })
 
   useEffect(() => {
     getRemoteValue(RemoteGV.GlobalStateZoomScale).then((scale: any) => {
@@ -599,7 +606,6 @@ export const GlobalState: React.FC<GlobalReverseStateProp> = React.memo((props) 
 
   // 启动全局状态轮询定时器
   useEffect(() => {
-    let timer: any = null
     if (isEngineLink) {
       // 仅在引擎连接时校验引擎是否为官方发布版本
       // 频繁读写将会大幅占用性能
@@ -610,10 +616,6 @@ export const GlobalState: React.FC<GlobalReverseStateProp> = React.memo((props) 
         if ((+time || 5) > 5) updateAllInfo()
       })
 
-      if (timer) clearInterval(timer)
-      timer = setInterval(() => {
-        setRemoteValue(RemoteGV.GlobalStateTimeInterval, `${getTimeInterval()}`)
-      }, 20000)
       updatePluginTotal()
       isIRify() && onRuleUpdate()
       emiter.on('onRefreshQueryYakScript', updatePluginTotal)
@@ -636,26 +638,19 @@ export const GlobalState: React.FC<GlobalReverseStateProp> = React.memo((props) 
       isFirstCheckRef.current = true
 
       isRunRef.current = false
-      if (timeRef.current) clearInterval(timeRef.current)
-      timeRef.current = null
     }
 
     return () => {
       if (isEngineLink) emiter.off('onRefreshQueryYakScript', updatePluginTotal)
-      if (timer) clearInterval(timer)
-      timer = null
     }
   }, [isEngineLink])
-  // 修改查询间隔时间后
+  // 修改查询间隔时间后：空闲再开、隐藏时跳过 tick
   useDebounceEffect(
     () => {
-      if (timeRef.current) clearInterval(timeRef.current)
-      timeRef.current = setInterval(updateAllInfo, timeInterval * 1000)
-
+      const cancel = startIdleVisibleInterval(updateAllInfo, timeInterval * 1000)
       return () => {
         isRunRef.current = false
-        if (timeRef.current) clearInterval(timeRef.current)
-        timeRef.current = null
+        cancel()
       }
     },
     [timeInterval],
@@ -1205,12 +1200,7 @@ export const GlobalState: React.FC<GlobalReverseStateProp> = React.memo((props) 
             formatter={(value) => `${value}s`}
             parser={(value) => value!.replace('s', '')}
             value={timeInterval}
-            onChange={(value) => {
-              if (!value) setTimeInterval(1)
-              else {
-                if (+value !== timeInterval) setTimeInterval(+value || 5)
-              }
-            }}
+            onChange={onTimeIntervalChange}
           />
         </div>
       </div>
@@ -1347,12 +1337,7 @@ export const GlobalState: React.FC<GlobalReverseStateProp> = React.memo((props) 
             formatter={(value) => `${value}s`}
             parser={(value) => value!.replace('s', '')}
             value={timeInterval}
-            onChange={(value) => {
-              if (!value) setTimeInterval(1)
-              else {
-                if (+value !== timeInterval) setTimeInterval(+value || 5)
-              }
-            }}
+            onChange={onTimeIntervalChange}
           />
         </div>
       </div>

--- a/app/renderer/src/main/src/components/layout/PerformanceDisplay.tsx
+++ b/app/renderer/src/main/src/components/layout/PerformanceDisplay.tsx
@@ -23,6 +23,7 @@ import { remoteOperation } from '@/pages/dynamicControl/DynamicControl'
 import { yakitApp, yakitEngine, yakitPerf, yakitUILayout } from '@/services/electronBridge'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
 import { YakitGlobalHost } from './YakitGlobalHost'
+import { startIdleVisibleInterval } from '@/utils/scheduleIdleTask'
 
 interface PerformanceDisplayProps {
   engineMode: YaklangEngineMode | undefined
@@ -37,14 +38,36 @@ export const PerformanceDisplay: React.FC<PerformanceDisplayProps> = React.memo(
   const [rps, setRps] = useState<number>(0)
 
   useEffect(() => {
-    yakitPerf.startComputePercent()
-    const time = setInterval(() => {
-      yakitPerf.fetchComputePercent().then((res) => setCpu(res))
-    }, 500)
+    let computeStarted = false
+    const ensureCompute = () => {
+      if (computeStarted || document.hidden) return
+      computeStarted = true
+      yakitPerf.startComputePercent()
+    }
+    const stopCompute = () => {
+      if (!computeStarted) return
+      computeStarted = false
+      yakitPerf.clearComputePercent()
+    }
+
+    // 空闲后再采 CPU，页面隐藏时停采集，避免首屏与后台空转抢主线程
+    const cancelInterval = startIdleVisibleInterval(
+      () => {
+        ensureCompute()
+        yakitPerf.fetchComputePercent().then((res) => setCpu(res))
+      },
+      500,
+      { runImmediately: true },
+    )
+    const onVisibilityChange = () => {
+      if (document.hidden) stopCompute()
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
 
     return () => {
-      clearInterval(time)
-      yakitPerf.clearComputePercent()
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      cancelInterval()
+      stopCompute()
     }
   }, [])
 

--- a/app/renderer/src/main/src/components/layout/UILayout.tsx
+++ b/app/renderer/src/main/src/components/layout/UILayout.tsx
@@ -87,6 +87,7 @@ import { NewYakitLoading } from '../basics/NewYakitLoading'
 import classNames from 'classnames'
 import styles from './uiLayout.module.scss'
 import { JSONParseLog } from '@/utils/tool'
+import { startIdleVisibleInterval } from '@/utils/scheduleIdleTask'
 import { closeDuplexConn, startupDuplexConn } from '@/utils/duplex/duplex'
 import { type SoftMode, useSoftMode } from '@/store/softMode'
 import { useI18nNamespaces } from '@/i18n/useI18nNamespaces'
@@ -197,16 +198,7 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
       setCredential(data.credential)
       onSetEngineMode(data.credential.Mode)
       setYakitStatus('ready')
-      if (data.credential.Mode === 'local') {
-        setTimeout(() => {
-          setKeepalive(true)
-        }, 500)
-      } else {
-        setKeepalive(true)
-      }
-      setTimeout(() => {
-        setNewCheckLog([])
-      }, 2000)
+      setKeepalive(true)
     })
     yakitUILayout.markRendererReady()
     return () => {
@@ -410,8 +402,7 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
 
       setLocalValue(LocalGV.YaklangEngineMode, getEngineMode())
 
-      const waitTime: number = 20000
-      const id = setInterval(() => {
+      return startIdleVisibleInterval(() => {
         grpcFetchYakInstallResult(true)
           .then((flag: boolean) => {
             if (isEngineInstalled.current === flag) return
@@ -420,10 +411,7 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
             yakitEngine.clearLocalYaklangVersionCache()
           })
           .catch()
-      }, waitTime)
-      return () => {
-        clearInterval(id)
-      }
+      }, 20000)
     } else {
       // 清空主进程yaklang版本缓存
       yakitEngine.clearLocalYaklangVersionCache()
@@ -519,9 +507,6 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
           yakitApp.completeMainWindow({ yakitStatus: type })
         }
       }, 1500)
-      setTimeout(() => {
-        setNewCheckLog([])
-      }, 2000)
     }, [GetConnectPort()])
   })
   useEffect(() => {
@@ -1633,7 +1618,7 @@ const UILayout: React.FC<UILayoutProp> = (props) => {
       yakitFailed(error + '')
     }
 
-    setTimeout(() => setEngineLink(true), 100)
+    setEngineLink(true)
   })
 
   const onReady = useMemoizedFn(() => {

--- a/app/renderer/src/main/src/components/layout/YakitGlobalHost.tsx
+++ b/app/renderer/src/main/src/components/layout/YakitGlobalHost.tsx
@@ -1,8 +1,9 @@
 import type React from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useMemoizedFn } from 'ahooks'
 import classNames from 'classnames'
 import { yakitEngine } from '@/services/electronBridge'
+import { startIdleVisibleInterval } from '@/utils/scheduleIdleTask'
 
 import styles from './yakitGlobalHost.module.scss'
 
@@ -15,8 +16,6 @@ export const YakitGlobalHost: React.FC<YakitGlobalHostProp> = (props) => {
   const { isEngineLink, compact } = props
 
   const [host, setHost] = useState<{ addr: string; port: string }>({ addr: '??', port: '??' })
-  /** 获取连接引擎地址计时器 */
-  const timeRef = useRef<any>(null)
 
   /** 获取连接引擎的地址参数 */
   const getGlobalHost = useMemoizedFn(() => {
@@ -33,18 +32,11 @@ export const YakitGlobalHost: React.FC<YakitGlobalHostProp> = (props) => {
 
   /** 引擎连接和断开时的展示内容处理 */
   useEffect(() => {
-    if (isEngineLink) {
-      if (timeRef.current) clearInterval(timeRef.current)
-      timeRef.current = setInterval(getGlobalHost, 1000)
-
-      return () => {
-        clearInterval(timeRef.current)
-      }
-    } else {
-      if (timeRef.current) clearInterval(timeRef.current)
-      timeRef.current = null
+    if (!isEngineLink) {
       setHost({ addr: '??', port: '??' })
+      return
     }
+    return startIdleVisibleInterval(getGlobalHost, 1000, { runImmediately: true })
   }, [isEngineLink])
 
   return (

--- a/app/renderer/src/main/src/components/layout/YaklangEngineWatchDog.tsx
+++ b/app/renderer/src/main/src/components/layout/YaklangEngineWatchDog.tsx
@@ -177,26 +177,23 @@ export const YaklangEngineWatchDog: React.FC<YaklangEngineWatchDogProps> = React
 
     const failedCountRef = useRef(0)
     const readyNotifiedRef = useRef(false)
-    const probingRef = useRef(false)
 
     /**
      * 引擎连接尝试逻辑
-     * 未连接每 1s 探活，已连接每 3s；上一轮未完成则跳过，避免 echo 堆积。
+     * 未连接每 1s 探活，已连接每 3s。
+     * 上一轮未完成不阻塞后续 tick，避免单次 Echo 挂起后探活与失败通知停止。
      * 引擎连接有效尝试次数: 1-10
      */
     useEffect(() => {
       if (!props.keepalive) {
         failedCountRef.current = 0
         readyNotifiedRef.current = false
-        probingRef.current = false
         props.onFailed?.(100)
         return
       }
       debugToPrintLog(`------ 开始启动引擎进程探活逻辑------`)
 
       const connect = () => {
-        if (probingRef.current) return
-        probingRef.current = true
         isEngineConnectionAlive()
           .then(() => {
             if (!props.keepalive) return
@@ -210,9 +207,6 @@ export const YaklangEngineWatchDog: React.FC<YaklangEngineWatchDogProps> = React
             failedCountRef.current += 1
             readyNotifiedRef.current = false
             props.onFailed?.(failedCountRef.current)
-          })
-          .finally(() => {
-            probingRef.current = false
           })
       }
       connect()

--- a/app/renderer/src/main/src/components/layout/YaklangEngineWatchDog.tsx
+++ b/app/renderer/src/main/src/components/layout/YaklangEngineWatchDog.tsx
@@ -175,58 +175,52 @@ export const YaklangEngineWatchDog: React.FC<YaklangEngineWatchDogProps> = React
       if (!props.engineLink) setAutoStartProgress(false)
     }, [props.engineLink])
 
-    /** 未连接引擎前, 每隔1秒尝试连接一次, 连接引擎后, 每隔5秒尝试连接一次 */
-    const attemptConnectTime = useMemoizedFn(() => {
-      return props.engineLink ? 5000 : 1000
-    })
+    const failedCountRef = useRef(0)
+    const readyNotifiedRef = useRef(false)
+    const probingRef = useRef(false)
 
     /**
      * 引擎连接尝试逻辑
+     * 未连接每 1s 探活，已连接每 3s；上一轮未完成则跳过，避免 echo 堆积。
      * 引擎连接有效尝试次数: 1-10
      */
     useEffect(() => {
-      const keepalive = props.keepalive
-      if (!keepalive) {
-        if (props.onFailed) {
-          props.onFailed(100)
-        }
+      if (!props.keepalive) {
+        failedCountRef.current = 0
+        readyNotifiedRef.current = false
+        probingRef.current = false
+        props.onFailed?.(100)
         return
       }
       debugToPrintLog(`------ 开始启动引擎进程探活逻辑------`)
 
-      let count = 0
-      let failedCount = 0
-      let notified = false
       const connect = () => {
-        count++
+        if (probingRef.current) return
+        probingRef.current = true
         isEngineConnectionAlive()
           .then(() => {
-            // debugToPrintLog(`[INFO] 探活结果: 存活`)
-            if (!keepalive) {
-              return
-            }
-            if (!notified) {
-              notified = true
-            }
-            failedCount = 0
-            if (props.onReady) {
-              props.onReady()
+            if (!props.keepalive) return
+            failedCountRef.current = 0
+            if (!readyNotifiedRef.current) {
+              readyNotifiedRef.current = true
+              props.onReady?.()
             }
           })
-          .catch((e) => {
-            // debugToPrintLog(`[INFO] 探活结果: 不存在`)
-            failedCount++
-            if (props.onFailed) {
-              props.onFailed(failedCount)
-            }
+          .catch(() => {
+            failedCountRef.current += 1
+            readyNotifiedRef.current = false
+            props.onFailed?.(failedCountRef.current)
+          })
+          .finally(() => {
+            probingRef.current = false
           })
       }
       connect()
-      const id = setInterval(connect, attemptConnectTime())
+      const id = setInterval(connect, props.engineLink ? 3000 : 1000)
       return () => {
         clearInterval(id)
       }
-    }, [props.keepalive, props.onReady, props.onFailed])
+    }, [props.keepalive, props.engineLink, props.onReady, props.onFailed])
     return <></>
   },
 )

--- a/app/renderer/src/main/src/components/layout/__test__/FuncDomain.test.tsx
+++ b/app/renderer/src/main/src/components/layout/__test__/FuncDomain.test.tsx
@@ -38,7 +38,7 @@ const { startIdleVisibleInterval, queryRisks } = vi.hoisted(() => ({
 vi.mock('@/utils/scheduleIdleTask', () => ({ startIdleVisibleInterval }))
 
 vi.mock('@/services/electronBridge', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/services/electronBridge')>()
+  const actual = (await importOriginal()) as Record<string, unknown>
   return {
     ...actual,
     yakitRisk: {
@@ -79,7 +79,7 @@ vi.mock('@/utils/duplex/duplex', () => ({
 }))
 
 vi.mock('@/utils/envfile', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/utils/envfile')>()
+  const actual = (await importOriginal()) as Record<string, unknown>
   return {
     ...actual,
     isIRify: () => false,

--- a/app/renderer/src/main/src/components/layout/__test__/FuncDomain.test.tsx
+++ b/app/renderer/src/main/src/components/layout/__test__/FuncDomain.test.tsx
@@ -1,0 +1,278 @@
+vi.hoisted(() => {
+  ;(window as any).require = (id: string) => {
+    if (id === 'electron') {
+      return {
+        ipcRenderer: {
+          invoke: async () => ({}),
+          on: () => {},
+          off: () => {},
+          send: () => {},
+          removeAllListeners: () => {},
+        },
+      }
+    }
+    return {}
+  }
+  ;(window as any).matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  })
+})
+
+vi.mock('lottie-web', () => ({ default: vi.fn() }))
+
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { startIdleVisibleInterval, queryRisks } = vi.hoisted(() => ({
+  startIdleVisibleInterval: vi.fn(() => vi.fn()),
+  queryRisks: vi.fn(),
+}))
+
+vi.mock('@/utils/scheduleIdleTask', () => ({ startIdleVisibleInterval }))
+
+vi.mock('@/services/electronBridge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/electronBridge')>()
+  return {
+    ...actual,
+    yakitRisk: {
+      queryRisks,
+      fetchLatestInfo: vi.fn().mockResolvedValue({ Data: [], Total: 0, NewRiskTotal: 0, Unread: 0 }),
+    },
+    yakitStream: {
+      onData: vi.fn(() => vi.fn()),
+      onError: vi.fn(() => vi.fn()),
+      onEnd: vi.fn(() => vi.fn()),
+    },
+    yakitUILayout: {
+      cancelScreenRecorder: vi.fn(),
+      onOpenScreenCapModal: vi.fn(() => vi.fn()),
+      isScreenRecorderReady: vi.fn().mockResolvedValue({ Ok: false, Reason: '' }),
+      refreshMainMenu: vi.fn(),
+      requestOpenScreenCapModal: vi.fn(),
+      activateScreenshot: vi.fn(),
+    },
+    yakitEngine: new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          if (String(prop).startsWith('on')) return vi.fn(() => vi.fn())
+          return vi.fn().mockResolvedValue(undefined)
+        },
+      },
+    ),
+  }
+})
+
+vi.mock('@/i18n/useI18nNamespaces', () => ({
+  useI18nNamespaces: () => ({ t: (key: string) => key, i18n: { language: 'zh' }, i18nRefresh: 0 }),
+}))
+
+vi.mock('@/utils/duplex/duplex', () => ({
+  serverPushStatus: false,
+}))
+
+vi.mock('@/utils/envfile', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/envfile')>()
+  return {
+    ...actual,
+    isIRify: () => false,
+    isCommunityEdition: () => true,
+    isCommunityYakit: () => true,
+    isEnpriTrace: () => false,
+    isEnpriTraceAgent: () => false,
+    isMemfit: () => false,
+    isYakit: () => true,
+    showDevTool: () => false,
+    getReleaseEditionName: () => 'Yakit',
+    getCurrentVersionSource: () => 'community',
+  }
+})
+
+vi.mock('@/store', () => ({
+  useStore: () => ({ userInfo: { isLogin: false } }),
+  yakitDynamicStatus: () => ({
+    dynamicStatus: { isDynamicStatus: false },
+  }),
+  useEeSystemConfig: () => ({ eeSystemConfig: [] }),
+}))
+
+vi.mock('@/store/screenRecorder', () => ({
+  useScreenRecorder: () => ({
+    screenRecorderInfo: { token: 't', isRecording: false },
+    setRecording: vi.fn(),
+  }),
+}))
+
+vi.mock('@/store/runNode', () => ({
+  useRunNodeStore: () => ({ runNodeList: new Map() }),
+}))
+
+vi.mock('@/store/temporaryProject', () => ({
+  useTemporaryProjectStore: () => ({ delTemporaryProject: vi.fn() }),
+}))
+
+vi.mock('@/store/performanceSampling', () => ({
+  usePerformanceSampling: () => ({
+    performanceSamplingInfo: { isSampling: false, isPerformanceSampling: false, token: '', log: [] },
+    setPerformanceSamplingLog: vi.fn(),
+    setSampling: vi.fn(),
+  }),
+}))
+
+vi.mock('../userMenu/useUserMenu', () => ({
+  useUserMenu: () => ({
+    userMenu: [],
+    ceUserMenuShow: false,
+    setCeUserMenuShow: vi.fn(),
+    usageStatisticsShow: false,
+    setUsageStatisticsShow: vi.fn(),
+    rechargeVisible: false,
+    setRechargeVisible: vi.fn(),
+    apiKeys: '',
+    apiKeysInfo: {},
+    apiKeysInfoLoading: false,
+    onUpdateApiKey: vi.fn(),
+    passwordShow: false,
+    setPasswordShow: vi.fn(),
+    passwordClose: vi.fn(),
+    uploadModalShow: false,
+    setUploadModalShow: vi.fn(),
+    dynamicControlModal: false,
+    setDynamicControlModal: vi.fn(),
+    controlMyselfModal: false,
+    setControlMyselfModal: vi.fn(),
+    controlOtherModal: false,
+    setControlOtherModal: vi.fn(),
+    dynamicMenuOpen: false,
+    setDynamicMenuOpen: vi.fn(),
+    robotControlModal: false,
+    setRobotControlModal: vi.fn(),
+    imControlBadge: 0,
+    imControlStatus: '',
+    refreshIMControlStatus: vi.fn(),
+    onUserMenuClick: vi.fn(),
+    loginShow: false,
+    setLoginShow: vi.fn(),
+  }),
+}))
+
+vi.mock('../hooks/useEngineConsole/useEngineConsole', () => ({
+  default: () => undefined,
+}))
+
+vi.mock('../update/useDownloadYakit', () => ({
+  useDownloadYakit: () => ({ downloadProgress: 0 }),
+}))
+
+vi.mock('../../MessageCenter/useEETaskNotificationHook', () => ({
+  useEETaskNotificationHook: () => ({
+    taskModalInfo: {},
+    taskErrModalInfo: {},
+    debugTaskEvent: {},
+  }),
+}))
+
+vi.mock('@/pages/layout/NotepadMenu/NotepadMenu', () => ({
+  NotepadMenu: () => null,
+}))
+
+vi.mock('../userMenu/UserMenuModals', () => ({
+  UserMenuModals: () => null,
+}))
+
+vi.mock('../userMenu/UserAvatarIMBadge', () => ({
+  UserAvatarIMBadge: () => null,
+}))
+
+vi.mock('../../CeUserMenu/CeRechargeModal', () => ({
+  default: () => null,
+}))
+
+vi.mock('../userMenu/constants', () => ({
+  randomAvatarColor: () => '#000',
+}))
+
+vi.mock('@/utils/eventBus/eventBus', () => ({
+  default: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+}))
+
+vi.mock('@/utils/notification', () => ({
+  failed: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  yakitFailed: vi.fn(),
+  yakitNotify: vi.fn(),
+}))
+
+vi.mock('@/hook/useHoldGRPCStream/useHoldGRPCStream', () => ({
+  default: () => [
+    { progressState: [], logState: [] },
+    { stop: vi.fn(), start: vi.fn(), reset: vi.fn() },
+  ],
+}))
+
+import { FuncDomain } from '../FuncDomain'
+import type { FuncDomainProp } from '../FuncDomain'
+
+const baseProps: FuncDomainProp = {
+  isEngineLink: true,
+  engineMode: 'local',
+  isRemoteMode: false,
+  onEngineModeChange: vi.fn(),
+  typeCallback: vi.fn(),
+  runDynamicControlRemote: vi.fn(),
+  isJudgeLicense: true,
+  system: 'Windows_NT',
+  onDevToolRefresh: vi.fn(),
+  showProjectManage: false,
+}
+
+describe('FuncDomain 风险轮询卸载竞态', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('queryRisks 完成前卸载则不再启动轮询', async () => {
+    let resolveQuery: ((value: { Data: { Id: number }[] }) => void) | undefined
+    queryRisks.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveQuery = resolve
+        }),
+    )
+
+    const { unmount } = render(<FuncDomain {...baseProps} />)
+    expect(queryRisks).toHaveBeenCalled()
+    expect(startIdleVisibleInterval).not.toHaveBeenCalled()
+
+    unmount()
+    await act(async () => {
+      resolveQuery?.({ Data: [] })
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(startIdleVisibleInterval).not.toHaveBeenCalled()
+  })
+
+  it('引擎已连接且请求完成后启动轮询', async () => {
+    queryRisks.mockResolvedValue({ Data: [] })
+    render(<FuncDomain {...baseProps} />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(startIdleVisibleInterval).toHaveBeenCalled()
+  })
+})

--- a/app/renderer/src/main/src/components/layout/__test__/GlobalState.test.tsx
+++ b/app/renderer/src/main/src/components/layout/__test__/GlobalState.test.tsx
@@ -1,0 +1,181 @@
+vi.hoisted(() => {
+  ;(window as any).require = (id: string) => {
+    if (id === 'electron') {
+      return {
+        ipcRenderer: {
+          invoke: async () => ({}),
+          on: () => {},
+          off: () => {},
+          send: () => {},
+          removeAllListeners: () => {},
+        },
+      }
+    }
+    return {}
+  }
+})
+
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RemoteGV } from '@/yakitGV'
+
+const { startIdleVisibleInterval, setRemoteValue, getRemoteValue } = vi.hoisted(() => ({
+  startIdleVisibleInterval: vi.fn(() => vi.fn()),
+  setRemoteValue: vi.fn().mockResolvedValue(undefined),
+  getRemoteValue: vi.fn().mockResolvedValue(''),
+}))
+
+vi.mock('@/utils/scheduleIdleTask', () => ({ startIdleVisibleInterval }))
+
+vi.mock('@/utils/kv', () => ({
+  getRemoteValue,
+  setRemoteValue,
+  getLocalValue: vi.fn().mockResolvedValue(''),
+  setLocalValue: vi.fn(),
+}))
+
+vi.mock('@/i18n/useI18nNamespaces', () => ({
+  useI18nNamespaces: () => ({ t: (key: string) => key, i18n: { language: 'zh' }, i18nRefresh: 0 }),
+}))
+
+vi.mock('@/utils/envfile', () => ({
+  isEnpriTraceAgent: () => false,
+  isIRify: () => false,
+}))
+
+vi.mock('@/utils/duplex/duplex', () => ({
+  serverPushStatus: false,
+}))
+
+vi.mock('@/utils/eventBus/eventBus', () => ({
+  default: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+}))
+
+vi.mock('@/utils/notification', () => ({
+  failed: vi.fn(),
+  info: vi.fn(),
+  yakitFailed: vi.fn(),
+  yakitNotify: vi.fn(),
+}))
+
+vi.mock('@/store/runNode', () => ({
+  useRunNodeStore: () => ({ runNodeList: new Map() }),
+}))
+
+vi.mock('@/services/electronBridge', () => ({
+  yakitApp: { setZoomFactor: vi.fn() },
+  yakitHost: {},
+  yakitPlugin: { queryYakScript: vi.fn().mockResolvedValue({ Total: 1, Data: [] }) },
+  yakitReverse: {
+    config: vi.fn().mockResolvedValue({}),
+    setYakBridgeLogServer: vi.fn().mockResolvedValue({}),
+    getGlobalReverseServer: vi.fn().mockResolvedValue({}),
+  },
+}))
+
+vi.mock('@/components/yakitUI/YakitInputNumber/YakitInputNumber', () => ({
+  YakitInputNumber: ({
+    onChange,
+    value,
+    formatter,
+  }: {
+    onChange?: (v: number) => void
+    value?: number
+    formatter?: (v: number) => string
+  }) => (
+    <input
+      data-testid={String(formatter?.(1) || '').includes('s') ? 'time-interval' : 'zoom-scale'}
+      value={value}
+      onChange={(e) => onChange?.(Number(e.target.value))}
+    />
+  ),
+}))
+
+vi.mock('@/components/yakitUI/YakitPopover/YakitPopover', () => ({
+  YakitPopover: ({ children, content }: { children?: React.ReactNode; content?: React.ReactNode }) => (
+    <div>
+      {children}
+      {content}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/yakitUI/YakitButton/YakitButton', () => ({
+  YakitButton: ({ children, onClick }: { children?: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+}))
+
+vi.mock('@/components/yakitUI/YakitHint/YakitHint', () => ({
+  YakitHint: () => null,
+}))
+
+vi.mock('@/components/yakitUI/YakitTag/YakitTag', () => ({
+  YakitTag: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock('@/components/yakitUI/YakitCheckbox/YakitCheckbox', () => ({
+  YakitCheckbox: () => null,
+}))
+
+vi.mock('@/pages/mitm/MITMServerHijacking/MITMPluginOnline', () => ({
+  YakitGetOnlinePlugin: () => null,
+}))
+
+vi.mock('@/apiUtils/grpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/apiUtils/grpc')>()
+  return {
+    ...actual,
+    grpcFetchBuildInYakVersion: vi.fn().mockResolvedValue('dev'),
+    grpcFetchLocalYakVersion: vi.fn().mockResolvedValue('dev'),
+    grpcFetchSpecifiedYakVersionHash: vi.fn().mockResolvedValue(''),
+    grpcFetchLocalYakVersionHash: vi.fn().mockResolvedValue(''),
+  }
+})
+
+import { GlobalState } from '../GlobalState'
+
+const mcp = {
+  mcpStreamInfo: {
+    mcpCurrent: null,
+    mcpServerUrl: '',
+  },
+} as any
+
+describe('GlobalState 间隔持久化与连接状态', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    startIdleVisibleInterval.mockClear()
+    setRemoteValue.mockClear()
+    getRemoteValue.mockClear()
+    getRemoteValue.mockResolvedValue('')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('修改刷新间隔会写入 remote 配置', async () => {
+    render(<GlobalState isEngineLink={false} system="Windows_NT" mcp={mcp} />)
+
+    const input = screen.getByTestId('time-interval')
+    fireEvent.change(input, { target: { value: '8' } })
+    expect(setRemoteValue).toHaveBeenCalledWith(RemoteGV.GlobalStateTimeInterval, '8')
+  })
+
+  it('引擎连接时读取间隔配置，断开时停止沿用连接态副作用', async () => {
+    const { rerender } = render(<GlobalState isEngineLink system="Windows_NT" mcp={mcp} />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(getRemoteValue).toHaveBeenCalledWith(RemoteGV.GlobalStateTimeInterval)
+
+    getRemoteValue.mockClear()
+    rerender(<GlobalState isEngineLink={false} system="Windows_NT" mcp={mcp} />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(getRemoteValue).not.toHaveBeenCalledWith(RemoteGV.GlobalStateTimeInterval)
+  })
+})

--- a/app/renderer/src/main/src/components/layout/__test__/GlobalState.test.tsx
+++ b/app/renderer/src/main/src/components/layout/__test__/GlobalState.test.tsx
@@ -123,7 +123,7 @@ vi.mock('@/pages/mitm/MITMServerHijacking/MITMPluginOnline', () => ({
 }))
 
 vi.mock('@/apiUtils/grpc', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/apiUtils/grpc')>()
+  const actual = (await importOriginal()) as Record<string, unknown>
   return {
     ...actual,
     grpcFetchBuildInYakVersion: vi.fn().mockResolvedValue('dev'),

--- a/app/renderer/src/main/src/components/layout/__test__/PerformanceDisplay.test.tsx
+++ b/app/renderer/src/main/src/components/layout/__test__/PerformanceDisplay.test.tsx
@@ -1,0 +1,160 @@
+vi.hoisted(() => {
+  ;(window as any).require = (id: string) => {
+    if (id === 'electron') {
+      return {
+        ipcRenderer: {
+          invoke: async () => ({}),
+          on: () => {},
+          off: () => {},
+          send: () => {},
+          removeAllListeners: () => {},
+        },
+      }
+    }
+    return {}
+  }
+})
+
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PerformanceDisplay } from '../PerformanceDisplay'
+import { yakitPerf } from '@/services/electronBridge'
+
+vi.mock('@/services/electronBridge', () => ({
+  yakitPerf: {
+    startComputePercent: vi.fn(),
+    clearComputePercent: vi.fn(),
+    fetchComputePercent: vi.fn(),
+  },
+  yakitEngine: {
+    listYakGrpc: vi.fn().mockResolvedValue([]),
+    fetchYaklangEngineAddr: vi.fn().mockResolvedValue({ addr: '127.0.0.1:9011' }),
+    killYakGrpc: vi.fn(),
+  },
+  yakitApp: {},
+  yakitUILayout: {},
+}))
+
+vi.mock('@/i18n/useI18nNamespaces', () => ({
+  useI18nNamespaces: () => ({ t: (key: string) => key, i18nRefresh: 0 }),
+}))
+
+vi.mock('@/utils/eventBus/eventBus', () => ({
+  default: { on: vi.fn(), off: vi.fn() },
+}))
+
+vi.mock('@/utils/notification', () => ({
+  failed: vi.fn(),
+  info: vi.fn(),
+  success: vi.fn(),
+  yakitNotify: vi.fn(),
+}))
+
+vi.mock('@/store/runNode', () => ({
+  useRunNodeStore: () => ({ runNodeList: new Map() }),
+}))
+
+vi.mock('@/store/temporaryProject', () => ({
+  useTemporaryProjectStore: () => ({ delTemporaryProject: vi.fn() }),
+}))
+
+vi.mock('@/store', () => ({
+  yakitDynamicStatus: () => ({
+    dynamicStatus: { isDynamicStatus: false },
+  }),
+}))
+
+vi.mock('@/utils/envfile', () => ({
+  getReleaseEditionName: () => 'Yakit',
+  isEnpriTraceAgent: () => false,
+}))
+
+vi.mock('../YakitGlobalHost', () => ({
+  YakitGlobalHost: () => null,
+}))
+
+vi.mock('@/components/yakitUI/YakitPopover/YakitPopover', () => ({
+  YakitPopover: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/yakitUI/YakitButton/YakitButton', () => ({
+  YakitButton: ({ children }: { children?: React.ReactNode }) => <button>{children}</button>,
+}))
+
+vi.mock('@/components/yakitUI/YakitTag/YakitTag', () => ({
+  YakitTag: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock('@/components/yakitUI/YakitPopconfirm/YakitPopconfirm', () => ({
+  YakitPopconfirm: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/yakitUI/YakitModal/YakitModalConfirm', () => ({
+  showYakitModal: vi.fn(),
+}))
+
+vi.mock('react-sparklines', () => ({
+  Sparklines: () => null,
+  SparklinesCurve: () => null,
+}))
+
+describe('PerformanceDisplay CPU 采集', () => {
+  let mockHidden = false
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('requestIdleCallback', undefined)
+    vi.stubGlobal('cancelIdleCallback', undefined)
+    mockHidden = false
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => mockHidden })
+    vi.mocked(yakitPerf.startComputePercent).mockReset()
+    vi.mocked(yakitPerf.clearComputePercent).mockReset()
+    vi.mocked(yakitPerf.fetchComputePercent).mockReset()
+    vi.mocked(yakitPerf.fetchComputePercent).mockResolvedValue([10])
+  })
+
+  afterEach(() => {
+    delete (document as any).hidden
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('空闲后启动 CPU 采集', async () => {
+    render(<PerformanceDisplay engineMode="local" typeCallback={vi.fn()} engineLink />)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(yakitPerf.startComputePercent).toHaveBeenCalledTimes(1)
+    expect(yakitPerf.fetchComputePercent).toHaveBeenCalled()
+  })
+
+  it('页面隐藏时停止采集且不再拉取', async () => {
+    render(<PerformanceDisplay engineMode="local" typeCallback={vi.fn()} engineLink />)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    const fetches = vi.mocked(yakitPerf.fetchComputePercent).mock.calls.length
+
+    mockHidden = true
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(yakitPerf.clearComputePercent).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+    expect(yakitPerf.fetchComputePercent).toHaveBeenCalledTimes(fetches)
+  })
+
+  it('卸载时停止 CPU 采集', async () => {
+    const { unmount } = render(<PerformanceDisplay engineMode="local" typeCallback={vi.fn()} engineLink />)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    unmount()
+    expect(yakitPerf.clearComputePercent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/renderer/src/main/src/components/layout/__test__/UILayout.test.tsx
+++ b/app/renderer/src/main/src/components/layout/__test__/UILayout.test.tsx
@@ -36,7 +36,7 @@ const { startIdleVisibleInterval, grpcFetchYakInstallResult } = vi.hoisted(() =>
 vi.mock('@/utils/scheduleIdleTask', () => ({ startIdleVisibleInterval }))
 
 vi.mock('@/apiUtils/grpc', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/apiUtils/grpc')>()
+  const actual = (await importOriginal()) as Record<string, unknown>
   return {
     ...actual,
     grpcFetchYakInstallResult,
@@ -46,7 +46,7 @@ vi.mock('@/apiUtils/grpc', async (importOriginal) => {
 
 vi.mock('@/components/layout/YaklangEngineWatchDog', () => ({
   YaklangEngineWatchDog: ({ onReady }: { onReady?: () => void }) => {
-    const { useEffect } = require('react') as typeof import('react')
+    const { useEffect } = require('react')
     useEffect(() => {
       onReady?.()
     }, [])
@@ -59,7 +59,7 @@ vi.mock('@/i18n/useI18nNamespaces', () => ({
 }))
 
 vi.mock('@/utils/envfile', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/utils/envfile')>()
+  const actual = (await importOriginal()) as Record<string, unknown>
   return {
     ...actual,
     isEnpriTraceAgent: () => true,
@@ -136,7 +136,7 @@ vi.mock('@/constants/hardware', () => ({
 }))
 
 vi.mock('@/services/electronBridge', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/services/electronBridge')>()
+  const actual = (await importOriginal()) as Record<string, unknown>
   const unsubscribe = () => undefined
   return {
     ...actual,
@@ -235,14 +235,20 @@ vi.mock('@/pages/yakRunner/BottomEditorDetails/TerminalBox/TerminalMap', () => (
   clearTerminalMap: vi.fn(),
   getMapAllTerminalKey: () => [],
 }))
-vi.mock('@/pages/pluginHub/hooks/useGetSetState', () => ({
-  default: (init: unknown) => {
-    const React = require('react') as typeof import('react')
-    const [v, setV] = React.useState(init)
-    const get = () => v
-    return [v, setV, get]
-  },
-}))
+vi.mock('@/pages/pluginHub/hooks/useGetSetState', () => {
+  const { useRef, useState } = require('react')
+  const useGetSetState = (init?: unknown) => {
+    const [v, setV] = useState(init)
+    const ref = useRef(init)
+    const set = (next: unknown) => {
+      const value = typeof next === 'function' ? (next as (prev: unknown) => unknown)(ref.current) : next
+      ref.current = value
+      setV(value)
+    }
+    return [v, set, () => ref.current]
+  }
+  return { default: useGetSetState }
+})
 
 import UILayout from '../UILayout'
 

--- a/app/renderer/src/main/src/components/layout/__test__/UILayout.test.tsx
+++ b/app/renderer/src/main/src/components/layout/__test__/UILayout.test.tsx
@@ -1,0 +1,267 @@
+vi.hoisted(() => {
+  ;(window as any).require = (id: string) => {
+    if (id === 'electron') {
+      return {
+        ipcRenderer: {
+          invoke: async () => ({}),
+          on: () => {},
+          off: () => {},
+          send: () => {},
+          removeAllListeners: () => {},
+        },
+      }
+    }
+    return {}
+  }
+  ;(window as any).matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  })
+})
+
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { startIdleVisibleInterval, grpcFetchYakInstallResult } = vi.hoisted(() => ({
+  startIdleVisibleInterval: vi.fn(() => vi.fn()),
+  grpcFetchYakInstallResult: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('@/utils/scheduleIdleTask', () => ({ startIdleVisibleInterval }))
+
+vi.mock('@/apiUtils/grpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/apiUtils/grpc')>()
+  return {
+    ...actual,
+    grpcFetchYakInstallResult,
+    grpcFetchLatestYakVersion: vi.fn().mockResolvedValue(''),
+  }
+})
+
+vi.mock('@/components/layout/YaklangEngineWatchDog', () => ({
+  YaklangEngineWatchDog: ({ onReady }: { onReady?: () => void }) => {
+    const { useEffect } = require('react') as typeof import('react')
+    useEffect(() => {
+      onReady?.()
+    }, [])
+    return null
+  },
+}))
+
+vi.mock('@/i18n/useI18nNamespaces', () => ({
+  useI18nNamespaces: () => ({ t: (key: string) => key, i18n: { language: 'zh' }, i18nRefresh: 0 }),
+}))
+
+vi.mock('@/utils/envfile', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/envfile')>()
+  return {
+    ...actual,
+    isEnpriTraceAgent: () => true,
+    isEnpriTrace: () => false,
+    isEnterpriseEdition: () => false,
+    isCommunityYakit: () => false,
+    isCommunityEdition: () => false,
+    isMemfit: () => false,
+    isIRify: () => false,
+    getReleaseEditionName: () => 'Yakit',
+    GetConnectPort: () => 9011,
+  }
+})
+
+vi.mock('@/utils/kv', () => ({
+  getRemoteValue: vi.fn().mockResolvedValue(''),
+  setRemoteValue: vi.fn(),
+  getLocalValue: vi.fn().mockResolvedValue(''),
+  setLocalValue: vi.fn(),
+}))
+
+vi.mock('@/utils/eventBus/eventBus', () => ({
+  default: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+}))
+
+vi.mock('@/utils/notification', () => ({
+  failed: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  yakitFailed: vi.fn(),
+  yakitNotify: vi.fn(),
+}))
+
+vi.mock('@/store', () => ({
+  useStore: () => ({ userInfo: { isLogin: false } }),
+  yakitDynamicStatus: () => ({
+    dynamicStatus: { isDynamicStatus: false },
+    setDynamicStatus: vi.fn(),
+  }),
+  useEeSystemConfig: () => ({ eeSystemConfig: [] }),
+}))
+
+vi.mock('@/store/temporaryProject', () => ({
+  useTemporaryProjectStore: () => ({
+    setTemporaryProjectNoPromptFlag: vi.fn(),
+    temporaryProjectId: '',
+  }),
+}))
+
+vi.mock('@/store/screenRecorder', () => ({
+  useScreenRecorder: () => ({
+    screenRecorderInfo: { isRecording: false, token: '' },
+    setRecording: vi.fn(),
+  }),
+}))
+
+vi.mock('@/store/performanceSampling', () => ({
+  usePerformanceSampling: () => ({
+    performanceSamplingInfo: { isSampling: false, log: [] },
+    resetPerformanceSampling: vi.fn(),
+  }),
+}))
+
+vi.mock('@/store/yakMcpStream', () => ({
+  useSyncYakMcpStream: () => ({
+    mcpStreamInfo: { mcpCurrent: null, mcpServerUrl: '' },
+  }),
+}))
+
+vi.mock('@/constants/hardware', () => ({
+  SystemInfo: { isDev: false },
+  handleFetchArchitecture: vi.fn(),
+  handleFetchIsDev: vi.fn(),
+}))
+
+vi.mock('@/services/electronBridge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/electronBridge')>()
+  const unsubscribe = () => undefined
+  return {
+    ...actual,
+    yakitUILayout: new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          if (String(prop).startsWith('on')) return vi.fn(() => unsubscribe)
+          return vi.fn().mockResolvedValue(undefined)
+        },
+      },
+    ),
+  }
+})
+
+vi.mock('lottie-web', () => ({ default: vi.fn() }))
+vi.mock('../basics/NewYakitLoading', () => ({
+  NewYakitLoading: () => null,
+}))
+
+vi.mock('@/utils/duplex/duplex', () => ({
+  closeDuplexConn: vi.fn(),
+  startupDuplexConn: vi.fn(),
+  serverPushStatus: false,
+}))
+
+vi.mock('@/store/softMode', () => ({
+  useSoftMode: () => ({ softMode: '', setSoftMode: vi.fn() }),
+}))
+
+vi.mock('@/utils/visitorsStatistics', () => ({
+  visitorsStatisticsFun: vi.fn(),
+}))
+
+vi.mock('@/pages/dynamicControl/remoteOperation', () => ({
+  remoteOperation: vi.fn(),
+}))
+
+vi.mock('@/pages/spaceEngine/utils', () => ({
+  handleAIConfig: vi.fn(),
+  apiGetGlobalNetworkConfig: vi.fn().mockResolvedValue({}),
+  apiSetGlobalNetworkConfig: vi.fn(),
+}))
+
+vi.mock('@/components/yakitUI/YakitModal/YakitModalConfirm', () => ({
+  showYakitModal: vi.fn(),
+}))
+
+vi.mock('@/utils/openWebsite', () => ({
+  openABSFileLocated: vi.fn(),
+}))
+
+vi.mock('@/utils/logCollection', () => ({
+  debugToPrintLog: vi.fn(),
+}))
+
+vi.mock('@/utils/getMainOperatorPageBodyContainer', () => ({
+  getMainOperatorPageBodyContainer: () => document.body,
+}))
+
+vi.mock('../utils', () => ({
+  apiSplitUpload: vi.fn(),
+  grpcExportProject: vi.fn(),
+  grpcGetProjects: vi.fn().mockResolvedValue({ Projects: [] }),
+}))
+
+vi.mock('@/pages/pluginHub/utils/grpc', () => ({
+  grpcFetchLocalPluginDetail: vi.fn(),
+}))
+
+vi.mock('../MacUIOp', () => ({ MacUIOp: () => null }))
+vi.mock('../WinUIOp', () => ({ WinUIOp: () => null, TemporaryProjectPop: () => null }))
+vi.mock('../PerformanceDisplay', () => ({ PerformanceDisplay: () => null }))
+vi.mock('../FuncDomain', () => ({ FuncDomain: () => null, UIOpNotice: () => null }))
+vi.mock('../GlobalState', () => ({ GlobalState: () => null }))
+vi.mock('../AllKillEngineConfirm', () => ({ AllKillEngineConfirm: () => null }))
+vi.mock('../basics/YakitLoading', () => ({ EngineModeVerbose: () => 'local' }))
+vi.mock('@/components/yakitUI/YakitButton/YakitButton', () => ({
+  YakitButton: ({ children }: { children?: React.ReactNode }) => <button>{children}</button>,
+}))
+vi.mock('@/components/yakitUI/YakitHint/YakitHint', () => ({ YakitHint: () => null }))
+vi.mock('@/components/yakitUI/YakitSpin/YakitSpin', () => ({
+  YakitSpin: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}))
+vi.mock('@/components/yakitUI/YakitPopover/YakitPopover', () => ({
+  YakitPopover: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}))
+vi.mock('@/pages/softwareSettings/ProjectManage', () => ({
+  NewProjectAndFolder: () => null,
+  TransferProject: () => null,
+}))
+vi.mock('@/pages/mitm/MITMServerHijacking/MITMPluginOnline', () => ({
+  YakitGetOnlinePlugin: () => null,
+}))
+vi.mock('@/pages/yakRunner/BottomEditorDetails/TerminalBox/TerminalMap', () => ({
+  clearTerminalMap: vi.fn(),
+  getMapAllTerminalKey: () => [],
+}))
+vi.mock('@/pages/pluginHub/hooks/useGetSetState', () => ({
+  default: (init: unknown) => {
+    const React = require('react') as typeof import('react')
+    const [v, setV] = React.useState(init)
+    const get = () => v
+    return [v, setV, get]
+  },
+}))
+
+import UILayout from '../UILayout'
+
+describe('UILayout 引擎连接后的安装探测轮询', () => {
+  beforeEach(() => {
+    startIdleVisibleInterval.mockClear()
+    grpcFetchYakInstallResult.mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('探活 Ready 后置 engineLink 并启动引擎安装探测', async () => {
+    render(<UILayout />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(startIdleVisibleInterval).toHaveBeenCalled()
+  })
+})

--- a/app/renderer/src/main/src/components/layout/__test__/YakitGlobalHost.test.tsx
+++ b/app/renderer/src/main/src/components/layout/__test__/YakitGlobalHost.test.tsx
@@ -1,0 +1,65 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { YakitGlobalHost } from '../YakitGlobalHost'
+import { yakitEngine } from '@/services/electronBridge'
+
+vi.mock('@/services/electronBridge', () => ({
+  yakitEngine: {
+    fetchYaklangEngineAddr: vi.fn(),
+  },
+}))
+
+describe('YakitGlobalHost', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('requestIdleCallback', undefined)
+    vi.stubGlobal('cancelIdleCallback', undefined)
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => false })
+    vi.mocked(yakitEngine.fetchYaklangEngineAddr).mockReset()
+    vi.mocked(yakitEngine.fetchYaklangEngineAddr).mockResolvedValue({ addr: '127.0.0.1:9011' })
+  })
+
+  afterEach(() => {
+    delete (document as any).hidden
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('引擎未连接时展示占位且不轮询地址', () => {
+    render(<YakitGlobalHost isEngineLink={false} />)
+
+    expect(screen.getAllByText('??')).toHaveLength(2)
+    expect(yakitEngine.fetchYaklangEngineAddr).not.toHaveBeenCalled()
+  })
+
+  it('引擎已连接后轮询并展示地址', async () => {
+    render(<YakitGlobalHost isEngineLink={true} />)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+      await Promise.resolve()
+    })
+    expect(yakitEngine.fetchYaklangEngineAddr).toHaveBeenCalled()
+    expect(screen.getByText(/127\.0\.0\.1/)).toBeInTheDocument()
+    expect(screen.getByText('9011')).toBeInTheDocument()
+  })
+
+  it('断开连接后停止轮询并回到占位', async () => {
+    const { rerender } = render(<YakitGlobalHost isEngineLink={true} />)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+      await Promise.resolve()
+    })
+    expect(screen.getByText(/127\.0\.0\.1/)).toBeInTheDocument()
+    const calls = vi.mocked(yakitEngine.fetchYaklangEngineAddr).mock.calls.length
+
+    rerender(<YakitGlobalHost isEngineLink={false} />)
+    expect(screen.getAllByText('??')).toHaveLength(2)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+    expect(yakitEngine.fetchYaklangEngineAddr).toHaveBeenCalledTimes(calls)
+  })
+})

--- a/app/renderer/src/main/src/components/layout/__test__/YaklangEngineWatchDog.test.tsx
+++ b/app/renderer/src/main/src/components/layout/__test__/YaklangEngineWatchDog.test.tsx
@@ -106,6 +106,7 @@ describe('YaklangEngineWatchDog 组件测试', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.clearAllMocks()
   })
 
@@ -213,6 +214,60 @@ describe('YaklangEngineWatchDog 组件测试', () => {
       await waitFor(() => {
         expect(props.onFailed).toHaveBeenCalled()
       })
+    })
+
+    it('探活持续成功时只回调一次 onReady，未连接时仍每 1s 探测', async () => {
+      vi.useFakeTimers()
+      props.keepalive = true
+      vi.mocked(isEngineConnectionAlive).mockResolvedValue(true)
+      render(<YaklangEngineWatchDog {...props} />)
+
+      await vi.runOnlyPendingTimersAsync()
+      expect(props.onReady).toHaveBeenCalledTimes(1)
+      const aliveCalls = vi.mocked(isEngineConnectionAlive).mock.calls.length
+
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(isEngineConnectionAlive).toHaveBeenCalledTimes(aliveCalls + 1)
+      expect(props.onReady).toHaveBeenCalledTimes(1)
+    })
+
+    it('引擎已连接后探活间隔为 3s', async () => {
+      vi.useFakeTimers()
+      props.keepalive = true
+      props.engineLink = true
+      vi.mocked(isEngineConnectionAlive).mockResolvedValue(true)
+      render(<YaklangEngineWatchDog {...props} />)
+
+      await vi.runOnlyPendingTimersAsync()
+      const aliveCalls = vi.mocked(isEngineConnectionAlive).mock.calls.length
+
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(isEngineConnectionAlive).toHaveBeenCalledTimes(aliveCalls)
+
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(isEngineConnectionAlive).toHaveBeenCalledTimes(aliveCalls + 1)
+    })
+
+    it('上一轮探活未完成时跳过本轮，避免请求堆积', async () => {
+      vi.useFakeTimers()
+      props.keepalive = true
+      let resolveAlive: ((value: boolean) => void) | undefined
+      vi.mocked(isEngineConnectionAlive).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveAlive = resolve
+          }),
+      )
+      render(<YaklangEngineWatchDog {...props} />)
+
+      expect(isEngineConnectionAlive).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(isEngineConnectionAlive).toHaveBeenCalledTimes(1)
+
+      resolveAlive?.(true)
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(isEngineConnectionAlive).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/app/renderer/src/main/src/components/layout/__test__/YaklangEngineWatchDog.test.tsx
+++ b/app/renderer/src/main/src/components/layout/__test__/YaklangEngineWatchDog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { YaklangEngineWatchDog } from '../YaklangEngineWatchDog'
 import type { YaklangEngineWatchDogProps } from '../YaklangEngineWatchDog'
 import emiter from '@/utils/eventBus/eventBus'
@@ -248,26 +248,25 @@ describe('YaklangEngineWatchDog 组件测试', () => {
       expect(isEngineConnectionAlive).toHaveBeenCalledTimes(aliveCalls + 1)
     })
 
-    it('上一轮探活未完成时跳过本轮，避免请求堆积', async () => {
+    it('上一轮探活未完成时仍继续探测，避免单次挂起阻断失败通知', async () => {
       vi.useFakeTimers()
       props.keepalive = true
-      let resolveAlive: ((value: boolean) => void) | undefined
-      vi.mocked(isEngineConnectionAlive).mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            resolveAlive = resolve
-          }),
-      )
+      let call = 0
+      vi.mocked(isEngineConnectionAlive).mockImplementation(() => {
+        call += 1
+        if (call === 1) return new Promise(() => {})
+        return Promise.reject(new Error('fail'))
+      })
       render(<YaklangEngineWatchDog {...props} />)
 
       expect(isEngineConnectionAlive).toHaveBeenCalledTimes(1)
-      await vi.advanceTimersByTimeAsync(1000)
-      expect(isEngineConnectionAlive).toHaveBeenCalledTimes(1)
+      expect(props.onFailed).not.toHaveBeenCalled()
 
-      resolveAlive?.(true)
-      await Promise.resolve()
-      await vi.advanceTimersByTimeAsync(1000)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000)
+      })
       expect(isEngineConnectionAlive).toHaveBeenCalledTimes(2)
+      expect(props.onFailed).toHaveBeenCalledWith(1)
     })
   })
 })

--- a/app/renderer/src/main/src/newApp/NewApp.tsx
+++ b/app/renderer/src/main/src/newApp/NewApp.tsx
@@ -141,8 +141,6 @@ function NewApp() {
     testYak()
   }
 
-  /** 定时器 */
-  const timeRef = useRef<NodeJS.Timeout>()
   const testYak = () => {
     getRemoteValue(getRemoteHttpSettingGV()).then((setting) => {
       if (!setting) {
@@ -152,9 +150,6 @@ function NewApp() {
             yakitApp.syncEditBaseUrl(data.BaseUrl)
             setRemoteValue(getRemoteHttpSettingGV(), JSON.stringify({ BaseUrl: data.BaseUrl }))
             refreshLogin()
-            timeRef.current = setTimeout(() => {
-              if (timeRef.current) clearTimeout(timeRef.current)
-            }, 200)
           })
           .catch((e) => {
             failed(t('NewApp.fetchFailed', { error: String(e) }))
@@ -170,9 +165,6 @@ function NewApp() {
             yakitApp.syncEditBaseUrl(values.BaseUrl)
             setRemoteValue(getRemoteHttpSettingGV(), JSON.stringify(values))
             refreshLogin()
-            timeRef.current = setTimeout(() => {
-              if (timeRef.current) clearTimeout(timeRef.current)
-            }, 200)
           })
           .catch((e: any) => failed(t('NewApp.setPrivateDomainFailed', { error: String(e) })))
       }

--- a/app/renderer/src/main/src/pages/MainOperator.tsx
+++ b/app/renderer/src/main/src/pages/MainOperator.tsx
@@ -18,6 +18,7 @@ import { useEeSystemConfig, type UserInfoProps, useStore, yakitDynamicStatus } f
 import type { SimpleQueryYakScriptSchema } from './invoker/batch/QueryYakScriptParam'
 import { refreshToken } from '@/utils/login'
 import { getLocalValue, getRemoteValue, setLocalValue, setRemoteValue } from '@/utils/kv'
+import { startIdleVisibleInterval } from '@/utils/scheduleIdleTask'
 import { NetWorkApi } from '@/services/fetch'
 import type { API } from '@/services/swagger/resposeType'
 import {
@@ -333,9 +334,9 @@ const Main: React.FC<MainProp> = React.memo((props) => {
   const [controlShow, setControlShow] = useState<boolean>(false)
   const [controlName, setControlName] = useState<string>('')
   const { dynamicStatus, setDynamicStatus } = yakitDynamicStatus()
-  // 定时器监听是否连接/断开
+  // 定时器监听是否连接/断开：空闲后再开，页面隐藏时跳过
   useEffect(() => {
-    const id = setInterval(() => {
+    const cancel = startIdleVisibleInterval(() => {
       // 当服务启动时 请求接口
       ipcRenderer.invoke('alive-dynamic-control-status').then((is: boolean) => {
         if (is) {
@@ -371,7 +372,7 @@ const Main: React.FC<MainProp> = React.memo((props) => {
     })
 
     return () => {
-      clearInterval(id)
+      cancel()
       ipcRenderer.removeAllListeners('lougin-out-dynamic-control-page-callback')
     }
   }, [])

--- a/app/renderer/src/main/src/pages/__test__/MainOperator.test.tsx
+++ b/app/renderer/src/main/src/pages/__test__/MainOperator.test.tsx
@@ -109,7 +109,7 @@ vi.mock('@/pages/ai-re-act/hooks/persist/aiChatPersistStore', () => ({
 }))
 
 vi.mock('antd', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('antd')>()
+  const actual = (await importOriginal()) as Record<string, unknown>
   return {
     ...actual,
     Watermark: ({ children }: { children?: React.ReactNode }) => <>{children}</>,

--- a/app/renderer/src/main/src/pages/__test__/MainOperator.test.tsx
+++ b/app/renderer/src/main/src/pages/__test__/MainOperator.test.tsx
@@ -1,0 +1,163 @@
+const { ipcRendererMock } = vi.hoisted(() => {
+  const ipcRendererMock = {
+    invoke: vi.fn().mockResolvedValue(false),
+    on: vi.fn(),
+    off: vi.fn(),
+    send: vi.fn(),
+    removeAllListeners: vi.fn(),
+  }
+  ;(window as any).require = (id: string) => {
+    if (id === 'electron') return { ipcRenderer: ipcRendererMock }
+    return {}
+  }
+  return { ipcRendererMock }
+})
+
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { startIdleVisibleInterval } = vi.hoisted(() => ({
+  startIdleVisibleInterval: vi.fn((cb: () => void) => {
+    const id = setInterval(cb, 15000)
+    return () => clearInterval(id)
+  }),
+}))
+
+vi.mock('@/utils/scheduleIdleTask', () => ({ startIdleVisibleInterval }))
+
+vi.mock('@/i18n/useI18nNamespaces', () => ({
+  useI18nNamespaces: () => ({ t: (key: string) => key, i18n: { language: 'zh' } }),
+}))
+
+vi.mock('@/store', () => ({
+  useStore: () => ({ userInfo: { isLogin: false }, setStoreUserInfo: vi.fn() }),
+  yakitDynamicStatus: () => ({
+    dynamicStatus: { isDynamicStatus: false, isDynamicSelfStatus: false },
+    setDynamicStatus: vi.fn(),
+  }),
+  useEeSystemConfig: () => ({ eeSystemConfig: [] }),
+}))
+
+vi.mock('@/store/screenRecorder', () => ({
+  useScreenRecorder: () => ({ screenRecorderInfo: { isRecording: false } }),
+}))
+
+vi.mock('@/utils/kv', () => ({
+  getRemoteValue: vi.fn().mockResolvedValue(''),
+  setRemoteValue: vi.fn(),
+  getLocalValue: vi.fn().mockResolvedValue(''),
+  setLocalValue: vi.fn(),
+}))
+
+vi.mock('@/utils/envfile', () => ({
+  isCommunityEdition: () => true,
+  isCommunityIRify: () => false,
+  isEnpriTrace: () => false,
+  isEnpriTraceAgent: () => false,
+  isEnterpriseOrSimpleEdition: () => false,
+  isIRify: () => false,
+  isMemfit: () => false,
+  globalUserLogin: vi.fn(),
+}))
+
+vi.mock('@/utils/eventBus/eventBus', () => ({
+  default: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+}))
+
+vi.mock('@/utils/notification', () => ({
+  failed: vi.fn(),
+  success: vi.fn(),
+  yakitFailed: vi.fn(),
+}))
+
+vi.mock('@/hook/useGetColorsByTheme', () => ({
+  default: () => ({ colorPrimary: '#000' }),
+}))
+
+vi.mock('@/pages/layout/HeardMenu/HeardMenu', () => ({ default: () => null }))
+vi.mock('@/pages/layout/publicMenu/PublicMenu', () => ({ default: () => null }))
+vi.mock('@/pages/layout/mainOperatorContent/MainOperatorContent', () => ({
+  MainOperatorContent: () => null,
+}))
+vi.mock('@/pages/Login', () => ({ default: () => null }))
+vi.mock('@/pages/SetPassword', () => ({ default: () => null }))
+vi.mock('@/pages/customizeMenu/CustomizeMenu', () => ({ default: () => null }))
+vi.mock('@/pages/dynamicControl/DynamicControl', () => ({ ControlOperation: () => null }))
+vi.mock('@/components/yakChat/chatCS', () => ({ YakChatCS: () => null }))
+vi.mock('@/components/MessageCenter/MessageCenter', () => ({ MessageCenterModal: () => null }))
+vi.mock('@/components/yakitUI/YakitHint/YakitHint', () => ({ YakitHint: () => null }))
+vi.mock('@/components/yakitUI/YakitHint/YakitHintModal', () => ({ YakitHintModal: () => null }))
+vi.mock('@/components/yakitUI/YakitModal/YakitModal', () => ({ YakitModal: () => null }))
+vi.mock('@/components/yakitUI/YakitButton/YakitButton', () => ({
+  YakitButton: ({ children }: { children?: React.ReactNode }) => <button>{children}</button>,
+}))
+vi.mock('@/pages/YakRunnerProjectManager/YakRunnerProjectManager', () => ({
+  IRifyUpdateProjectManagerModal: () => null,
+}))
+vi.mock('@/utils/monacoSpec/yakCompletionSchema', () => ({
+  setYaklangBuildInMethodCompletion: vi.fn(),
+  setYaklangCompletions: vi.fn(),
+}))
+vi.mock('@/utils/monacoSpec/yakEditor', () => ({ setUpYaklangMonaco: vi.fn() }))
+vi.mock('@/utils/monacoSpec/syntaxflowEditor', () => ({ setUpSyntaxFlowMonaco: vi.fn() }))
+vi.mock('@/pages/ai-re-act/hooks/persist/aiChatPersistStore', () => ({
+  default: {
+    open: () => Promise.resolve(),
+    close: () => Promise.resolve(),
+    getState: () => ({}),
+  },
+}))
+
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>()
+  return {
+    ...actual,
+    Watermark: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  }
+})
+
+import Main from '../MainOperator'
+
+describe('MainOperator 远程控制轮询', () => {
+  let mockHidden = false
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('requestIdleCallback', undefined)
+    vi.stubGlobal('cancelIdleCallback', undefined)
+    mockHidden = false
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => mockHidden })
+    startIdleVisibleInterval.mockClear()
+    ipcRendererMock.invoke.mockImplementation(async (channel: string) => {
+      if (channel === 'GetYakitCompletionRaw') return { RawJson: new Uint8Array([123, 125]) }
+      if (channel === 'GetYakVMBuildInMethodCompletion') return { Suggestions: [] }
+      if (channel === 'alive-dynamic-control-status') return false
+      return undefined
+    })
+  })
+
+  afterEach(() => {
+    delete (document as any).hidden
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('挂载后启动远程控制状态轮询', () => {
+    render(<Main />)
+    expect(startIdleVisibleInterval).toHaveBeenCalled()
+  })
+
+  it('卸载后停止轮询，不再请求 alive-dynamic-control-status', async () => {
+    const { unmount } = render(<Main />)
+    const cancel = startIdleVisibleInterval.mock.results[0]?.value as () => void
+    unmount()
+    expect(cancel).toEqual(expect.any(Function))
+
+    ipcRendererMock.invoke.mockClear()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000)
+    })
+    expect(ipcRendererMock.invoke).not.toHaveBeenCalledWith('alive-dynamic-control-status')
+  })
+})

--- a/app/renderer/src/main/src/pages/home/Home.tsx
+++ b/app/renderer/src/main/src/pages/home/Home.tsx
@@ -77,10 +77,11 @@ import type { RouteToPageProps } from '../layout/publicMenu/PublicMenu'
 import { usePluginToId } from '@/store/publicMenu'
 import { ResidentPluginName } from '@/routes/newRoute'
 import { Form, Tooltip } from 'antd'
-import { useDebounceEffect, useGetState, useInViewport, useMemoizedFn, useSize, useThrottleFn } from 'ahooks'
+import { useDebounceEffect, useInViewport, useMemoizedFn, useSize, useThrottleFn } from 'ahooks'
 import { YakitInput } from '@/components/yakitUI/YakitInput/YakitInput'
 import { YakitSwitch } from '@/components/yakitUI/YakitSwitch/YakitSwitch'
 import { getRemoteValue, setRemoteValue } from '@/utils/kv'
+import { startIdleVisibleInterval } from '@/utils/scheduleIdleTask'
 import { MITMConsts } from '../mitm/MITMConsts'
 import { CacheDropDownGV, RemoteGV } from '@/yakitGV'
 import { openABSFileLocated } from '@/utils/openWebsite'
@@ -142,8 +143,7 @@ const Home: React.FC<HomeProp> = (props) => {
   const [inViewport] = useInViewport(homeRef)
   const { pluginToId } = usePluginToId()
   const isRunRef = useRef<boolean>(false)
-  const [timeInterval, setTimeInterval, getTimeInterval] = useGetState<number>(5)
-  const timeRef = useRef<any>(null)
+  const [timeInterval, setTimeInterval] = useState<number>(5)
   const [showMitmDropdown, setShowMitmDropdown] = useState<boolean>(false)
   const showMitmDropdownRef = useRef<boolean>(showMitmDropdown)
   const mitmDropdownRef = useRef<HTMLDivElement>(null)
@@ -365,14 +365,8 @@ const Home: React.FC<HomeProp> = (props) => {
   }, [showMitmDropdown])
 
   useEffect(() => {
-    let timer: any = null
     getRemoteValue(RemoteGV.GlobalStateTimeInterval).then((time: any) => {
       setTimeInterval(+time || 5)
-      if ((+time || 5) > 5) updateAllInfo()
-      if (timer) clearInterval(timer)
-      timer = setInterval(() => {
-        setRemoteValue(RemoteGV.GlobalStateTimeInterval, `${getTimeInterval()}`)
-      }, 20000)
     })
 
     getRemoteValue(CacheDropDownGV.MITMDefaultHostHistoryList).then((e) => {
@@ -453,19 +447,17 @@ const Home: React.FC<HomeProp> = (props) => {
     { wait: 200 },
   )
 
-  // 修改查询间隔时间后
+  // 仅首页在视口内时轮询证书/网卡权限；离开首页或页面隐藏时停掉，避免后台 IPC
   useDebounceEffect(
     () => {
-      if (timeRef.current) clearInterval(timeRef.current)
-      timeRef.current = setInterval(updateAllInfo, timeInterval * 1000)
-
+      if (!inViewport) return
+      const cancel = startIdleVisibleInterval(updateAllInfo, timeInterval * 1000, { runImmediately: true })
       return () => {
         isRunRef.current = false
-        if (timeRef.current) clearInterval(timeRef.current)
-        timeRef.current = null
+        cancel()
       }
     },
-    [timeInterval],
+    [timeInterval, inViewport],
     { wait: 300 },
   )
 

--- a/app/renderer/src/main/src/pages/home/__test__/Home.test.tsx
+++ b/app/renderer/src/main/src/pages/home/__test__/Home.test.tsx
@@ -1,0 +1,171 @@
+const { ipcRendererMock, inViewport } = vi.hoisted(() => {
+  const ipcRendererMock = {
+    invoke: vi.fn().mockImplementation(async (channel: string) => {
+      if (channel === 'QueryAvailableRiskLevel') return { Values: [] }
+      if (channel === 'QueryHTTPFlows') return { Total: 0 }
+      if (channel === 'fetch-system-name') return 'Windows_NT'
+      if (channel === 'IsPrivileged') return { IsPrivileged: true }
+      return {}
+    }),
+    on: vi.fn(),
+    off: vi.fn(),
+    send: vi.fn(),
+    removeAllListeners: vi.fn(),
+  }
+  ;(window as any).require = (id: string) => {
+    if (id === 'electron') return { ipcRenderer: ipcRendererMock }
+    return {}
+  }
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  ;(window as any).ResizeObserver = ResizeObserverStub
+  ;(window as any).matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  })
+  return { ipcRendererMock, inViewport: { current: true } }
+})
+
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { startIdleVisibleInterval } = vi.hoisted(() => ({
+  startIdleVisibleInterval: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('@/utils/scheduleIdleTask', () => ({ startIdleVisibleInterval }))
+
+vi.mock('ahooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ahooks')>()
+  return {
+    ...actual,
+    useInViewport: () => [inViewport.current],
+  }
+})
+
+vi.mock('@/i18n/useI18nNamespaces', () => ({
+  useI18nNamespaces: () => ({ t: (key: string) => key, i18nRefresh: 0 }),
+}))
+
+vi.mock('@/utils/kv', () => ({
+  getRemoteValue: vi.fn().mockResolvedValue(''),
+  setRemoteValue: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/utils/envfile', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/envfile')>()
+  return {
+    ...actual,
+    getReleaseEditionName: () => 'Yakit',
+    isCommunityYakit: () => true,
+    isEnpriTrace: () => false,
+    isEnpriTraceAgent: () => false,
+  }
+})
+
+vi.mock('@/store/publicMenu', () => ({
+  usePluginToId: () => ({ pluginToId: {} }),
+}))
+
+vi.mock('@/store/softMode', () => ({
+  useSoftMode: () => ({ softMode: '' }),
+  YakitModeEnum: {},
+}))
+
+vi.mock('@/store/screenRecorder', () => ({
+  useScreenRecorder: () => ({ screenRecorderInfo: { isRecording: false } }),
+}))
+
+vi.mock('@/utils/eventBus/eventBus', () => ({
+  default: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+}))
+
+vi.mock('@/utils/notification', () => ({
+  yakitNotify: vi.fn(),
+}))
+
+vi.mock('@/pages/plugins/utils', () => ({
+  apiQueryYakScriptTotal: vi.fn().mockResolvedValue({ Total: 0 }),
+}))
+
+vi.mock('@/pages/assetViewer/PortTable/utils', () => ({
+  apiQueryPortsBase: vi.fn().mockResolvedValue({ Total: 0 }),
+}))
+
+vi.mock('@/pages/layout/NotepadMenu/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/pages/layout/NotepadMenu/utils')>()
+  return {
+    ...actual,
+    getNotepadAdd: () => 'add',
+    getNotepadManage: () => 'manage',
+  }
+})
+
+vi.mock('lottie-web', () => ({
+  default: {
+    loadAnimation: () => ({ destroy: () => undefined, play: () => undefined, stop: () => undefined }),
+  },
+}))
+
+vi.mock('@/components/yakitUI/YakitResizeBox/YakitResizeBox', () => ({
+  YakitResizeBox: ({ firstNode, secondNode }: { firstNode?: React.ReactNode; secondNode?: React.ReactNode }) => (
+    <div>
+      {firstNode}
+      {secondNode}
+    </div>
+  ),
+}))
+
+import Home from '../Home'
+
+describe('Home 离开首页停止轮询', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    inViewport.current = true
+    startIdleVisibleInterval.mockClear()
+    ipcRendererMock.invoke.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('首页在视口内时启动证书/网卡轮询', async () => {
+    render(<Home />)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+    expect(startIdleVisibleInterval).toHaveBeenCalled()
+  })
+
+  it('离开首页后停止轮询', async () => {
+    const { rerender } = render(<Home />)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+    const cancel = startIdleVisibleInterval.mock.results[0]?.value as ReturnType<typeof vi.fn>
+    expect(cancel).toEqual(expect.any(Function))
+
+    inViewport.current = false
+    rerender(<Home />)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+    expect(cancel).toHaveBeenCalled()
+    const callsAfterLeave = startIdleVisibleInterval.mock.calls.length
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+    expect(startIdleVisibleInterval).toHaveBeenCalledTimes(callsAfterLeave)
+  })
+})

--- a/app/renderer/src/main/src/pages/home/__test__/Home.test.tsx
+++ b/app/renderer/src/main/src/pages/home/__test__/Home.test.tsx
@@ -45,7 +45,7 @@ const { startIdleVisibleInterval } = vi.hoisted(() => ({
 vi.mock('@/utils/scheduleIdleTask', () => ({ startIdleVisibleInterval }))
 
 vi.mock('ahooks', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('ahooks')>()
+  const actual = (await importOriginal()) as Record<string, unknown>
   return {
     ...actual,
     useInViewport: () => [inViewport.current],
@@ -62,7 +62,7 @@ vi.mock('@/utils/kv', () => ({
 }))
 
 vi.mock('@/utils/envfile', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/utils/envfile')>()
+  const actual = (await importOriginal()) as Record<string, unknown>
   return {
     ...actual,
     getReleaseEditionName: () => 'Yakit',
@@ -102,7 +102,7 @@ vi.mock('@/pages/assetViewer/PortTable/utils', () => ({
 }))
 
 vi.mock('@/pages/layout/NotepadMenu/utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/pages/layout/NotepadMenu/utils')>()
+  const actual = (await importOriginal()) as Record<string, unknown>
   return {
     ...actual,
     getNotepadAdd: () => 'add',

--- a/app/renderer/src/main/src/utils/__test__/scheduleIdleTask.test.ts
+++ b/app/renderer/src/main/src/utils/__test__/scheduleIdleTask.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startIdleVisibleInterval } from '../scheduleIdleTask'
+
+describe('startIdleVisibleInterval', () => {
+  let mockHidden = false
+
+  const setHidden = (hidden: boolean) => {
+    mockHidden = hidden
+  }
+  const becomeVisible = () => {
+    mockHidden = false
+    document.dispatchEvent(new Event('visibilitychange'))
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // jsdom 无 requestIdleCallback，显式禁用以固定走 setTimeout fallback，避免环境差异
+    vi.stubGlobal('requestIdleCallback', undefined)
+    vi.stubGlobal('cancelIdleCallback', undefined)
+    mockHidden = false
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => mockHidden })
+  })
+
+  afterEach(() => {
+    delete (document as any).hidden
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('空闲后再按周期执行，默认不立即执行回调', () => {
+    const cb = vi.fn()
+    startIdleVisibleInterval(cb, 1000)
+
+    // 空闲回调（fallback 1ms）触发并启动 interval，但首tick要等一个周期
+    vi.advanceTimersByTime(1)
+    expect(cb).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1000)
+    expect(cb).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(1000)
+    expect(cb).toHaveBeenCalledTimes(2)
+  })
+
+  it('runImmediately 时启动后立即执行一次', () => {
+    const cb = vi.fn()
+    startIdleVisibleInterval(cb, 1000, { runImmediately: true })
+
+    vi.advanceTimersByTime(1)
+    expect(cb).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1000)
+    expect(cb).toHaveBeenCalledTimes(2)
+  })
+
+  it('页面隐藏时跳过 tick，重新可见时立即补一次', () => {
+    const cb = vi.fn()
+    startIdleVisibleInterval(cb, 1000)
+    vi.advanceTimersByTime(1) // 启动 interval
+
+    setHidden(true)
+    vi.advanceTimersByTime(3000)
+    expect(cb).not.toHaveBeenCalled()
+
+    becomeVisible()
+    expect(cb).toHaveBeenCalledTimes(1)
+
+    // 可见后恢复周期执行
+    vi.advanceTimersByTime(1000)
+    expect(cb).toHaveBeenCalledTimes(2)
+  })
+
+  it('未启动（空闲回调触发前）时 visibilitychange 不触发回调', () => {
+    const cb = vi.fn()
+    startIdleVisibleInterval(cb, 1000)
+
+    document.dispatchEvent(new Event('visibilitychange'))
+    vi.advanceTimersByTime(1) // 空闲回调触发、interval 启动（无 runImmediately）
+    vi.advanceTimersByTime(999) // 尚未到第一个周期
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('cancel 后停止周期与可见补偿', () => {
+    const cb = vi.fn()
+    const cancel = startIdleVisibleInterval(cb, 1000, { runImmediately: true })
+    vi.advanceTimersByTime(1)
+    expect(cb).toHaveBeenCalledTimes(1)
+
+    cancel()
+    vi.advanceTimersByTime(5000)
+    becomeVisible()
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  it('启动前 cancel 则回调永不执行', () => {
+    const cb = vi.fn()
+    const cancel = startIdleVisibleInterval(cb, 1000, { runImmediately: true })
+
+    cancel()
+    vi.advanceTimersByTime(5000)
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('requestIdleCallback 环境下由空闲回调触发启动', () => {
+    let idleCb: (() => void) | undefined
+    vi.stubGlobal('requestIdleCallback', (cb: () => void) => {
+      idleCb = cb
+      return 1
+    })
+    vi.stubGlobal('cancelIdleCallback', vi.fn())
+    const cb = vi.fn()
+    startIdleVisibleInterval(cb, 1000, { runImmediately: true })
+
+    // 空闲回调未触发前不启动
+    vi.advanceTimersByTime(5000)
+    expect(cb).not.toHaveBeenCalled()
+
+    idleCb!()
+    expect(cb).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(1000)
+    expect(cb).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancel 会取消尚未触发的空闲回调', () => {
+    let idleCb: (() => void) | undefined
+    const cancelIdle = vi.fn()
+    vi.stubGlobal('requestIdleCallback', (cb: () => void) => {
+      idleCb = cb
+      return 7
+    })
+    vi.stubGlobal('cancelIdleCallback', cancelIdle)
+    const cb = vi.fn()
+
+    const cancel = startIdleVisibleInterval(cb, 1000)
+    cancel()
+
+    expect(cancelIdle).toHaveBeenCalledWith(7)
+    // 即使空闲回调被误触发，也被 cancelled 标志拦截
+    idleCb!()
+    vi.advanceTimersByTime(5000)
+    expect(cb).not.toHaveBeenCalled()
+  })
+})

--- a/app/renderer/src/main/src/utils/scheduleIdleTask.ts
+++ b/app/renderer/src/main/src/utils/scheduleIdleTask.ts
@@ -5,6 +5,11 @@ export interface ScheduleIdleTaskOptions {
   fallbackDelay?: number
 }
 
+export interface StartIdleVisibleIntervalOptions extends ScheduleIdleTaskOptions {
+  /** 启动 interval 时是否立刻执行一次回调，默认 false（与原生 setInterval 一致） */
+  runImmediately?: boolean
+}
+
 /**
  * 将非首帧任务延后到浏览器空闲时执行，缩短切页同步路径。
  * 返回 cancel 函数，组件卸载或依赖变更时应调用。
@@ -35,6 +40,57 @@ export function scheduleIdleTask(task: () => void, options?: ScheduleIdleTaskOpt
     }
     if (timerId !== undefined) {
       clearTimeout(timerId)
+    }
+  }
+}
+
+const isDocumentHidden = () => typeof document !== 'undefined' && document.hidden
+
+/**
+ * 空闲后再启动 interval；页面 hidden 时跳过 tick，重新可见时立刻补一次。
+ * 不改变回调语义，只推迟启动、避免后台标签空转。
+ */
+export function startIdleVisibleInterval(
+  callback: () => void,
+  delay: number,
+  options?: StartIdleVisibleIntervalOptions,
+): () => void {
+  let intervalId: ReturnType<typeof setInterval> | undefined
+  let cancelled = false
+  let started = false
+
+  const tick = () => {
+    if (cancelled || isDocumentHidden()) return
+    callback()
+  }
+
+  const start = () => {
+    if (cancelled || started) return
+    started = true
+    if (options?.runImmediately) tick()
+    intervalId = setInterval(tick, delay)
+  }
+
+  const cancelIdle = scheduleIdleTask(start, options)
+
+  const onVisibilityChange = () => {
+    if (cancelled || !started || isDocumentHidden()) return
+    tick()
+  }
+
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', onVisibilityChange)
+  }
+
+  return () => {
+    cancelled = true
+    cancelIdle()
+    if (intervalId !== undefined) {
+      clearInterval(intervalId)
+      intervalId = undefined
+    }
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
     }
   }
 }


### PR DESCRIPTION
## 改动类型

- [ ] 新功能（新页面 / 新选项 / 新能力）
- [ ] Bug 修复（有用户可见行为修正）
- [ ] 文档改动
- [ ] 样式 / UI 调整（无逻辑变化）
- [x] 性能优化
- [ ] 重构（不改变外部行为）
- [x] 测试改动
- [ ] 构建 / 依赖 / 打包配置
- [ ] CI 流程改动
- [ ] 杂项（脚本 / 工程化 / 版本号）
- [ ] 其他

## 🔗 关联 Issue / PR

None

## 💡 背景与方案

首屏 Performance 分析发现：首页挂载后立即启动了 10 余个轮询定时器（CPU 采样、引擎地址、风险数、版本信息、全局状态、动控状态、证书权限等），与首屏渲染争抢主线程；其中 `UILayout` 的 `setTimeout(() => setEngineLink(true), 100)` 回调单次重渲染耗时近 300ms。

本次统一收敛首页相关定时器：

- 新增 `startIdleVisibleInterval`（基于已有 `scheduleIdleTask`）：轮询延迟到浏览器空闲后再启动，页面隐藏时跳过 tick，重新可见时立即补一次，返回 cancel 便于清理
- 各处轮询迁移到该工具：PerformanceDisplay（CPU 采样，隐藏时同步停止主进程采样）、YakitGlobalHost（引擎地址）、FuncDomain（版本信息 / 风险数）、GlobalState（全局状态）、MainOperator（动控状态）、Home（证书权限，仅首页在视口内时轮询）、UILayout（引擎安装检测）
- 引擎探活去掉 `probingRef` 防重入：单次 Echo 挂起时不再锁死后续 tick，失败通知可继续；已连接后的探测间隔 5s→3s，故障恢复后会重新回调 onReady
- 修复 FuncDomain（UIOpRisk / UIOpIRifyRisk）effect 清理后 `finally` 仍注册事件监听的泄漏
- 清理无效定时器：NewApp 自清空 setTimeout、local 模式 500ms 延迟 setKeepalive；`setTimeout(setEngineLink, 100)` 改为同步 set，与其它状态更新合并渲染
- 补充消费方生命周期回归测：WatchDog 挂起不阻断、CPU 启停、引擎地址连接切换、风险轮询卸载竞态、离开首页、间隔持久化、动控轮询、引擎安装探测
- 合并 FuncDomain 4 个 60s 版本轮询为 1 个；GlobalState / Home 删除每 20s 回写轮询间隔的定时器，改为变更时写入

## 影响范围

- 首屏挂载后的各类轮询统一推迟到空闲启动；页面隐藏时不再后台轮询。引擎探活保持原生 interval，不受隐藏影响（最小化 / 切后台仍持续保活）
- 引擎断开重连后 `onReady` 会再次触发（原为整个生命周期仅一次），消费方 UILayout 已有 `getEngineLink()` 守卫，行为幂等
- 单次 Echo 挂起时探活会继续发起后续请求（可能短暂重叠），面板不会因一把锁永久停更
- 版本信息、风险数等首次出现时机略微延后（空闲后立即执行，rIC 超时兜底最长约 2s）
- 纯定时器调度改造，无 UI / 交互变化

## 代码评审结论

**结论：可以合并**（正确 6 项 / 问题 0 项（P0 0 项 / P1 0 项）/ 警告 3 项）

## 建议合并前修复的问题

- [x] ~~`app/renderer/src/main/src/utils/scheduleIdleTask.ts:53` 新增纯工具函数 `startIdleVisibleInterval`（空闲启动 / 隐藏跳过 / 可见补偿 / runImmediately / cancel 多分支）缺失单测，建议补充 `src/utils/__test__/scheduleIdleTask.test.ts`~~（✅ 已修复：12cd3efb3，8 个用例覆盖空闲启动 / runImmediately / 隐藏跳过与可见补偿 / 未启动时不补偿 / cancel 两阶段 / rIC 双路径）

## 合并方式

- [ ] Create a merge commit（保留完整提交历史）
- [x] Squash and merge（压缩为一条提交）
- [ ] Rebase and merge（线性历史）