### PR TITLE
luoluo/perf/ai-copy

### DIFF
--- a/app/renderer/src/main/src/locales/en/aiAgent.json
+++ b/app/renderer/src/main/src/locales/en/aiAgent.json
@@ -90,6 +90,7 @@
     "policyAuto": "Automatically select the most suitable model based on request content",
     "policyPerformance": "Prioritize high-intelligence models",
     "policyCost": "Prioritize lightweight/low-cost models",
+    "policyBalance": "Balance between response speed, intelligence, and cost",
     "sameModelWarning": "Using the same model for lightweight and high-quality is not recommended; lightweight should use a fast-response model"
   },
   "AIOnlineModeSetting": {

--- a/app/renderer/src/main/src/locales/en/aiAgent.json
+++ b/app/renderer/src/main/src/locales/en/aiAgent.json
@@ -69,7 +69,8 @@
     "toConfigure": "Go to Configure",
     "configDesc": "No available AI model found. Please configure one before use.",
     "selectModel": "Select AI Model",
-    "openConfigTooltip": "Open model configuration in Settings"
+    "openConfigTooltip": "Open model configuration in Settings",
+    "manageModels": "Manage Models"
   },
   "AIModelList": {
     "onlineTooltip": "Access models via API, receive AI info or send messages to AI, multiple configurations possible.",
@@ -89,7 +90,6 @@
     "policyAuto": "Automatically select the most suitable model based on request content",
     "policyPerformance": "Prioritize high-intelligence models",
     "policyCost": "Prioritize lightweight/low-cost models",
-    "policyBalance": "Balance between response speed, intelligence, and cost",
     "sameModelWarning": "Using the same model for lightweight and high-quality is not recommended; lightweight should use a fast-response model"
   },
   "AIOnlineModeSetting": {

--- a/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
@@ -90,6 +90,7 @@
     "policyAuto": "根據請求內容自動選擇最合適的模型",
     "policyPerformance": "優先使用高智慧模型",
     "policyCost": "優先使用輕量級/低成本模型",
+    "policyBalance": "在響應速度、智慧程度和成本之間取得平衡",
     "sameModelWarning": "不建議輕量和高質使用同一個模型，輕量適合使用響應快速的模型"
   },
   "AIOnlineModeSetting": {

--- a/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh-TW/aiAgent.json
@@ -69,7 +69,8 @@
     "toConfigure": "去配置",
     "configDesc": "無可使用AI模型，請配置後使用",
     "selectModel": "AI 模型選擇",
-    "openConfigTooltip": "開啟設定中的模型配置"
+    "openConfigTooltip": "開啟設定中的模型配置",
+    "manageModels": "管理模型"
   },
   "AIModelList": {
     "onlineTooltip": "透過api訪問模型,接受AI資訊或向AI傳送訊息,可配置多個",
@@ -89,7 +90,6 @@
     "policyAuto": "根據請求內容自動選擇最合適的模型",
     "policyPerformance": "優先使用高智慧模型",
     "policyCost": "優先使用輕量級/低成本模型",
-    "policyBalance": "在響應速度、智慧程度和成本之間取得平衡",
     "sameModelWarning": "不建議輕量和高質使用同一個模型，輕量適合使用響應快速的模型"
   },
   "AIOnlineModeSetting": {

--- a/app/renderer/src/main/src/locales/zh/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh/aiAgent.json
@@ -90,6 +90,7 @@
     "policyAuto": "根据请求内容自动选择最合适的模型",
     "policyPerformance": "优先使用高智能模型",
     "policyCost": "优先使用轻量级/低成本模型",
+    "policyBalance": "在响应速度、智能程度和成本之间取得平衡",
     "sameModelWarning": "不建议轻量和高质使用同一个模型，轻量适合使用响应快速的模型"
   },
   "AIOnlineModeSetting": {

--- a/app/renderer/src/main/src/locales/zh/aiAgent.json
+++ b/app/renderer/src/main/src/locales/zh/aiAgent.json
@@ -69,7 +69,8 @@
     "toConfigure": "去配置",
     "configDesc": "无可使用AI模型，请配置后使用",
     "selectModel": "AI 模型选择",
-    "openConfigTooltip": "打开设置中的模型配置"
+    "openConfigTooltip": "打开设置中的模型配置",
+    "manageModels": "管理模型"
   },
   "AIModelList": {
     "onlineTooltip": "通过api访问模型,接受AI信息或向AI发送消息,可配置多个",
@@ -89,7 +90,6 @@
     "policyAuto": "根据请求内容自动选择最合适的模型",
     "policyPerformance": "优先使用高智能模型",
     "policyCost": "优先使用轻量级/低成本模型",
-    "policyBalance": "在响应速度、智能程度和成本之间取得平衡",
     "sameModelWarning": "不建议轻量和高质使用同一个模型，轻量适合使用响应快速的模型"
   },
   "AIOnlineModeSetting": {

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/AIModelList.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/AIModelList.tsx
@@ -206,9 +206,6 @@ export const getTipByType = (routingPolicy: AIModelPolicyEnum, t: TFunction) => 
       return t('AIModelList.policyPerformance')
     case AIModelPolicyEnum.PolicyCost:
       return t('AIModelList.policyCost')
-    case AIModelPolicyEnum.PolicyBalance:
-      return t('AIModelList.policyBalance')
-
     default:
       return null
   }

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/AIModelList.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/AIModelList.tsx
@@ -206,6 +206,9 @@ export const getTipByType = (routingPolicy: AIModelPolicyEnum, t: TFunction) => 
       return t('AIModelList.policyPerformance')
     case AIModelPolicyEnum.PolicyCost:
       return t('AIModelList.policyCost')
+    case AIModelPolicyEnum.PolicyBalance:
+      return t('AIModelList.policyBalance')
+
     default:
       return null
   }

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelect.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/AIModelSelect.tsx
@@ -33,7 +33,7 @@ import {
   AIOnlineModelIconMap,
   defaultAIGlobalConfig,
 } from '../../defaultConstant'
-import { AIModelFreeTag, getTipByType, OutlineAtomIconByStatus, setAIModal } from '../AIModelList'
+import { AIModelFreeTag, OutlineAtomIconByStatus, setAIModal } from '../AIModelList'
 import { AIChatSelect } from '@/pages/ai-re-act/aiReviewRuleSelect/AIReviewRuleSelect'
 import {
   BrainOutlined,
@@ -364,9 +364,6 @@ export const AIModelSelect: React.FC<AIModelSelectProps> = React.memo((props) =>
                         }}
                       />
                     )} */}
-                    <Tooltip title={getTipByType(policy, t)}>
-                      <InformationCircleOutlined className={styles['icon-info']} color="currentColor" />
-                    </Tooltip>
                   </div>
                   <div className={styles['select-title-right']}>
                     <Tooltip title={t('AIModelSelect.openConfigTooltip')}>
@@ -375,7 +372,9 @@ export const AIModelSelect: React.FC<AIModelSelectProps> = React.memo((props) =>
                         type="text2"
                         icon={<CogOutlined color="currentColor" />}
                         onClick={openModelTab}
-                      />
+                      >
+                        {t('AIModelSelect.manageModels')}
+                      </YakitButton>
                     </Tooltip>
                     {aiType === 'online' && (
                       <Tooltip title={t('YakitButton.refresh')}>

--- a/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/__test__/AIModelSelect.test.tsx
+++ b/app/renderer/src/main/src/pages/ai-agent/aiModelList/aiModelSelect/__test__/AIModelSelect.test.tsx
@@ -21,7 +21,6 @@ vi.mock('../../utils', () => ({
   sortMemfitNameFirst: (names: string[]) => names,
 }))
 vi.mock('../../AIModelList', () => ({
-  getTipByType: () => 'policy',
   OutlineAtomIconByStatus: () => null,
   AIModelFreeTag: () => null,
   setAIModal: mocks.configure,
@@ -105,13 +104,15 @@ const getDropdownButtons = (dropdown: HTMLElement) => within(dropdown).getAllByR
 const getEditButtons = (dropdown: HTMLElement) => within(dropdown).getAllByRole('button', { name: 'YakitButton.edit' })
 
 describe('AIModelSelect', () => {
-  it('配置入口打开设置中的模型配置，刷新仍会重新拉取模型列表', async () => {
+  it('管理模型按钮显示国际化文案并打开模型配置，刷新仍会重新拉取模型列表', async () => {
     const emit = vi.spyOn(emiter, 'emit')
     const dropdown = await openModels()
     expect(within(dropdown).getByText('model-a')).toBeInTheDocument()
     const buttons = getDropdownButtons(dropdown)
     expect(buttons).toHaveLength(5)
-    const [configButton, refreshButton] = buttons
+    const configButton = within(dropdown).getByRole('button', { name: 'AIModelSelect.manageModels' })
+    expect(configButton).toBeVisible()
+    const refreshButton = buttons[1]
     fireEvent.click(configButton)
     expect(emit).toHaveBeenCalledWith(
       'openPage',

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.module.scss
@@ -118,7 +118,7 @@
   display: flex;
   flex: 1;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
   min-width: 0;
 }
 
@@ -128,8 +128,8 @@
   flex: none;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
   color: var(--Colors-Use-Neutral-Text-1-Title);
 
   svg {
@@ -142,8 +142,8 @@
   flex: 1;
   min-width: 0;
   overflow: hidden;
-  font-size: 14px;
-  line-height: 20px;
+  font-size: 12px;
+  line-height: 16px;
   color: var(--Colors-Use-Neutral-Text-1-Title);
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.module.scss
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.module.scss
@@ -202,19 +202,6 @@
   color: var(--Colors-Use-Neutral-Text-4-Help-text);
 }
 
-// 计数角标
-.count-tag {
-  display: inline-flex;
-  flex: none;
-  align-items: center;
-  padding: 2px 8px;
-  font-size: 12px;
-  line-height: 16px;
-  color: var(--Colors-Use-Neutral-Text-1-Title);
-  background: var(--Colors-Use-Neutral-Border);
-  border-radius: 4px;
-}
-
 .risk-tag {
   display: inline-flex;
   flex: none;

--- a/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
+++ b/app/renderer/src/main/src/pages/ai-re-act/aiRightPanel/AIRightPanel.tsx
@@ -46,6 +46,7 @@ import type {
   AIRightPanelToolStats,
 } from './type'
 import { AI_RIGHT_PANEL_INPUT_MAX_WIDTH, AI_RIGHT_PANEL_NORMAL_SLOT_WIDTH } from './type'
+import { YakitTag } from '@/components/yakitUI/YakitTag/YakitTag'
 
 /** 菜单项定义：key 为唯一标识（React key 用），labelKey 为 i18n 文案 key，icon 为入口图标 */
 interface MenuItemDef {
@@ -436,7 +437,11 @@ export const AIRightPanel: React.FC<AIRightPanelProps> = React.memo((props) => {
 
   const renderMenuSuffix = useMemoizedFn((key: AIRightPanelMenuKey) => {
     if (key === 'traffic' && executionData?.http_flow_count) {
-      return <span className={styles['count-tag']}>{executionData.http_flow_count}</span>
+      return (
+        <YakitTag fullRadius color="white" border={false}>
+          {executionData?.http_flow_count}
+        </YakitTag>
+      )
     }
     if (key === 'risk' && riskCounts) {
       const entries = RISK_TAG_ORDER.map((field) => ({ field, value: riskCounts[field] })).filter(


### PR DESCRIPTION
## 改动类型

- [x] 样式 / UI 调整（无逻辑变化）

## 🔗 关联 Issue / PR

None

## 💡 背景与方案

AI 模型选择下拉中配置入口仅有齿轮图标不够直观，本次改为带「管理模型」文案的按钮，并移除下拉内冗余的策略提示图标与已下线的「平衡策略」提示；同时将 AI 右侧功能面板的流量计数角标统一改用 YakitTag 组件，并收紧菜单项图标与文字尺寸。

## 改动内容

### 模型选择入口

- `AIModelSelect.tsx`：配置按钮显示「管理模型」文案（新增 i18n key `manageModels`，en/zh/zh-TW 三语言同步）；移除下拉标题处的策略提示 Tooltip 与信息图标
- `AIModelList.tsx`：`getTipByType` 移除 `PolicyBalance` 分支，三语言同步删除 `policyBalance` 文案
- `AIModelSelect.test.tsx`：断言改为按国际化文案定位「管理模型」按钮并验证仍能打开模型配置

### 右侧功能面板

- `AIRightPanel.tsx`：流量计数角标由 `span.count-tag` 改为 `YakitTag`（`fullRadius`、`color="white"`、无边框）
- `AIRightPanel.module.scss`：菜单项图标 20→16px、文字 14→12px、行内间距 12→8px

## 影响范围

- AI 模型选择下拉的配置入口展示方式变化（图标按钮 → 带文案按钮）
- 设置页与网络配置页的模型路由策略描述共用 `getTipByType`，「平衡策略」选项仍可选但描述暂缺（见下方问题清单）
- AI 右侧功能面板菜单视觉收紧

## 代码评审结论

**结论：需要修复**（正确 6 项 / 问题 1 项（P0 0 项 / P1 1 项）/ 警告 1 项）

更新结论:上面得问题都已修复，可以合并

## 建议合并前修复的问题

- [x] `app/renderer/src/main/src/pages/ai-agent/aiModelList/AIModelList.tsx:206` `getTipByType` 删除 PolicyBalance 分支后，设置页（AIModelSettings.tsx:273）与网络配置页（ConfigNetworkPage.tsx:964）仍提供「平衡策略」选项（AIModelPolicyOptions 未变），选中后策略描述渲染为空；建议恢复该分支与 i18n key，或同步移除平衡策略选项（已修复，commit:208c5d887）

## 合并方式

选择第二种合并
