### PR TITLE
fix: 引擎进程退出不再误报为启动超时

### DIFF
--- a/app/renderer/engine-link-startup/src/pages/StartupPage/__test__/engineFailure.test.ts
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/__test__/engineFailure.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { engineFailureMessage } from '../engineFailure'
+import { engineFailureMessage, engineFailureStatus } from '../engineFailure'
 import zh from '../../../locales/zh/link.json'
 import en from '../../../locales/en/link.json'
 import zhTW from '../../../locales/zh-TW/link.json'
@@ -44,5 +44,45 @@ describe('localized engine recovery advice', () => {
       expect(locale.LocalEngine.migration_wait_hint).toContain('180')
       expect(locale.UIEngineList.authenticated_switch_required.length).toBeGreaterThan(20)
     }
+  })
+})
+
+describe('engineFailureStatus', () => {
+  it.each([
+    ['cancelled', null],
+    ['port_occupied', 'port_occupied_prev'],
+    ['port_denied', 'port_denied'],
+    ['endpoint_unreachable', 'endpoint_unreachable'],
+    ['database_error', 'database_error'],
+    ['protocol_error', 'check_error'],
+    ['old_version', 'old_version'],
+    ['timeout', 'check_timeout'],
+    ['call_error', 'check_timeout'],
+    ['build_yak_error', 'build_yak_error'],
+    ['dial_error', 'dial_error'],
+    ['antivirus_blocked', 'antivirus_blocked'],
+    ['unknownReason', 'check_error'],
+    ['engine_exited', 'check_error'],
+    ['engine_init_failed', 'check_error'],
+    ['process_error', 'check_error'],
+  ] as const)('check %s maps to %s', (status, expected) => {
+    expect(engineFailureStatus(status, 'check')).toBe(expected)
+  })
+
+  it.each([
+    ['cancelled', null],
+    ['port_occupied', 'port_occupied_prev'],
+    ['port_denied', 'port_denied'],
+    ['endpoint_unreachable', 'endpoint_unreachable'],
+    ['database_error', 'database_error'],
+    ['protocol_error', 'check_error'],
+    ['timeout', 'start_timeout'],
+    ['call_error', 'start_timeout'],
+    ['dial_error', 'start_timeout'],
+    ['engine_exited', 'engine_exited'],
+    ['engine_init_failed', 'engine_init_failed'],
+    ['engine_failed', 'engine_failed'],
+  ] as const)('start %s maps to %s', (status, expected) => {
+    expect(engineFailureStatus(status, 'start')).toBe(expected)
   })
 })

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/__test__/startupRecovery.test.tsx
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/components/YakitLoading/__test__/startupRecovery.test.tsx
@@ -77,6 +77,16 @@ describe('startup recovery buttons', () => {
     expect(callback).toHaveBeenCalledExactlyOnceWith('start_timeout')
   })
 
+  it.each(['engine_exited', 'engine_init_failed', 'engine_failed'] as const)(
+    'a start %s failure retries with the original process status',
+    (failure) => {
+      const status = engineFailureStatus(failure, 'start')!
+      const { callback } = show(status)
+      fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.retry' }))
+      expect(callback).toHaveBeenCalledExactlyOnceWith(failure)
+    },
+  )
+
   it('an occupied port never offers to kill an unrelated engine implicitly', () => {
     const { callback } = show('port_occupied_prev')
     fireEvent.click(screen.getByRole('button', { name: 'YakitLoading.reconnect' }))

--- a/app/renderer/engine-link-startup/src/pages/StartupPage/engineFailure.ts
+++ b/app/renderer/engine-link-startup/src/pages/StartupPage/engineFailure.ts
@@ -15,6 +15,7 @@ export function engineFailureStatus(status: string, stage: 'check' | 'start'): Y
     if (status === 'antivirus_blocked') return status
     return 'check_error'
   }
+  if (status === 'engine_exited' || status === 'engine_init_failed' || status === 'engine_failed') return status
   return 'start_timeout'
 }
 


### PR DESCRIPTION
## 改动类型

- [ ] 新功能（新页面 / 新选项 / 新能力）
- [x] Bug 修复（有用户可见行为修正）
- [ ] 文档改动
- [ ] 样式 / UI 调整（无逻辑变化）
- [ ] 性能优化
- [ ] 重构（不改变外部行为）
- [ ] 测试改动
- [ ] 构建 / 依赖 / 打包配置
- [ ] CI 流程改动
- [ ] 杂项（脚本 / 工程化 / 版本号）
- [ ] 其他

## 🔗 关联 Issue / PR

None

## 💡 背景与方案

引擎 start 阶段失败时，`engineFailureStatus` 把 `engine_exited`、`engine_init_failed`、`engine_failed` 全部折叠成 `start_timeout`。日志仍显示真实原因，但界面状态变成「等待引擎就绪超时」，误导排查。本次在映射为超时前透传这三种进程失败状态，并补齐 `engineFailureStatus` 在 check / start 两阶段的直接用例。

## 影响范围

本地引擎启动失败时，进程意外退出 / 初始化失败 / 未分类启动失败会显示对应状态与重试按钮，不再被显示成启动超时。超时失败路径不变。

## 代码评审结论

**结论：可以合并**（正确 6 项 / 问题 0 项（P0 0 项 / P1 0 项）/ 警告 0 项）

## 合并方式

- [ ] Create a merge commit（保留完整提交历史）
- [x] Squash and merge（压缩为一条提交）
- [ ] Rebase and merge（线性历史）
