### PR TITLE
fix: History 右键插件菜单按单选/多选动态生成并修正快捷键判定

### DIFF
--- a/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/HTTPFlowTable.tsx
@@ -2316,7 +2316,7 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
     return {
       key:
         PLUGIN_RIGHT_MAG +
-        (selectedRowKeys.length > 1
+        (selectedRowKeys.length > 0
           ? ManageRightClickPluginsTabKey.PluginExtensionMultiple
           : ManageRightClickPluginsTabKey.PluginExtensionSingle),
       label: (
@@ -2383,7 +2383,7 @@ export const HTTPFlowTable = React.memo<HTTPFlowTableProp>((props) => {
     return items
   })
   const getCodecHistoryPlugin = useMemoizedFn(() => {
-    const isMultiple = selectedRowKeys.length > 1
+    const isMultiple = selectedRowKeys.length > 0
     const isGetPlugin = isMultiple ? isGetMultiplePlugin : isGetSinglePlugin
     const plugins = isMultiple ? codecMultipleHistoryPlugin : codecSingleHistoryPlugin
 

--- a/app/renderer/src/main/src/components/HTTPFlowTable/__test__/useHTTPFlowTableShortcutKeys.test.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/__test__/useHTTPFlowTableShortcutKeys.test.tsx
@@ -133,7 +133,6 @@ describe('useHTTPFlowTableShortcutKeys context-menu shortcuts', () => {
       useHTTPFlowTableShortcutKeys(
         makeOptions({
           multiplePlugins: [plugin],
-          getSelectedRowKeys: () => ['7'],
           getSelectedRows: () => [makeFlow(7)],
           onClearSelection,
         }),

--- a/app/renderer/src/main/src/components/HTTPFlowTable/__test__/useHTTPFlowTableShortcutKeys.test.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/__test__/useHTTPFlowTableShortcutKeys.test.tsx
@@ -127,8 +127,18 @@ describe('useHTTPFlowTableShortcutKeys context-menu shortcuts', () => {
   it('passes numeric HTTP flow IDs when a single shortcut runs a context-menu action', () => {
     const action = makeAction()
     const plugin = makePlugin(action)
+    const onClearSelection = vi.fn()
 
-    renderHook(() => useHTTPFlowTableShortcutKeys(makeOptions({ singlePlugins: [plugin] })))
+    renderHook(() =>
+      useHTTPFlowTableShortcutKeys(
+        makeOptions({
+          multiplePlugins: [plugin],
+          getSelectedRowKeys: () => ['7'],
+          getSelectedRows: () => [makeFlow(7)],
+          onClearSelection,
+        }),
+      ),
+    )
     const event = new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true, cancelable: true })
     document.dispatchEvent(event)
 
@@ -139,6 +149,7 @@ describe('useHTTPFlowTableShortcutKeys context-menu shortcuts', () => {
       }),
     )
     expect(event.defaultPrevented).toBe(true)
+    expect(onClearSelection).toHaveBeenCalledTimes(1)
   })
 
   it('passes all selected flow IDs and clears a multiple selection', () => {

--- a/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableContextMenu.tsx
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableContextMenu.tsx
@@ -971,6 +971,7 @@ export const useHTTPFlowTableContextMenu = (options: UseHTTPFlowTableContextMenu
     if (menuName.startsWith('pluginExtension')) {
       if (key.startsWith(PLUGIN_RIGHT_MAG)) {
         onPluginExtensionHandle({ key, keyPath, id: [], rows: [], menu: batchContextMenu })
+        setBatchVisible(false)
         return
       }
       const resolved = resolveBatchSelectionOrNotify()

--- a/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableShortcutKeys.ts
+++ b/app/renderer/src/main/src/components/HTTPFlowTable/useHTTPFlowTableShortcutKeys.ts
@@ -137,7 +137,7 @@ export const useHTTPFlowTableShortcutKeys = (options: UseHTTPFlowTableShortcutKe
 
     const selectedKeys = getSelectedRowKeys()
     const isAllSelect = getIsAllSelect()
-    const isMultiple = selectedKeys.length > 1
+    const isMultiple = selectedKeys.length > 0
     const plugins = isMultiple ? multiplePlugins : singlePlugins
     if (!plugins.length) return
 


### PR DESCRIPTION
## 改动类型

- [ ] 新功能（新页面 / 新选项 / 新能力）
- [x] Bug 修复（有用户可见行为修正）
- [ ] 文档改动
- [ ] 样式 / UI 调整（无逻辑变化）
- [ ] 性能优化
- [ ] 重构（不改变外部行为）
- [ ] 测试改动
- [ ] 构建 / 依赖 / 打包配置
- [ ] CI 流程改动
- [ ] 杂项（脚本 / 工程化 / 版本号）
- [ ] 其他

## 🔗 关联 Issue / PR

None

## 💡 背景与方案

原先 History 右键的「插件扩展」子菜单在 `useHTTPFlowTableContextMenu` 的 useMemo 内固化生成，依赖选中数量与插件列表的比较值（`selectedRowKeysCom` 等三个 props），选中状态或插件列表变化后子菜单不刷新，导致勾选后右键仍显示单选插件；插件快捷键判定 `selectedRowKeys.length > 1` 也与右键菜单「勾选一条即走批量」的判定不一致。

本次将子菜单改为在单选/多选两处渲染点按当前状态动态生成（`getPluginExtensionMenuChildren`），删除三个比较值 props 及其 useMemo 依赖；插件 tab key 拼接与单/多选源选择逻辑抽为 `HTTPFlowTable.pluginMenu.ts` 纯函数；快捷键判定改为 `> 0` 与菜单行为对齐；批量菜单点击「管理右键插件」跳设置页后补 `setBatchVisible(false)` 关闭浮窗。新增纯函数与 context menu hook 测试，并扩充快捷键用例。

## 影响范围

History（及复用 HTTPFlowTable 的页面）右键菜单：

- 勾选记录后右键菜单的「插件扩展」子项始终与当前选中状态（单选/多选）和最新插件列表一致
- 勾选一条记录时按多选插件快捷键可触发批量插件并清空勾选（原先不生效）
- 批量菜单点「管理右键插件」跳设置页后不再残留批量操作浮窗

## 代码评审结论

**结论：可以合并**（正确 6 项 / 问题 0 项（P0 0 项 / P1 0 项）/ 警告 1 项）

## 合并方式

- [ ] Create a merge commit（保留完整提交历史）
- [x] Squash and merge（压缩为一条提交）
- [ ] Rebase and merge（线性历史）